### PR TITLE
feat(quadrics): debug-sweep `a` through ellipsoid → cylinder → hyperboloid

### DIFF
--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -6,6 +6,13 @@ const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -3);
 const BOUND = 2.5;
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
 
+// Debug sweep on the `a` coefficient: 1 → 0 → -1 → 0 → 1 over SWEEP_PERIOD
+// seconds, exercising the ellipsoid → cylinder → 1-sheet hyperboloid →
+// cylinder → ellipsoid family transitions. Removed when controller-driven
+// sliders take over the uniforms (#5).
+const DEBUG_SWEEP = true;
+const SWEEP_PERIOD = 8;
+
 const VERTEX_SHADER = /* glsl */ `
   varying vec3 vWorldPos;
 
@@ -129,6 +136,9 @@ const FRAGMENT_SHADER = /* glsl */ `
   }
 `;
 
+let material: THREE.ShaderMaterial | undefined;
+let elapsed = 0;
+
 const quadricsExhibit: Exhibit = {
   id: 'quadrics',
   title: 'Quadric surfaces',
@@ -146,7 +156,7 @@ const quadricsExhibit: Exhibit = {
     directional.position.copy(LIGHT_DIR).multiplyScalar(5);
     scene.add(directional);
 
-    const material = new THREE.ShaderMaterial({
+    material = new THREE.ShaderMaterial({
       vertexShader: VERTEX_SHADER,
       fragmentShader: FRAGMENT_SHADER,
       side: THREE.DoubleSide,
@@ -170,8 +180,11 @@ const quadricsExhibit: Exhibit = {
     scene.add(surface);
   },
 
-  update() {
-    // Static surface in v0.1; #4 introduces uniform animation.
+  update({ delta }) {
+    if (!DEBUG_SWEEP || !material) return;
+    elapsed += delta;
+    const a = Math.cos((2 * Math.PI * elapsed) / SWEEP_PERIOD);
+    material.uniforms.uA.value = a;
   },
 };
 


### PR DESCRIPTION
**Stacked on #12 — base is `3-quadrics-raymarched-sphere`, not `main`. Will rebase onto `main` once #12 lands.**

## Summary

- `update({ delta })` now drives `uA = cos(2π·t/8)`, sweeping the `a` coefficient `1 → 0 → -1 → 0 → 1` over 8 s. The surface morphs through ellipsoid → elliptic cylinder → 1-sheet hyperboloid → elliptic cylinder → ellipsoid each cycle, exercising two SPEC.md classification boundaries each direction.
- Sweep is behind a module-local `DEBUG_SWEEP` constant. #5 flips it off when the controller takes over the same uniform.
- The "lift `a, b, c, d` to uniforms" half of #4 was wired preemptively in #3 (the SPEC required uniforms either way). Net new code here is the time-driven write into `uA`.

## Notes

- Cosine sweep — smooth (no derivative discontinuities at the extremes), passes through every value of `a` in `[−1, 1]` twice per cycle. Boundary cases (`a ≈ 0`) flash by faster than the stable family members; pedagogically a feature, not a bug.
- When `a ≤ 0` the surface becomes unbounded (cylinder, hyperboloid). The bounding cube clips it to half-extent 2.5 — visible cross-section ends at the cube faces with an "open tube" appearance, which is the correct visualization (we render the surface, not a solid).
- No flicker is *expected* across the `a = 0` transition: the raymarcher uses `f(p)` directly + bisection on sign change; the implicit function is continuous in `a` even where the surface's topology changes.

## Test plan

- [x] `npm run build` clean
- [x] `npm run dev` serves
- [x] **Visual check (Brad):** open `localhost:5173`, watch ~10 s, confirm the morph is smooth — no flicker, no holes, no popping at the topology transitions
- [ ] **VR check (Brad):** Quest 3S, same as above

Closes #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)