### PR TITLE
feat(quadrics): VR fixes + animated coefficient sweep (recovery PR)

### DIFF
--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -116,9 +116,9 @@ drags through a degeneracy.
 
 | Object         | Position (x, y, z)  | Notes                                 |
 |----------------|---------------------|---------------------------------------|
-| Surface center | `(0, 1.5, −1)`      | Same anchor as the hello-cube smoke scene; matches expected gaze direction. |
+| Surface center | `(0, 1.5, −3)`      | ~2 m in front of the standing user; close enough to walk up to, far enough that the bounding volume doesn't clip through the spawn point. |
 | Slider rack    | `(0, 1.0, −0.7)`    | Below-and-in-front; reachable with controllers without a step. |
-| Family label   | `(0, 2.4, −1)`      | Above the surface, billboarded to face the user. |
+| Family label   | `(0, 2.4, −3)`      | Above the surface, billboarded to face the user. |
 | Floor          | `y = 0`             | Inherited from the shell convention; visual horizon and comfort anchor. |
 
 Units are meters. The user's head start position is the WebXR session

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import type { Exhibit, ExhibitContext } from '../../shell/Exhibit';
 import { registerExhibit } from '../../shell/registry';
 
-const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -1);
+const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -3);
 const BOUND = 2.5;
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
 
@@ -112,6 +112,14 @@ const FRAGMENT_SHADER = /* glsl */ `
     float lambert = max(dot(n, normalize(uLightDir)), 0.0);
     vec3 color = uBaseColor * (0.2 + 0.8 * lambert);
     gl_FragColor = vec4(color, 1.0);
+
+    // Write the implicit-surface depth, not the bounding cube's. Quest's
+    // asynchronous spacewarp reprojects per-pixel from the depth buffer; with
+    // the cube's depth (meters off from the visible surface), reprojection
+    // smears the surface into a translucent / negative-space ghost.
+    vec3 hitWorld = pHit + uSurfaceCenter;
+    vec4 clip = projectionMatrix * viewMatrix * vec4(hitWorld, 1.0);
+    gl_FragDepth = (clip.z / clip.w) * 0.5 + 0.5;
   }
 `;
 

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -19,6 +19,12 @@ const VERTEX_SHADER = /* glsl */ `
 const FRAGMENT_SHADER = /* glsl */ `
   precision highp float;
 
+  // Three.js auto-populates projectionMatrix on every program, but only
+  // declares it in vertex-shader prefixes — fragment shaders have to
+  // declare it explicitly to use it. (viewMatrix and cameraPosition are
+  // declared automatically.)
+  uniform mat4 projectionMatrix;
+
   uniform vec3  uSurfaceCenter;
   uniform float uA;
   uniform float uB;

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -6,6 +6,13 @@ const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -3);
 const BOUND = 2.5;
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
 
+// Debug sweep on the `a` coefficient: 1 → 0 → -1 → 0 → 1 over SWEEP_PERIOD
+// seconds, exercising the ellipsoid → cylinder → 1-sheet hyperboloid →
+// cylinder → ellipsoid family transitions. Removed when controller-driven
+// sliders take over the uniforms (#5).
+const DEBUG_SWEEP = true;
+const SWEEP_PERIOD = 8;
+
 const VERTEX_SHADER = /* glsl */ `
   varying vec3 vWorldPos;
 
@@ -129,6 +136,9 @@ const FRAGMENT_SHADER = /* glsl */ `
   }
 `;
 
+let material: THREE.ShaderMaterial | undefined;
+let elapsed = 0;
+
 const quadricsExhibit: Exhibit = {
   id: 'quadrics',
   title: 'Quadric surfaces',
@@ -146,7 +156,7 @@ const quadricsExhibit: Exhibit = {
     directional.position.copy(LIGHT_DIR).multiplyScalar(5);
     scene.add(directional);
 
-    const material = new THREE.ShaderMaterial({
+    material = new THREE.ShaderMaterial({
       vertexShader: VERTEX_SHADER,
       fragmentShader: FRAGMENT_SHADER,
       side: THREE.DoubleSide,
@@ -170,8 +180,11 @@ const quadricsExhibit: Exhibit = {
     scene.add(surface);
   },
 
-  update() {
-    // Static surface in v0.1; #4 introduces uniform animation.
+  update({ delta }) {
+    if (!DEBUG_SWEEP || !material) return;
+    elapsed += delta;
+    const a = Math.cos((2 * Math.PI * elapsed) / SWEEP_PERIOD);
+    material.uniforms.uA.value = a;
   },
 };
 


### PR DESCRIPTION
## Why this PR exists

Recovery PR after a stacking mishap. PR #12 (issue #3) was merged before PR #13 (issue #4, stacked on it) and before two follow-up fix-up commits had landed on the #3 branch. PR #13 was then merged into the #3 branch (not main), so `origin/3-quadrics-raymarched-sphere` now contains all the work that should have made it to main, but never did.

This PR brings the missing commits over.

## Contents

Three commits, in order:

1. **`fix(quadrics): write per-fragment depth + push surface 2 m further away`** — closes the rest of issue #3's VR acceptance criterion. Anchor moved from `z = -1` to `z = -3` so the bounding cube doesn't intersect the user's spawn point. `gl_FragDepth` written from the world-space hit point's clip-space z so Quest's asynchronous spacewarp reprojects the surface at its actual depth instead of the bounding cube's depth (which was producing the translucent / negative-space ghosting). SPEC scene-geometry table updated to match the new anchor.
2. **`fix(quadrics): declare projectionMatrix in fragment shader`** — Three.js auto-declares `projectionMatrix` in vertex-shader prefixes only; the fragment shader needs an explicit `uniform mat4 projectionMatrix;` to use it. Without it, the previous commit's shader failed to link and the surface vanished entirely.
3. **`feat(quadrics): debug-sweep \`a\` through ellipsoid → cylinder → hyperboloid`** — closes issue #4. Drives `uA` via `cos(2π·t/8)`, sweeping `a` through `1 → 0 → -1 → 0 → 1` over 8 s. Gated behind `DEBUG_SWEEP` so #5 can flip it off when the controller takes over the same uniform.

## Test plan

- [x] `npm run build` clean
- [x] `npm run dev` confirmed surface visible after the projectionMatrix fix
- [x] **Browser visual (Brad):** confirm the morphing surface shows up at `https://skylinetrailcomputing.github.io/geometer/` once Pages deploys
- [ ] **VR (Brad):** Quest 3S Pages URL → Enter VR → confirm (a) surface sits comfortably at ~2 m, (b) no negative-space / translucent ghosting during head motion, (c) sweep morphs smoothly through topology transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)