### PR TITLE
feat(quadrics): controller-driven slider for `a` coefficient

### DIFF
--- a/src/exhibits/quadrics/Slider.ts
+++ b/src/exhibits/quadrics/Slider.ts
@@ -1,0 +1,167 @@
+import * as THREE from 'three';
+
+export interface SliderOptions {
+  label: string;
+  min: number;
+  max: number;
+  initial: number;
+  trackLength?: number;
+  thumbRadius?: number;
+}
+
+const DEFAULT_TRACK_LENGTH = 0.3;
+const DEFAULT_THUMB_RADIUS = 0.025;
+
+// Snap-to-zero detent half-width, per quadrics SPEC.md "Slider model".
+// Lets the user park exactly on a degeneracy boundary instead of approximating.
+const ZERO_DETENT = 0.05;
+
+const HAPTIC_AMPLITUDE = 0.5;
+const HAPTIC_DURATION_MS = 10;
+
+interface ControllerWithGamepad extends THREE.Object3D {
+  userData: { gamepad?: Gamepad };
+}
+
+export class Slider {
+  readonly group: THREE.Group;
+
+  private readonly opts: Required<SliderOptions>;
+  private readonly track: THREE.Mesh;
+  private readonly thumb: THREE.Mesh;
+  private readonly thumbWorld = new THREE.Vector3();
+  private readonly controllerWorld = new THREE.Vector3();
+  private readonly localPoint = new THREE.Vector3();
+
+  private currentValue: number;
+  private grabbedBy: THREE.Object3D | null = null;
+
+  constructor(options: SliderOptions) {
+    this.opts = {
+      trackLength: DEFAULT_TRACK_LENGTH,
+      thumbRadius: DEFAULT_THUMB_RADIUS,
+      ...options,
+    };
+    this.currentValue = clamp(options.initial, options.min, options.max);
+
+    this.group = new THREE.Group();
+    this.group.name = `slider:${options.label}`;
+
+    // Track is a thin cylinder oriented along local +X. Default cylinder
+    // axis is +Y, so rotate -Z by 90°.
+    const trackGeom = new THREE.CylinderGeometry(
+      0.005,
+      0.005,
+      this.opts.trackLength,
+      12,
+    );
+    trackGeom.rotateZ(Math.PI / 2);
+    this.track = new THREE.Mesh(
+      trackGeom,
+      new THREE.MeshStandardMaterial({ color: 0x556677 }),
+    );
+    this.group.add(this.track);
+
+    this.thumb = new THREE.Mesh(
+      new THREE.SphereGeometry(this.opts.thumbRadius, 16, 12),
+      new THREE.MeshStandardMaterial({ color: 0xeeaa33 }),
+    );
+    this.group.add(this.thumb);
+
+    this.syncThumbPosition();
+  }
+
+  get value(): number {
+    return this.currentValue;
+  }
+
+  get isGrabbed(): boolean {
+    return this.grabbedBy !== null;
+  }
+
+  /**
+   * Test whether `controller`'s forward ray hits the thumb. On hit, attach
+   * the grab to that controller and pulse haptics. Returns whether grabbed.
+   */
+  tryGrab(controller: THREE.Object3D): boolean {
+    if (this.grabbedBy) return false;
+
+    const rayOrigin = new THREE.Vector3();
+    const rayDir = new THREE.Vector3();
+    controller.getWorldPosition(rayOrigin);
+    rayDir.set(0, 0, -1).applyQuaternion(controller.getWorldQuaternion(new THREE.Quaternion()));
+
+    this.thumb.getWorldPosition(this.thumbWorld);
+    const r = this.opts.thumbRadius * 1.5;
+    if (!raySphereHit(rayOrigin, rayDir, this.thumbWorld, r)) return false;
+
+    this.grabbedBy = controller;
+    pulse(controller);
+    return true;
+  }
+
+  releaseFromController(controller: THREE.Object3D): void {
+    if (this.grabbedBy !== controller) return;
+    this.grabbedBy = null;
+    pulse(controller);
+  }
+
+  /**
+   * Per-frame tick. If grabbed, project the controller's world position onto
+   * the slider's local X axis, clamp to range, apply zero-detent, sync thumb.
+   */
+  update(): void {
+    if (!this.grabbedBy) return;
+    this.grabbedBy.getWorldPosition(this.controllerWorld);
+    this.group.worldToLocal(this.localPoint.copy(this.controllerWorld));
+
+    const halfLen = this.opts.trackLength / 2;
+    const localX = clamp(this.localPoint.x, -halfLen, halfLen);
+    const t = (localX + halfLen) / this.opts.trackLength;
+    let v = this.opts.min + t * (this.opts.max - this.opts.min);
+    if (Math.abs(v) < ZERO_DETENT) v = 0;
+
+    this.currentValue = v;
+    this.syncThumbPosition();
+  }
+
+  private syncThumbPosition(): void {
+    const halfLen = this.opts.trackLength / 2;
+    const t =
+      (this.currentValue - this.opts.min) /
+      (this.opts.max - this.opts.min);
+    this.thumb.position.x = -halfLen + t * this.opts.trackLength;
+  }
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.min(Math.max(v, lo), hi);
+}
+
+function raySphereHit(
+  origin: THREE.Vector3,
+  dir: THREE.Vector3,
+  center: THREE.Vector3,
+  radius: number,
+): boolean {
+  const oc = new THREE.Vector3().subVectors(origin, center);
+  const b = oc.dot(dir);
+  const c = oc.dot(oc) - radius * radius;
+  const disc = b * b - c;
+  if (disc < 0) return false;
+  const sqrtDisc = Math.sqrt(disc);
+  const t = -b - sqrtDisc;
+  return t >= 0 || -b + sqrtDisc >= 0;
+}
+
+function pulse(controller: THREE.Object3D): void {
+  const gamepad = (controller as ControllerWithGamepad).userData.gamepad;
+  const actuator = gamepad?.hapticActuators?.[0];
+  if (!actuator) return;
+  // hapticActuators is part of the Gamepad Extensions draft; pulse() is the
+  // widely-shipped surface on Quest, so the type narrowing here is permissive.
+  (actuator as { pulse?: (a: number, d: number) => void }).pulse?.(
+    HAPTIC_AMPLITUDE,
+    HAPTIC_DURATION_MS,
+  );
+}

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -1,16 +1,16 @@
 import * as THREE from 'three';
 import type { Exhibit, ExhibitContext } from '../../shell/Exhibit';
 import { registerExhibit } from '../../shell/registry';
+import { Slider } from './Slider';
 
 const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -3);
+const SLIDER_RACK_CENTER = new THREE.Vector3(0, 1.0, -0.7);
 const BOUND = 2.5;
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
 
-// Debug sweep on the `a` coefficient: 1 → 0 → -1 → 0 → 1 over SWEEP_PERIOD
-// seconds, exercising the ellipsoid → cylinder → 1-sheet hyperboloid →
-// cylinder → ellipsoid family transitions. Removed when controller-driven
-// sliders take over the uniforms (#5).
-const DEBUG_SWEEP = true;
+// Debug sweep on `a`: gated off once controller sliders took over (#5).
+// Re-enable for shader / boundary-case debugging without controllers.
+const DEBUG_SWEEP = false;
 const SWEEP_PERIOD = 8;
 
 const VERTEX_SHADER = /* glsl */ `
@@ -137,13 +137,14 @@ const FRAGMENT_SHADER = /* glsl */ `
 `;
 
 let material: THREE.ShaderMaterial | undefined;
+let sliderA: Slider | undefined;
 let elapsed = 0;
 
 const quadricsExhibit: Exhibit = {
   id: 'quadrics',
   title: 'Quadric surfaces',
 
-  mount({ scene }: ExhibitContext) {
+  mount({ scene, renderer }: ExhibitContext) {
     const floor = new THREE.Mesh(
       new THREE.PlaneGeometry(10, 10),
       new THREE.MeshStandardMaterial({ color: 0x222244 }),
@@ -178,15 +179,72 @@ const quadricsExhibit: Exhibit = {
     );
     surface.position.copy(SURFACE_CENTER);
     scene.add(surface);
+
+    sliderA = new Slider({
+      label: 'a',
+      min: -2,
+      max: 2,
+      initial: 1,
+    });
+    sliderA.group.position.copy(SLIDER_RACK_CENTER);
+    scene.add(sliderA.group);
+
+    setupControllers(scene, renderer, sliderA);
   },
 
   update({ delta }) {
-    if (!DEBUG_SWEEP || !material) return;
-    elapsed += delta;
-    const a = Math.cos((2 * Math.PI * elapsed) / SWEEP_PERIOD);
-    material.uniforms.uA.value = a;
+    sliderA?.update();
+    if (sliderA && material) {
+      material.uniforms.uA.value = sliderA.value;
+    }
+    if (DEBUG_SWEEP && material) {
+      elapsed += delta;
+      const a = Math.cos((2 * Math.PI * elapsed) / SWEEP_PERIOD);
+      material.uniforms.uA.value = a;
+    }
   },
 };
+
+function setupControllers(
+  scene: THREE.Scene,
+  renderer: THREE.WebGLRenderer,
+  slider: Slider,
+): void {
+  // Visible 1 m laser line along controller −Z, so the user can see where
+  // they're aiming before pressing the trigger.
+  const rayGeom = new THREE.BufferGeometry().setFromPoints([
+    new THREE.Vector3(0, 0, 0),
+    new THREE.Vector3(0, 0, -1),
+  ]);
+  const rayMat = new THREE.LineBasicMaterial({
+    color: 0xffffff,
+    transparent: true,
+    opacity: 0.6,
+  });
+
+  for (const i of [0, 1] as const) {
+    const controller = renderer.xr.getController(i);
+    controller.add(new THREE.Line(rayGeom, rayMat));
+    scene.add(controller);
+
+    controller.addEventListener('connected', (event: { data: XRInputSource }) => {
+      const inputSource = event.data;
+      if (inputSource.gamepad) {
+        controller.userData.gamepad = inputSource.gamepad;
+      }
+    });
+    controller.addEventListener('disconnected', () => {
+      delete controller.userData.gamepad;
+    });
+
+    controller.addEventListener('selectstart', () => {
+      slider.tryGrab(controller);
+    });
+    controller.addEventListener('selectend', () => {
+      slider.releaseFromController(controller);
+    });
+  }
+}
 
 registerExhibit(quadricsExhibit);
 


### PR DESCRIPTION
Closes #5.

## Summary
- New reusable `Slider` class at `src/exhibits/quadrics/Slider.ts` — track + thumb mesh, configurable range, snap-to-zero detent at `|v| < 0.05` per SPEC.md, ray–sphere hit test (1.5× thumb radius for grab tolerance), haptic pulse helper.
- One `a` slider mounted at the rack center `(0, 1.0, −0.7)`, range `[−2, 2]`, default `1`.
- Both XR controllers wired: 1 m white laser line for aim feedback, `selectstart` → `tryGrab` + haptic, `selectend` → release + haptic. Per-frame `slider.update()` writes `slider.value` into `uA`.
- `DEBUG_SWEEP` flipped to `false` (gated, not deleted — keeps the sweep code path live for headless shader debugging).

## Deliberately deferred
- No layout/rack abstraction yet — one slider doesn't justify it. Issue #6 (the `b` slider) is where 2+ sliders force the question.
- No changes to the `Exhibit` shell interface — controllers come from `renderer.xr` which the exhibit already has via `ExhibitContext`.

## What localhost (non-XR) confirms
- Page loads, builds, no runtime errors.
- Slider geometry renders at the rack position; thumb sits ~7.5 cm right of center for the default `a = 1`.
- Surface is now the static unit-sphere ellipsoid (sweep is off) — change is visible.

## What only Quest can confirm (smoke checklist)
- [ ] Surface morphs as you drag the thumb across the track.
- [ ] Thumb tracks the controller smoothly with no fight/snap-back outside the detent.
- [ ] Crossing `|v| < 0.05` snaps to exactly 0 — surface should turn into the elliptic cylinder family `(2, 0, 1)` with `d = 1`.
- [ ] Light haptic pulse felt on trigger-press (grab) and trigger-release.
- [ ] Either controller can grab; second controller's trigger does nothing while held.

## Known unknowns until headset eyes
- Grab tolerance (1.5× thumb radius = 3.75 cm) is a guess; may feel sticky or slippery — first knob to twist if the UX is off.
- Local-X projection of the controller position works because the slider group is unrotated. Once we billboard or angle the rack toward the user, this needs revisiting.