### PR TITLE
chore: import workspace OSS-repo policy doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,9 @@
 ## Multi-agent autonomy policy
 @/Users/bradmartin/claude-workspace-2026/knowledge/agents/autonomy-policy.md
 
+## Open-source repo policy
+@/Users/bradmartin/claude-workspace-2026/knowledge/oss-repo-policy.md
+
 ## Repo-specific rules
 
 - **Public OSS repo.** Never commit anything that references FullContact


### PR DESCRIPTION
Wires this repo's `CLAUDE.md` to the cross-cutting policy at `knowledge/oss-repo-policy.md` in the workspace.

## Context
Workspace just gained a canonical doc for "what protections do we apply to public OSS repos under the org" alongside `geometer`'s first protection pass. This PR makes future Claude sessions in this repo pick up the same threat-model + protection defaults.

## Trivia
First PR through the new ruleset — confirms the gate works (require PR, gitleaks must pass, no force-push, no delete) and that solo-merge with zero required approvals is unimpeded.