### PR TITLE
chore: split CLAUDE.md into public-facing + local maintainer file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ npm-debug.log*
 # Misc
 *.pem
 .cache/
+
+# Claude Code maintainer-only context (workspace @-imports etc.)
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,26 +1,32 @@
 # geometer
 
-@/Users/bradmartin/claude-workspace-2026/knowledge/projects/geometer.md
+WebXR sandbox of geometry exhibits for STEM undergraduates. See
+[`README.md`](README.md), [`VISION.md`](VISION.md), and
+[`CONTRIBUTING.md`](CONTRIBUTING.md) for project-level context and
+the contribution flow.
 
-## Multi-agent autonomy policy
-@/Users/bradmartin/claude-workspace-2026/knowledge/agents/autonomy-policy.md
+## Stack
 
-## Repo-specific rules
+TypeScript + Three.js + Vite. WebXR via the platform `navigator.xr`
+API; HTTPS or `localhost` is required for any XR session. Pages
+deployment from `main` via `.github/workflows/pages.yml`.
 
-- **Public OSS repo.** Never commit anything that references FullContact
-  or Ziff Davis systems, internal account IDs, proprietary data shapes,
-  or other day-job artifacts. The work/personal wall in
-  `~/.claude/CLAUDE.md` applies to everything in this directory.
-- **Pre-commit hygiene.** `pre-commit` hooks run gitleaks + standard
-  fixers before every commit. If a hook ever blocks legitimate work,
-  fix the underlying issue rather than `--no-verify`-ing.
-- **Author identity.** Commits are authored by Brad's personal Gmail
-  (`1bradley.martin1@gmail.com`) — never the deprecating CU Boulder
-  email, which is explicitly banned in `.gitleaks.toml` (rule id
-  `deprecated-cu-email`).
-- **Distribution.** Public, MIT-licensed, copyright Skyline Trail
-  Computing LLC. Deployed via GitHub Pages from `main` (workflow:
-  `.github/workflows/pages.yml`).
-- **Stack.** TypeScript + Three.js + Vite. WebXR via the platform
-  `navigator.xr` API; HTTPS or `localhost` is required for any XR
-  session.
+## Repo conventions
+
+- **Public OSS repo, MIT-licensed, copyright Skyline Trail Computing
+  LLC.** Never commit secrets, credentials, or proprietary content.
+- **Pre-commit hygiene.** `pre-commit` hooks (gitleaks + standard
+  fixers) run before every commit, with CI as a backstop. Fix the
+  underlying issue rather than `--no-verify`-ing.
+- **Conventional Commits** for messages (`feat:`, `fix:`, `docs:`,
+  `refactor:`, `chore:`, `test:`); see `CONTRIBUTING.md`.
+- **Branch protection on `main`:** PR required, the `gitleaks` check
+  must pass, no force-push or delete.
+
+## Maintainer-side Claude Code context
+
+A git-ignored `CLAUDE.local.md` alongside this file holds the
+maintainer's personal Claude Code context — workspace cross-references,
+author-identity rules, agent autonomy policy. It's auto-loaded by
+Claude Code in addition to this file. Not required to contribute to
+or build the project; nothing in it changes the public contract above.


### PR DESCRIPTION
Supersedes #16 (closed).

## What changed
- **Committed `CLAUDE.md`:** contributor-facing only — stack, repo conventions, branch-protection summary, and a transparent note that maintainer-only context lives alongside in a git-ignored file.
- **New `CLAUDE.local.md`:** git-ignored, auto-loaded by Claude Code. Holds the workspace `@`-imports (project notes, agent autonomy policy, OSS-repo policy), author-identity rules, and the work/personal wall.
- **`.gitignore`:** add `CLAUDE.local.md`.

## Why
Hardcoded `/Users/bradmartin/...` paths and `@`-imports to unfollowable private docs read as non-portable / "we have rules you can't see" to outside contributors browsing the repo. None of that content is actually meaningful to a contributor's understanding of the project — it's about the maintainer's Claude Code workflow, not the project itself.

This is the convention `Claude Code` documents for personal additions on top of repo-shared context (loaded automatically, by-convention git-ignored).

## Follow-ups (separate PRs / commits)
- Workspace's `scripts/new-project.sh` will be updated to scaffold both files for any future Skyline OSS repo.
- `knowledge/oss-repo-policy.md` will be updated to codify the convention so it doesn't drift.