### PR TITLE
fix(quadrics): tune slider drag gain 2.5 → 1.75

### DIFF
--- a/src/exhibits/quadrics/Slider.ts
+++ b/src/exhibits/quadrics/Slider.ts
@@ -15,7 +15,7 @@ export interface SliderOptions {
 
 const DEFAULT_TRACK_LENGTH = 0.3;
 const DEFAULT_THUMB_RADIUS = 0.025;
-const DEFAULT_DRAG_GAIN = 2.5;
+const DEFAULT_DRAG_GAIN = 1.75;
 
 // Snap-to-zero detent half-width, per quadrics SPEC.md "Slider model".
 // Lets the user park exactly on a degeneracy boundary instead of approximating.


### PR DESCRIPTION
Headset feedback follow-up to #17. Single-line change to `DEFAULT_DRAG_GAIN`.

## Why
- 2.5× felt slightly fast — overshoot risk near the ends and around the zero detent.
- 1.75× is closer to the sweet spot per in-headset feel.
- Side benefit: smaller value-swing per mm of hand jitter, so the zero detent should hold more reliably when the user is just trying to keep it parked.

`dragGain` is still a per-slider `SliderOption` — only the default moves.

## Smoke
- [ ] Drag still feels noticeably more sensitive than the original absolute-position version (~17 cm of hand travel for full [-2, 2] range, vs ~30 cm absolute).
- [ ] Zero detent feels more stable when held still — less easy to bounce out of by accident.