### PR TITLE
feat(quadrics): add b, c, d sliders alongside a (#6)

### DIFF
--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -139,7 +139,12 @@ The label re-classifies every frame.
 ## Controller interaction
 
 - **Hands:** either left or right controller drives any slider. No
-  hand-specific roles in v0.1.
+  hand-specific roles in v0.1. Both hands may simultaneously grab and
+  drag *different* sliders — pedagogically useful for exploring joint
+  coefficient effects (e.g., dragging `a` and `c` together to slide
+  between hyperboloids of one and two sheets through the cone). Two
+  hands cannot grab the same slider at once; whichever pulls the trigger
+  first wins.
 - **Pointer model:** ray-pointer extending from each controller. Visible
   laser line when the ray intersects an interactable.
 - **Grab:** trigger press while the ray intersects a slider thumb grabs

--- a/src/exhibits/quadrics/Slider.ts
+++ b/src/exhibits/quadrics/Slider.ts
@@ -78,6 +78,10 @@ export class Slider {
     this.syncThumbPosition();
   }
 
+  get label(): string {
+    return this.opts.label;
+  }
+
   get value(): number {
     return this.currentValue;
   }

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -17,6 +17,9 @@ const COEFF_NAMES: readonly CoeffName[] = ['a', 'b', 'c', 'd'] as const;
 
 // Debug sweep on `a`: gated off once controller sliders took over (#5).
 // Re-enable for shader / boundary-case debugging without controllers.
+// Sweeps `uA` only — `uB`/`uC`/`uD` continue tracking their sliders, which
+// is fine for the original use case (verify single-axis morphing) but
+// produces mixed live/sweep state if you forget. Adjust if needed.
 const DEBUG_SWEEP = false;
 const SWEEP_PERIOD = 8;
 
@@ -205,11 +208,10 @@ const quadricsExhibit: Exhibit = {
 
   update({ delta }) {
     for (const s of sliders) s.update();
-    if (material && sliders.length === COEFF_NAMES.length) {
-      material.uniforms.uA.value = sliders[0].value;
-      material.uniforms.uB.value = sliders[1].value;
-      material.uniforms.uC.value = sliders[2].value;
-      material.uniforms.uD.value = sliders[3].value;
+    if (material) {
+      for (const s of sliders) {
+        material.uniforms[`u${s.label.toUpperCase()}`].value = s.value;
+      }
     }
     if (DEBUG_SWEEP && material) {
       elapsed += delta;

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -8,6 +8,13 @@ const SLIDER_RACK_CENTER = new THREE.Vector3(0, 1.0, -0.7);
 const BOUND = 2.5;
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
 
+// Vertical stacking pitch for the rack. SPEC pins the rack center but
+// not per-slider positions; horizontal arrangement would be ~1.6 m wide.
+// 0.07 m keeps the four thumbs visually distinct without crowding.
+const SLIDER_ROW_PITCH = 0.07;
+type CoeffName = 'a' | 'b' | 'c' | 'd';
+const COEFF_NAMES: readonly CoeffName[] = ['a', 'b', 'c', 'd'] as const;
+
 // Debug sweep on `a`: gated off once controller sliders took over (#5).
 // Re-enable for shader / boundary-case debugging without controllers.
 const DEBUG_SWEEP = false;
@@ -137,7 +144,7 @@ const FRAGMENT_SHADER = /* glsl */ `
 `;
 
 let material: THREE.ShaderMaterial | undefined;
-let sliderA: Slider | undefined;
+let sliders: Slider[] = [];
 let elapsed = 0;
 
 const quadricsExhibit: Exhibit = {
@@ -180,22 +187,29 @@ const quadricsExhibit: Exhibit = {
     surface.position.copy(SURFACE_CENTER);
     scene.add(surface);
 
-    sliderA = new Slider({
-      label: 'a',
-      min: -2,
-      max: 2,
-      initial: 1,
+    // Top → bottom: a, b, c, d. Span centered on SLIDER_RACK_CENTER.
+    const topY = SLIDER_RACK_CENTER.y + ((COEFF_NAMES.length - 1) / 2) * SLIDER_ROW_PITCH;
+    sliders = COEFF_NAMES.map((label, i) => {
+      const slider = new Slider({ label, min: -2, max: 2, initial: 1 });
+      slider.group.position.set(
+        SLIDER_RACK_CENTER.x,
+        topY - i * SLIDER_ROW_PITCH,
+        SLIDER_RACK_CENTER.z,
+      );
+      scene.add(slider.group);
+      return slider;
     });
-    sliderA.group.position.copy(SLIDER_RACK_CENTER);
-    scene.add(sliderA.group);
 
-    setupControllers(scene, renderer, sliderA);
+    setupControllers(scene, renderer, sliders);
   },
 
   update({ delta }) {
-    sliderA?.update();
-    if (sliderA && material) {
-      material.uniforms.uA.value = sliderA.value;
+    for (const s of sliders) s.update();
+    if (material && sliders.length === COEFF_NAMES.length) {
+      material.uniforms.uA.value = sliders[0].value;
+      material.uniforms.uB.value = sliders[1].value;
+      material.uniforms.uC.value = sliders[2].value;
+      material.uniforms.uD.value = sliders[3].value;
     }
     if (DEBUG_SWEEP && material) {
       elapsed += delta;
@@ -208,7 +222,7 @@ const quadricsExhibit: Exhibit = {
 function setupControllers(
   scene: THREE.Scene,
   renderer: THREE.WebGLRenderer,
-  slider: Slider,
+  sliders: readonly Slider[],
 ): void {
   // Visible 1 m laser line along controller −Z, so the user can see where
   // they're aiming before pressing the trigger.
@@ -238,10 +252,12 @@ function setupControllers(
     });
 
     controller.addEventListener('selectstart', () => {
-      slider.tryGrab(controller);
+      for (const s of sliders) {
+        if (s.tryGrab(controller)) break;
+      }
     });
     controller.addEventListener('selectend', () => {
-      slider.releaseFromController(controller);
+      for (const s of sliders) s.releaseFromController(controller);
     });
   }
 }


### PR DESCRIPTION
## Summary

- Adds three sliders (`b`, `c`, `d`) using the `Slider` component from #5; each drives its corresponding shader uniform live.
- Refactors `setupControllers` to accept a `Slider[]` and iterate on grab/release, so either controller can pick up any free thumb without crosstalk.
- Layout: vertical stack centered on `SLIDER_RACK_CENTER`, 0.07 m pitch, top→bottom order `a, b, c, d`. SPEC pinned the rack center but not per-slider positions; horizontal arrangement (~1.6 m wide) was unworkable, vertical is the only sensible choice. Recorded as a comment in `index.ts`.

## Roundtable review follow-ups (additional commits on this branch)

Roundtable review (Sonnet, GPT-5.5, Qwen, DeepSeek) surfaced three actionable items, all addressed here:

- **`refactor(quadrics): map slider→uniform by label, not array index`** — Qwen flagged the implicit `sliders[i]→u${COEFF_NAMES[i].toUpperCase()}` index↔name contract. Replaced with a label-keyed loop after exposing `Slider.label`. Reordering `COEFF_NAMES` no longer silently rewires uniforms.
- **`docs(quadrics): clarify SPEC permits two-hand simultaneous drag`** — Sonnet flagged the SPEC was silent on whether both controllers could drag *different* sliders at the same time. Updated `Controller interaction` to state explicitly that simultaneous two-hand drag on different sliders is permitted and pedagogically intended.
- **DEBUG_SWEEP comment** — clarified that the sweep overrides `uA` only, while `uB`/`uC`/`uD` keep tracking sliders. Comment was misleading post-#6.

DeepSeek and Qwen both flagged a HIGH-severity finding ("shader doesn't consume `uB`/`uC`/`uD`") — both incorrect. The fragment shader has declared and used all four uniforms since #4; the reviewers reasoned about absence rather than declaring uncertainty when the shader text wasn't in the diff. Build passes; smoke confirms.

## Out of scope (filed as #22)

Per-slider visible labels (variable name + numeric value to 2 dp). SPEC requires them; #5 already shipped without; landing them here would commit to a text-rendering primitive ahead of #7's open architectural choice (`troika-three-text` vs `CanvasTexture`). Tracked in #22, blocked on #7.

## Test plan

- [x] `npm run build` — typecheck + Vite build clean (post-refactor).
- [x] `npm run dev` — page serves 200, module compiles in browser.
- [ ] **In headset, post-merge:** confirm four thumbs visible at the rack, each grabs/drags independently, dragging `b` doesn't disturb `a`'s value, two-handed drag of two different sliders works, all four uniforms drive the surface (e.g. `a → 0` collapses one axis, `d` flips sign through the cone case).

Closes #6.