### PR TITLE
fix(quadrics): hover highlight, wider grab radius, wider rack pitch

### DIFF
--- a/src/exhibits/quadrics/Slider.ts
+++ b/src/exhibits/quadrics/Slider.ts
@@ -21,8 +21,19 @@ const DEFAULT_DRAG_GAIN = 1.75;
 // Lets the user park exactly on a degeneracy boundary instead of approximating.
 const ZERO_DETENT = 0.05;
 
+// Ray–thumb hit-test radius is this multiple of the thumb's visual radius.
+// Wider than the visual makes re-grab forgiving when the hand drifts off-aim
+// during release — especially after a zero-snap, where the thumb jumps to
+// `value = 0` while the controller is still pointed where the drag ended.
+// Used identically by `tryGrab` and `updateHover` so the highlight region
+// equals the actual grabbable region.
+const GRAB_RADIUS_MULTIPLIER = 2.75;
+
 const HAPTIC_AMPLITUDE = 0.5;
 const HAPTIC_DURATION_MS = 10;
+
+const THUMB_BASE_COLOR = 0xeeaa33;
+const THUMB_HOVER_EMISSIVE = 0x884422;
 
 interface ControllerWithGamepad extends THREE.Object3D {
   userData: { gamepad?: Gamepad };
@@ -41,6 +52,7 @@ export class Slider {
   private currentValue: number;
   private grabbedBy: THREE.Object3D | null = null;
   private lastControllerLocalX = 0;
+  private hovered = false;
 
   constructor(options: SliderOptions) {
     this.opts = {
@@ -71,7 +83,7 @@ export class Slider {
 
     this.thumb = new THREE.Mesh(
       new THREE.SphereGeometry(this.opts.thumbRadius, 16, 12),
-      new THREE.MeshStandardMaterial({ color: 0xeeaa33 }),
+      new THREE.MeshStandardMaterial({ color: THUMB_BASE_COLOR }),
     );
     this.group.add(this.thumb);
 
@@ -96,15 +108,7 @@ export class Slider {
    */
   tryGrab(controller: THREE.Object3D): boolean {
     if (this.grabbedBy) return false;
-
-    const rayOrigin = new THREE.Vector3();
-    const rayDir = new THREE.Vector3();
-    controller.getWorldPosition(rayOrigin);
-    rayDir.set(0, 0, -1).applyQuaternion(controller.getWorldQuaternion(new THREE.Quaternion()));
-
-    this.thumb.getWorldPosition(this.thumbWorld);
-    const r = this.opts.thumbRadius * 1.5;
-    if (!raySphereHit(rayOrigin, rayDir, this.thumbWorld, r)) return false;
+    if (!this.rayHitsThumb(controller)) return false;
 
     this.grabbedBy = controller;
     this.lastControllerLocalX = this.controllerLocalX(controller);
@@ -116,6 +120,34 @@ export class Slider {
     if (this.grabbedBy !== controller) return;
     this.grabbedBy = null;
     pulse(controller);
+  }
+
+  /**
+   * Per-frame hover update. Lights the thumb's emissive when any controller's
+   * ray is within the grab region — a "you can grab now" affordance that also
+   * exposes the wider hit radius to the user. No-op while grabbed (the user
+   * already has it).
+   */
+  updateHover(controllers: readonly THREE.Object3D[]): void {
+    const hovered =
+      this.grabbedBy === null &&
+      controllers.some((c) => this.rayHitsThumb(c));
+    if (hovered === this.hovered) return;
+    this.hovered = hovered;
+    const mat = this.thumb.material as THREE.MeshStandardMaterial;
+    mat.emissive.setHex(hovered ? THUMB_HOVER_EMISSIVE : 0x000000);
+  }
+
+  private rayHitsThumb(controller: THREE.Object3D): boolean {
+    const rayOrigin = new THREE.Vector3();
+    const rayDir = new THREE.Vector3();
+    controller.getWorldPosition(rayOrigin);
+    rayDir.set(0, 0, -1).applyQuaternion(
+      controller.getWorldQuaternion(new THREE.Quaternion()),
+    );
+    this.thumb.getWorldPosition(this.thumbWorld);
+    const r = this.opts.thumbRadius * GRAB_RADIUS_MULTIPLIER;
+    return raySphereHit(rayOrigin, rayDir, this.thumbWorld, r);
   }
 
   /**

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -148,6 +148,7 @@ const FRAGMENT_SHADER = /* glsl */ `
 
 let material: THREE.ShaderMaterial | undefined;
 let sliders: Slider[] = [];
+let controllers: THREE.Object3D[] = [];
 let elapsed = 0;
 
 const quadricsExhibit: Exhibit = {
@@ -203,10 +204,11 @@ const quadricsExhibit: Exhibit = {
       return slider;
     });
 
-    setupControllers(scene, renderer, sliders);
+    controllers = setupControllers(scene, renderer, sliders);
   },
 
   update({ delta }) {
+    for (const s of sliders) s.updateHover(controllers);
     for (const s of sliders) s.update();
     if (material) {
       for (const s of sliders) {
@@ -225,7 +227,7 @@ function setupControllers(
   scene: THREE.Scene,
   renderer: THREE.WebGLRenderer,
   sliders: readonly Slider[],
-): void {
+): THREE.Object3D[] {
   // Visible 1 m laser line along controller −Z, so the user can see where
   // they're aiming before pressing the trigger.
   const rayGeom = new THREE.BufferGeometry().setFromPoints([
@@ -238,10 +240,12 @@ function setupControllers(
     opacity: 0.6,
   });
 
+  const out: THREE.Object3D[] = [];
   for (const i of [0, 1] as const) {
     const controller = renderer.xr.getController(i);
     controller.add(new THREE.Line(rayGeom, rayMat));
     scene.add(controller);
+    out.push(controller);
 
     controller.addEventListener('connected', (event: { data: XRInputSource }) => {
       const inputSource = event.data;
@@ -262,6 +266,7 @@ function setupControllers(
       for (const s of sliders) s.releaseFromController(controller);
     });
   }
+  return out;
 }
 
 registerExhibit(quadricsExhibit);

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -9,9 +9,14 @@ const BOUND = 2.5;
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
 
 // Vertical stacking pitch for the rack. SPEC pins the rack center but
-// not per-slider positions; horizontal arrangement would be ~1.6 m wide.
-// 0.07 m keeps the four thumbs visually distinct without crowding.
-const SLIDER_ROW_PITCH = 0.07;
+// not per-slider positions. Lower bound is set by the slider's grab
+// region: at thumbRadius (0.025) × GRAB_RADIUS_MULTIPLIER (2.75), each
+// thumb's hit sphere is ~0.069 m, so adjacent thumbs need ≥ 0.138 m of
+// pitch to keep their grab regions disjoint (otherwise a ray near the
+// midpoint could resolve to either slider). 0.15 leaves ~1 cm of
+// clearance between hit spheres and reads as comfortably spaced in
+// headset.
+const SLIDER_ROW_PITCH = 0.15;
 type CoeffName = 'a' | 'b' | 'c' | 'd';
 const COEFF_NAMES: readonly CoeffName[] = ['a', 'b', 'c', 'd'] as const;
 


### PR DESCRIPTION
## Summary

Fixes the intermittent re-grab after a zero-snap on quadrics sliders (issue #20). Three coordinated knobs in `src/exhibits/quadrics/`:

- **Hover highlight (`Slider.ts`).** New `updateHover(controllers)` lights the thumb's `emissive` when any controller's ray is in the grab region. Same hit-test as `tryGrab`, so the highlighted footprint = the actual grabbable footprint. No-op while grabbed (the user already has it).
- **Wider grab radius (`Slider.ts`).** Multiplier 1.5× → 2.75× via a single `GRAB_RADIUS_MULTIPLIER` constant shared by `tryGrab` and `updateHover`. Mid of the 2.5–3× range from the issue.
- **Wider rack pitch (`index.ts`).** `SLIDER_ROW_PITCH` 0.07 m → 0.15 m. The radius bump took each thumb's hit sphere to ~6.9 cm, which collided with the old 7 cm pitch — adjacent grab regions were overlapping almost entirely, so a ray near the midpoint could resolve to either slider. 0.15 m leaves ~1 cm clearance between hit spheres and reads more comfortably spaced in headset. Rack span 0.45 m at y∈[0.775, 1.225] still reachable without a step from the SPEC's standing pose.

`index.ts` now holds the controllers at module scope so the per-frame `update` can pass them to each slider's `updateHover`.

Closes #20.

## Test plan

- [x] `npm run build` (tsc --noEmit + vite build) clean.
- [ ] Headset smoke (post-merge per VR guardrail):
  - [ ] Pointing at a thumb lights it; lifting the ray off unhighlights it.
  - [ ] Re-grab after a zero-snap is reliable — no more "sometimes works."
  - [ ] First-grab from outside the slider feels the same as before (no regression).
  - [ ] No accidental grabs across adjacent sliders when aiming near the gap.
  - [ ] Hover unaffected by the held controller while a slider is grabbed (highlight only on the *other* thumbs).