### PR TITLE
feat(quadrics): live family classification label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "three": "^0.184.0"
+        "three": "^0.184.0",
+        "troika-three-text": "^0.52.4"
       },
       "devDependencies": {
         "@types/three": "^0.184.0",
@@ -416,6 +417,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -814,6 +824,15 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
@@ -880,6 +899,36 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -980,6 +1029,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "three": "^0.184.0"
+    "three": "^0.184.0",
+    "troika-three-text": "^0.52.4"
   },
   "devDependencies": {
     "@types/three": "^0.184.0",

--- a/src/exhibits/quadrics/Label.ts
+++ b/src/exhibits/quadrics/Label.ts
@@ -1,0 +1,102 @@
+import * as THREE from 'three';
+import { Text } from 'troika-three-text';
+
+export interface LabelOptions {
+  // Font sizes in world units (meters). Defaults sized for the family-label
+  // viewing distance in SPEC.md "Scene geometry" (~3 m). Per-slider reuse
+  // (#22) at ~1.5 m will pass smaller values.
+  primaryFontSize?: number;
+  secondaryFontSize?: number;
+  // Vertical gap between the bottom of the primary line and the top of the
+  // secondary line, in meters.
+  lineGap?: number;
+  color?: number | string;
+}
+
+const DEFAULT_PRIMARY_FONT_SIZE = 0.16;
+const DEFAULT_SECONDARY_FONT_SIZE = 0.07;
+const DEFAULT_LINE_GAP = 0.02;
+const DEFAULT_COLOR = 0xffffff;
+
+// Outline gives the text contrast against any surface color behind it.
+// SDF outline width is a fraction of the font size.
+const OUTLINE_WIDTH = '6%';
+const OUTLINE_COLOR = 0x000000;
+
+/**
+ * Two-line billboarded text label. Primary line on top (large), secondary
+ * line below (small). Owns a single `THREE.Group` you can position on the
+ * scene; call `faceCamera(camera)` per-frame to billboard.
+ *
+ * Reuse target: this primitive is shared with the per-slider labels in #22 —
+ * keep the surface narrow and orientation-agnostic.
+ */
+export class Label {
+  readonly group: THREE.Group;
+
+  private readonly primary: Text;
+  private readonly secondary: Text;
+  private primaryText = '';
+  private secondaryText = '';
+
+  constructor(opts: LabelOptions = {}) {
+    const primaryFontSize = opts.primaryFontSize ?? DEFAULT_PRIMARY_FONT_SIZE;
+    const secondaryFontSize =
+      opts.secondaryFontSize ?? DEFAULT_SECONDARY_FONT_SIZE;
+    const lineGap = opts.lineGap ?? DEFAULT_LINE_GAP;
+    const color = opts.color ?? DEFAULT_COLOR;
+
+    this.group = new THREE.Group();
+    this.group.name = 'label';
+
+    // Primary: glyphs extend upward from y = lineGap/2 (anchor at bottom).
+    this.primary = new Text();
+    this.primary.fontSize = primaryFontSize;
+    this.primary.color = color;
+    this.primary.anchorX = 'center';
+    this.primary.anchorY = 'bottom';
+    this.primary.textAlign = 'center';
+    this.primary.outlineWidth = OUTLINE_WIDTH;
+    this.primary.outlineColor = OUTLINE_COLOR;
+    this.primary.position.y = lineGap / 2;
+    this.group.add(this.primary);
+
+    // Secondary: glyphs extend downward from y = -lineGap/2 (anchor at top).
+    this.secondary = new Text();
+    this.secondary.fontSize = secondaryFontSize;
+    this.secondary.color = color;
+    this.secondary.anchorX = 'center';
+    this.secondary.anchorY = 'top';
+    this.secondary.textAlign = 'center';
+    this.secondary.outlineWidth = OUTLINE_WIDTH;
+    this.secondary.outlineColor = OUTLINE_COLOR;
+    this.secondary.position.y = -lineGap / 2;
+    this.group.add(this.secondary);
+  }
+
+  setPrimary(text: string): void {
+    if (text === this.primaryText) return;
+    this.primaryText = text;
+    this.primary.text = text;
+    this.primary.sync();
+  }
+
+  setSecondary(text: string): void {
+    if (text === this.secondaryText) return;
+    this.secondaryText = text;
+    this.secondary.text = text;
+    this.secondary.sync();
+  }
+
+  // Face the camera by matching its world rotation. Standard billboard:
+  // the group's local +Z is troika Text's natural facing direction, so
+  // copying the camera quaternion makes both lines face the viewer.
+  faceCamera(camera: THREE.Camera): void {
+    this.group.quaternion.copy(camera.quaternion);
+  }
+
+  dispose(): void {
+    this.primary.dispose();
+    this.secondary.dispose();
+  }
+}

--- a/src/exhibits/quadrics/classify.ts
+++ b/src/exhibits/quadrics/classify.ts
@@ -1,0 +1,73 @@
+// Pure classifier: (a, b, c, d) → family label, per SPEC.md "Classification taxonomy".
+//
+// Sign-flip symmetry — the surface defined by (a, b, c, d) equals the one
+// defined by (−a, −b, −c, −d) — is handled by enumerating both halves of
+// each flip-pair explicitly in the table below, mirroring SPEC.md.
+
+// Per SPEC.md "Classifier numerical contract". The slider's own zero detent
+// (0.05) already snaps to exact zero on emit; this epsilon is defense in
+// depth for any non-slider caller (tests, future presets).
+const ZERO_EPSILON = 1e-6;
+
+export type Sign = -1 | 0 | 1;
+
+export interface Classification {
+  family: string;
+}
+
+const TABLE: ReadonlyMap<string, string> = new Map([
+  // (n+, n−, n₀) | sgn(d) | Family
+  ['3,0,0|1', 'Ellipsoid'],
+  ['3,0,0|0', 'Degenerate'],
+  ['3,0,0|-1', 'Empty set'],
+  ['0,3,0|1', 'Empty set'],
+  ['0,3,0|0', 'Degenerate'],
+  ['0,3,0|-1', 'Ellipsoid'],
+  ['2,1,0|1', 'Hyperboloid (1 sheet)'],
+  ['2,1,0|0', 'Cone'],
+  ['2,1,0|-1', 'Hyperboloid (2 sheets)'],
+  ['1,2,0|1', 'Hyperboloid (2 sheets)'],
+  ['1,2,0|0', 'Cone'],
+  ['1,2,0|-1', 'Hyperboloid (1 sheet)'],
+  ['2,0,1|1', 'Elliptic cylinder'],
+  ['2,0,1|0', 'Degenerate'],
+  ['2,0,1|-1', 'Empty set'],
+  ['0,2,1|1', 'Empty set'],
+  ['0,2,1|0', 'Degenerate'],
+  ['0,2,1|-1', 'Elliptic cylinder'],
+  ['1,1,1|1', 'Hyperbolic cylinder'],
+  ['1,1,1|0', 'Pair of intersecting planes'],
+  ['1,1,1|-1', 'Hyperbolic cylinder'],
+  ['1,0,2|1', 'Pair of parallel planes'],
+  ['1,0,2|0', 'Degenerate'],
+  ['1,0,2|-1', 'Empty set'],
+  ['0,1,2|1', 'Empty set'],
+  ['0,1,2|0', 'Degenerate'],
+  ['0,1,2|-1', 'Pair of parallel planes'],
+  ['0,0,3|1', 'Empty set'],
+  ['0,0,3|0', 'Degenerate'],
+  ['0,0,3|-1', 'Empty set'],
+]);
+
+export function sign(v: number): Sign {
+  if (Math.abs(v) < ZERO_EPSILON) return 0;
+  return v > 0 ? 1 : -1;
+}
+
+export function classify(a: number, b: number, c: number, d: number): Classification {
+  const signs = [sign(a), sign(b), sign(c)];
+  let nPlus = 0;
+  let nMinus = 0;
+  let nZero = 0;
+  for (const s of signs) {
+    if (s === 1) nPlus++;
+    else if (s === -1) nMinus++;
+    else nZero++;
+  }
+  const key = `${nPlus},${nMinus},${nZero}|${sign(d)}`;
+  const family = TABLE.get(key);
+  // Unreachable: (n+, n−, n₀) always partitions 3, sgn(d) ∈ {-1, 0, 1};
+  // the table enumerates all 10 × 3 = 30 combinations.
+  if (!family) throw new Error(`classify: missing taxonomy entry for ${key}`);
+  return { family };
+}

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -1,9 +1,12 @@
 import * as THREE from 'three';
 import type { Exhibit, ExhibitContext } from '../../shell/Exhibit';
 import { registerExhibit } from '../../shell/registry';
+import { classify } from './classify';
+import { Label } from './Label';
 import { Slider } from './Slider';
 
 const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -3);
+const FAMILY_LABEL_POSITION = new THREE.Vector3(0, 2.4, -3);
 const SLIDER_RACK_CENTER = new THREE.Vector3(0, 1.0, -0.7);
 const BOUND = 2.5;
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
@@ -154,13 +157,25 @@ const FRAGMENT_SHADER = /* glsl */ `
 let material: THREE.ShaderMaterial | undefined;
 let sliders: Slider[] = [];
 let controllers: THREE.Object3D[] = [];
+let familyLabel: Label | undefined;
+let camera: THREE.Camera | undefined;
 let elapsed = 0;
+
+// Format a coefficient value for the secondary label line: explicit sign,
+// two decimal places. Per SPEC.md "Label content" — the explicit sign keeps
+// the visual jump from +0.05 to −0.05 unambiguous through the zero detent.
+function formatCoeff(name: string, v: number): string {
+  const sign = v < 0 ? '−' : '+';
+  return `${name} = ${sign}${Math.abs(v).toFixed(2)}`;
+}
 
 const quadricsExhibit: Exhibit = {
   id: 'quadrics',
   title: 'Quadric surfaces',
 
-  mount({ scene, renderer }: ExhibitContext) {
+  mount({ scene, renderer, camera: cam }: ExhibitContext) {
+    camera = cam;
+
     const floor = new THREE.Mesh(
       new THREE.PlaneGeometry(10, 10),
       new THREE.MeshStandardMaterial({ color: 0x222244 }),
@@ -210,6 +225,10 @@ const quadricsExhibit: Exhibit = {
     });
 
     controllers = setupControllers(scene, renderer, sliders);
+
+    familyLabel = new Label();
+    familyLabel.group.position.copy(FAMILY_LABEL_POSITION);
+    scene.add(familyLabel.group);
   },
 
   update({ delta }) {
@@ -224,6 +243,15 @@ const quadricsExhibit: Exhibit = {
       elapsed += delta;
       const a = Math.cos((2 * Math.PI * elapsed) / SWEEP_PERIOD);
       material.uniforms.uA.value = a;
+    }
+    if (familyLabel) {
+      const [a, b, c, d] = sliders.map((s) => s.value);
+      const { family } = classify(a, b, c, d);
+      familyLabel.setPrimary(family);
+      familyLabel.setSecondary(
+        sliders.map((s) => formatCoeff(s.label, s.value)).join(', '),
+      );
+      if (camera) familyLabel.faceCamera(camera);
     }
   },
 };

--- a/src/types/troika-three-text.d.ts
+++ b/src/types/troika-three-text.d.ts
@@ -1,0 +1,20 @@
+// Minimal ambient types for troika-three-text. The package ships no .d.ts;
+// only the surface this codebase touches is declared here. Extend as needed.
+
+declare module 'troika-three-text' {
+  import { Mesh } from 'three';
+
+  export class Text extends Mesh {
+    text: string;
+    fontSize: number;
+    color: number | string | null;
+    anchorX: number | string;
+    anchorY: number | string;
+    textAlign: 'left' | 'right' | 'center' | 'justify';
+    maxWidth: number;
+    outlineWidth: number | string;
+    outlineColor: number | string | null;
+    sync(callback?: () => void): void;
+    dispose(): void;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #7. Adds a billboarded two-line label above the quadric surface — large family name on top, small live `a, b, c, d` line below — and the pure classifier behind it.

- `classify.ts` — pure `(a, b, c, d) → { family }` against the SPEC's full 30-row taxonomy. Both halves of each sign-flip pair are enumerated explicitly, so flip symmetry falls out for free. Uses the SPEC's `1e-6` epsilon as defense in depth on top of the slider's `0.05` zero-detent.
- `Label.ts` — minimal two-line billboarded text primitive on `troika-three-text`. Mirrors `Slider`'s shape (`group` + simple setters); ready to be reused unchanged by #22 (per-slider labels). Outline gives contrast against any surface color.
- `troika-three-text.d.ts` — ambient declarations for the slice of the API this codebase touches; the package ships no types.

## Choices worth flagging

- **`troika-three-text` over `CanvasTexture`.** SDF stays sharp at any distance/angle. The family label is ~3 m off and the per-slider labels (#22) will be ~1.5 m of small text — exactly the failure mode CanvasTexture's distance-softness shows. Issue body recommended this; #22 is blocked on the choice and will reuse the primitive.
- **Bundle growth: ~470 KB minified / ~135 KB gzipped.** Troika ships its own SDF generator + worker. Single-chunk build for now (Vite warned about the 500 KB chunk threshold). Code-split candidate later — not v0.1 work.
- **Default font fetched from a CDN at runtime.** Self-hosting later if we want offline/Pages-only loads.
- **Billboard via `group.quaternion.copy(camera.quaternion)`.** Simplest correct billboard; full rotation match. If headset POV makes the up/down tilt feel wrong we can switch to Y-axis-only.

## Caveats / not covered here

- No test harness in repo; classifier was eyeballed against the SPEC table. Browser smoke covered: default state renders "Ellipsoid", flipping a coefficient sign switches families, snap-to-zero hits "Cone" / "Pair of intersecting planes" cleanly.
- VR-side polish (label height vs. surface, billboard tilt, exact font sizes) deliberately deferred to in-headset feedback. Brad confirmed desktop-render correctness; depth overlap on flat 2D viewport is expected and will be obvious in stereo.

## Test plan

- [x] `npm run build` clean (tsc + vite). ✅ verified locally
- [ ] Desktop browser smoke: label visible, updates as sliders move, families change at degeneracy boundaries. ✅ verified locally
- [ ] On-Quest smoke once deployed: text crisp at 3 m, label sits comfortably above surface, billboard reads naturally. (Post-merge per VR-smoke policy.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)