### PR TITLE
fix(quadrics): reposition family label above-and-forward of surface

### DIFF
--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -118,7 +118,7 @@ drags through a degeneracy.
 |----------------|---------------------|---------------------------------------|
 | Surface center | `(0, 1.5, −3)`      | ~2 m in front of the standing user; close enough to walk up to, far enough that the bounding volume doesn't clip through the spawn point. |
 | Slider rack    | `(0, 1.0, −0.7)`    | Below-and-in-front; reachable with controllers without a step. |
-| Family label   | `(0, 2.4, −3)`      | Above the surface, billboarded to face the user. |
+| Family label   | `(0, 3.5, −2.0)`    | Above and in front of the surface. The surface volume reaches `y ≈ 4.0` at small-coefficient states, so the label uses depth/parallax separation (1 m closer in `z` than the surface center) to stay readable when their screen-space rectangles overlap. Yaw-only billboarded (#29). |
 | Floor          | `y = 0`             | Inherited from the shell convention; visual horizon and comfort anchor. |
 
 Units are meters. The user's head start position is the WebXR session

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -6,7 +6,14 @@ import { Label } from './Label';
 import { Slider } from './Slider';
 
 const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -3);
-const FAMILY_LABEL_POSITION = new THREE.Vector3(0, 2.4, -3);
+// Above-and-forward of the surface. The surface render volume reaches
+// y = SURFACE_CENTER.y + BOUND = 4.0 at small-coefficient states, so a
+// label at z = SURFACE_CENTER.z would be buried for any large-surface
+// state. Forward placement (z = -2.0) gives 1.0 m of depth separation
+// from the surface center, so when their screen-space rectangles
+// overlap stereo parallax + the depth buffer keep the label clearly in
+// front. y = 3.5 is 1.0 m above the default ellipsoid's top (y = 2.5).
+const FAMILY_LABEL_POSITION = new THREE.Vector3(0, 3.5, -2.0);
 const SLIDER_RACK_CENTER = new THREE.Vector3(0, 1.0, -0.7);
 const BOUND = 2.5;
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();


### PR DESCRIPTION
## Summary
- Move `FAMILY_LABEL_POSITION` from `(0, 2.4, -3)` to `(0, 3.5, -2.0)`. The old position was 0.1 m *below* the default ellipsoid's surface top (y = 2.5) and shared `z` with the surface, so the label read as embedded — and it got worse for any small-coefficient state where the surface fills more of the BOUND volume up to y = 4.0.
- New position is 1 m above the default surface top, plus 1 m closer to the user than the surface center. Depth-buffer + stereo parallax keep it clearly in front when their screen-space rectangles overlap.
- SPEC "Scene geometry" updated with the new coordinates and the rationale.

## Position rationale
- **Default state `(1,1,1,1)`:** surface top at y = 2.5; label at y = 3.5 is unambiguously above.
- **Worst case (small `a/b/c`):** surface render volume reaches y = 4.0; label at y = 3.5 sits inside that band but at z = -2.0 (1 m forward of surface center) the depth test + stereo separation keep it readable as "in front and above" rather than "buried."
- **Trade-off accepted:** look-up angle from a 1.6 m standing eye is steeper (~43° vs. the original ~15°). Legibility was the issue; angle is the price.

## Static pick — easy to iterate
The issue notes that adaptive height (label tracks the surface's current bounding extent) is the most robust option but adds per-frame logic, and is "worth feeling out in headset before committing." This PR takes the issue's "Bump up + forward" suggestion as a starting point. If headset feel says nudge values, the constant on line 14 is a one-line change.

## Test plan
- [x] `npm run build` (tsc + vite) passes locally.
- [ ] On-device Quest 3S, default `(1,1,1,1)`: label clearly above the ellipsoid from a standing viewpoint.
- [ ] On-device Quest 3S, small-coefficient state (e.g. `(0.1, 0.1, 0.1, 1)`): label remains readable, reads as "in front of" the surface.
- [ ] No degraded readability across the slider range.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)