### PR TITLE
feat(quadrics): per-slider labels (variable name + signed value)

### DIFF
--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -110,7 +110,11 @@ drags through a degeneracy.
   at zero — no other snapping in v0.1.
 - **Per-slider visual:** horizontal track with a draggable thumb, labeled
   with its variable name (`a`, `b`, `c`, `d`) and current numeric value to
-  two decimal places.
+  two decimal places. The label is mounted just left of the track,
+  parented to the slider's group so it tracks position automatically;
+  variable name on the primary line (large), signed value on the
+  secondary line (small). Yaw-only billboarded, sharing the same
+  `Label` primitive as the family label.
 
 ## Scene geometry
 

--- a/src/exhibits/quadrics/Slider.ts
+++ b/src/exhibits/quadrics/Slider.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { Label } from './Label';
 
 export interface SliderOptions {
   label: string;
@@ -63,6 +64,7 @@ export class Slider {
   private grabbedBy: THREE.Object3D | null = null;
   private lastControllerLocalX = 0;
   private hovered = false;
+  private displayLabel: Label | undefined;
 
   constructor(options: SliderOptions) {
     this.opts = {
@@ -107,6 +109,51 @@ export class Slider {
 
   get label(): string {
     return this.opts.label;
+  }
+
+  /**
+   * Attach a billboarded text label to this slider, parented to its group so
+   * it tracks the slider's world position automatically. Primary line is the
+   * variable name (large); secondary is the current value with explicit sign
+   * to two decimals, refreshed by `tickLabel()`. Font sizes are tuned for
+   * the ~1.5 m controller-reach viewing distance per SPEC.md.
+   */
+  mountLabel(): void {
+    if (this.displayLabel) return;
+    this.displayLabel = new Label({
+      primaryFontSize: 0.04,
+      secondaryFontSize: 0.02,
+      lineGap: 0.01,
+    });
+    this.displayLabel.setPrimary(this.opts.label);
+    // Just left of the track. Track spans local x ∈ [−L/2, +L/2]; offset
+    // the label center 0.05 m beyond the left end so glyphs clear the
+    // track and the thumb at its leftmost position.
+    this.displayLabel.group.position.set(
+      -this.opts.trackLength / 2 - 0.05,
+      0,
+      0,
+    );
+    this.group.add(this.displayLabel.group);
+    this.refreshLabelValue();
+  }
+
+  /**
+   * Per-frame label tick: refresh the displayed value and re-billboard.
+   * Caller decides whether to tick (e.g. exhibit may skip when no camera
+   * is available yet). No-op if `mountLabel()` was never called.
+   */
+  tickLabel(camera: THREE.Camera): void {
+    if (!this.displayLabel) return;
+    this.refreshLabelValue();
+    this.displayLabel.faceCamera(camera);
+  }
+
+  private refreshLabelValue(): void {
+    if (!this.displayLabel) return;
+    const v = this.currentValue;
+    const sign = v < 0 ? '−' : '+';
+    this.displayLabel.setSecondary(`${sign}${Math.abs(v).toFixed(2)}`);
   }
 
   get value(): number {

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -227,6 +227,7 @@ const quadricsExhibit: Exhibit = {
         topY - i * SLIDER_ROW_PITCH,
         SLIDER_RACK_CENTER.z,
       );
+      slider.mountLabel();
       scene.add(slider.group);
       return slider;
     });
@@ -241,6 +242,7 @@ const quadricsExhibit: Exhibit = {
   update({ delta }) {
     for (const s of sliders) s.updateHover(controllers);
     for (const s of sliders) s.update();
+    if (camera) for (const s of sliders) s.tickLabel(camera);
     if (material) {
       for (const s of sliders) {
         material.uniforms[`u${s.label.toUpperCase()}`].value = s.value;


### PR DESCRIPTION
## Summary
- Add `Slider.mountLabel()` and `Slider.tickLabel(camera)` so each slider owns a billboarded label parented to its group. The exhibit calls them at construction and per-frame respectively — no scene-level label management leaks out.
- Primary line: variable name (`a`/`b`/`c`/`d`) at fontSize 0.04 m. Secondary line: signed value to two decimals at 0.02 m. Both stacked just left of the track at `x = -trackLength/2 - 0.05`, parented to the slider's group so they track its world position automatically.
- Reuses the `Label` primitive from #7 — no new text primitive — and inherits the yaw-only billboard fix from #29 for free.
- SPEC "Slider model" updated to describe the placement.

## Why big-name + small-value (and not "a = +1.00" single-line)
The issue's core rationale is "with four identical thumbs on the rack it's a genuine usability gap — there's no visual cue distinguishing which slider drives which coefficient." Making the variable name the prominent line directly addresses that — at a glance the user sees `a`/`b`/`c`/`d`, with the value as auxiliary detail.

## Why parented to the slider, not the thumb
Per the issue's "Notes": label is owned by `slider.group`, not following the thumb's sliding x position. Glyph jiggle as the thumb drags would be uglier than a fixed-position label, and a fixed left-side anchor reinforces the rack's row structure (`a`/`b`/`c`/`d` stacked top-to-bottom, mirroring the equation `ax² + by² + cz² = d`).

## Sizing rationale
At the controller-reach distance (~1.5 m, per SPEC):
- Primary 0.04 m → ~1.5° angular subtense (comfortably readable).
- Secondary 0.02 m → ~0.75° (legible but compact, intended as detail).
- Total label height including the 0.01 m line gap: ~0.07 m, well inside the 0.15 m row pitch — no overlap with adjacent sliders.

## Note on assumptions
`Label.faceCamera()` sets local rotation to `(0, atan2(dx, dz), 0)` — correct as long as the parent (slider's group) has zero world rotation. The current rack lays sliders out with translation only, so this is fine; if a future exhibit rotates the slider rack the billboarding would need to compensate.

## Test plan
- [x] `npm run build` (tsc + vite) passes locally.
- [ ] On-device Quest 3S: each slider's variable name (`a`, `b`, `c`, `d`) is unambiguously identifiable at a glance.
- [ ] Per-slider value updates within one frame as you drag a thumb.
- [ ] Labels remain readable from any walk-around angle (yaw-only billboard).
- [ ] No visual overlap between adjacent slider rows or between labels and the track.
- [ ] Sign rendering looks right at and around the zero-detent boundary (`+0.05` ↔ `−0.05`).

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)