### PR TITLE
feat(quadrics): rack-anchored classification readout (#33)

### DIFF
--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -123,6 +123,7 @@ drags through a degeneracy.
 | Surface center | `(0, 1.5, −3)`      | ~2 m in front of the standing user; close enough to walk up to, far enough that the bounding volume doesn't clip through the spawn point. |
 | Slider rack    | `(0, 1.0, −0.7)`    | Below-and-in-front; reachable with controllers without a step. |
 | Family label   | `(0, 3.5, −2.0)`    | Above and in front of the surface. The surface volume reaches `y ≈ 4.0` at small-coefficient states, so the label uses depth/parallax separation (1 m closer in `z` than the surface center) to stay readable when their screen-space rectangles overlap. Yaw-only billboarded (#29). |
+| Rack readout   | `(0, 1.4, −0.7)`    | Compact second classification readout above the slider rack so the family name sits in the user's gaze area while interacting (#33). Family name only — per-slider labels render values inline. Yaw-only billboarded. |
 | Floor          | `y = 0`             | Inherited from the shell convention; visual horizon and comfort anchor. |
 
 Units are meters. The user's head start position is the WebXR session
@@ -130,15 +131,30 @@ origin (`y ≈ 1.6` for a standing user).
 
 ## Label content
 
-Two lines, billboarded:
+Two classification labels with different jobs, plus one label per slider:
 
-- **Family name** (large): one of the `Family` strings from the taxonomy
-  (e.g., `Hyperboloid (1 sheet)`, `Cone`, `Empty set`, `Degenerate`).
-- **Coefficient values** (small): `a = +1.00, b = +1.00, c = +1.00, d = +1.00`,
-  updating in real time. Sign is always shown explicitly so the visual
-  jump from `+0.05` to `−0.05` is unambiguous to the learner.
+- **Surface-anchored family label** — two lines, billboarded. The
+  room-scale "hero" — anchors the classification to what's visually
+  being classified.
+  - **Family name** (large): one of the `Family` strings from the
+    taxonomy (e.g., `Hyperboloid (1 sheet)`, `Cone`, `Empty set`,
+    `Degenerate`).
+  - **Coefficient values** (small):
+    `a = +1.00, b = +1.00, c = +1.00, d = +1.00`, updating in real
+    time. Sign is always shown explicitly so the visual jump from
+    `+0.05` to `−0.05` is unambiguous to the learner.
 
-The label re-classifies every frame.
+- **Rack readout** — single line, billboarded, anchored above the
+  slider rack. Compact in-flight feedback during a drag — the user
+  shouldn't have to look up at the surface label to know what state
+  they're in. Family name only; coefficient values are already
+  rendered by the per-slider labels.
+
+- **Per-slider labels** — variable name (large) and signed value to
+  two decimals (small), parented to each slider's group. See
+  "Slider model" above.
+
+All labels re-classify / re-format every frame.
 
 ## Controller interaction
 

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -15,6 +15,20 @@ const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -3);
 // front. y = 3.5 is 1.0 m above the default ellipsoid's top (y = 2.5).
 const FAMILY_LABEL_POSITION = new THREE.Vector3(0, 3.5, -2.0);
 const SLIDER_RACK_CENTER = new THREE.Vector3(0, 1.0, -0.7);
+
+// Compact second classification readout, anchored above the rack so the
+// family name sits in the user's gaze area while interacting (#33). The
+// surface-anchored family label is for stepping back and reading the result
+// on the surface; this rack readout is for in-flight feedback during a drag.
+// y = 1.4 is ~0.175 m above the top slider 'a' (which lives at
+// SLIDER_RACK_CENTER.y + 1.5 * SLIDER_ROW_PITCH = 1.225) — clearance for
+// the per-slider label glyphs below and the rack-readout glyphs above.
+const RACK_LABEL_POSITION = new THREE.Vector3(0, 1.4, -0.7);
+
+// Roughly half the family-label default (0.16), matching the closer
+// viewing distance (~0.7 m vs. ~3 m for the surface label).
+const RACK_LABEL_PRIMARY_FONT_SIZE = 0.06;
+
 const BOUND = 2.5;
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
 
@@ -165,6 +179,7 @@ let material: THREE.ShaderMaterial | undefined;
 let sliders: Slider[] = [];
 let controllers: THREE.Object3D[] = [];
 let familyLabel: Label | undefined;
+let rackLabel: Label | undefined;
 let camera: THREE.Camera | undefined;
 let elapsed = 0;
 
@@ -237,6 +252,12 @@ const quadricsExhibit: Exhibit = {
     familyLabel = new Label();
     familyLabel.group.position.copy(FAMILY_LABEL_POSITION);
     scene.add(familyLabel.group);
+
+    // Rack readout — family name only. Per-slider labels already render
+    // coefficient values inline, so duplicating them here would be noise.
+    rackLabel = new Label({ primaryFontSize: RACK_LABEL_PRIMARY_FONT_SIZE });
+    rackLabel.group.position.copy(RACK_LABEL_POSITION);
+    scene.add(rackLabel.group);
   },
 
   update({ delta }) {
@@ -253,14 +274,18 @@ const quadricsExhibit: Exhibit = {
       const a = Math.cos((2 * Math.PI * elapsed) / SWEEP_PERIOD);
       material.uniforms.uA.value = a;
     }
+    const [a, b, c, d] = sliders.map((s) => s.value);
+    const { family } = classify(a, b, c, d);
     if (familyLabel) {
-      const [a, b, c, d] = sliders.map((s) => s.value);
-      const { family } = classify(a, b, c, d);
       familyLabel.setPrimary(family);
       familyLabel.setSecondary(
         sliders.map((s) => formatCoeff(s.label, s.value)).join(', '),
       );
       if (camera) familyLabel.faceCamera(camera);
+    }
+    if (rackLabel) {
+      rackLabel.setPrimary(family);
+      if (camera) rackLabel.faceCamera(camera);
     }
   },
 };


### PR DESCRIPTION
## Summary
- Adds a compact second classification label above the slider rack at `(0, 1.4, -0.7)` so the family name sits in the user's gaze area while interacting (#33).
- Existing surface-anchored family label is unchanged — it remains the room-scale "hero." Rack readout is family name only; per-slider labels already render coefficient values inline.
- Yaw-only billboard via `Label.faceCamera` (#29). SPEC.md "Scene geometry" + "Label content" updated.

## Test plan
- [ ] Headset smoke after merge: family name on the rack readout updates in lockstep with the surface label as sliders drag.
- [ ] Rack readout legible while gaze is at the rack (no head tilt up).
- [ ] Both labels read upright when head pitches/tilts (yaw-only billboard intact).
- [ ] No regressions in per-slider labels or family label.

Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)