### PR TITLE
feat(quadrics): world-axis gridlines on the surface (#34)

### DIFF
--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -128,6 +128,23 @@ drags through a degeneracy.
 Units are meters. The user's head start position is the WebXR session
 origin (`y ≈ 1.6` for a standing user).
 
+## Surface rendering
+
+The quadric is ray-marched in a fragment shader against a world-aligned
+bounding cube. Per-fragment depth is written from the implicit-surface
+hit point so Quest's async spacewarp reprojects against the visible
+surface rather than the bounding cube (#3 / earlier).
+
+**World-axis gridlines** (#34) are mixed into the surface color at every
+fragment whose hit point is near an integer multiple of the grid spacing
+on any of the three world axes. The grid is anchored to world `(0, 0, 0)`
+— not to the surface center — so the surface reads as carved out of a
+fixed 3D coordinate frame, and walking around the surface in roomscale
+gives parallax through the grid lines (stronger 3D readout than a
+uniformly-lit single-color quadric). Line spacing 0.5 m, near-black
+"carved" line color, anti-aliased via `fwidth`. Decorative depth cue
+only — labels / measurement come in v0.2.
+
 ## Label content
 
 Two lines, billboarded:
@@ -186,4 +203,6 @@ them.
 - Equation rendering (LaTeX-style).
 - Multiple simultaneous surfaces for side-by-side comparison.
 - Save / load preset coefficient configurations.
-- Per-axis labels and gridlines.
+- Per-axis labels and *measurement* gridlines (numbered tick marks on
+  the world axes). Distinct from v0.1's decorative depth-cue gridlines
+  (above) — those are unlabeled and exist purely for parallax.

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -66,6 +66,15 @@ const FRAGMENT_SHADER = /* glsl */ `
   uniform vec3  uLightDir;
   uniform vec3  uBaseColor;
 
+  // World-axis gridlines (#34). GRID_FREQ = 2.0 → lines every 0.5 m.
+  // GRID_COLOR is near-black so the lines read as "carved into" the
+  // surface; GRID_INTENSITY caps how much they darken at line-center.
+  // Hardcoded for v0.1 — promote to uniforms only if headset iteration
+  // wants live tuning.
+  const float GRID_FREQ = 2.0;
+  const float GRID_INTENSITY = 0.6;
+  const vec3  GRID_COLOR = vec3(0.05);
+
   varying vec3 vWorldPos;
 
   float fImplicit(vec3 p) {
@@ -148,14 +157,28 @@ const FRAGMENT_SHADER = /* glsl */ `
     }
 
     float lambert = max(dot(n, normalize(uLightDir)), 0.0);
-    vec3 color = uBaseColor * (0.2 + 0.8 * lambert);
+    vec3 baseColor = uBaseColor * (0.2 + 0.8 * lambert);
+
+    // World-axis gridlines as a depth cue (#34): distance from each
+    // hit-world coordinate to the nearest integer multiple of
+    // (1 / GRID_FREQ). Anti-aliased via fwidth so the line stays one
+    // pixel regardless of viewing angle or distance. Mix darkens the
+    // surface where it crosses a gridline — reads as "carved into" the
+    // surface rather than overlaid on it. Walking around the surface
+    // gives parallax through the grid: stronger 3D readout than a
+    // uniformly-lit single-color quadric.
+    vec3 hitWorld = pHit + uSurfaceCenter;
+    vec3 g = abs(fract(hitWorld * GRID_FREQ) - 0.5);
+    float lineDist = min(min(g.x, g.y), g.z);
+    float lineWidth = 1.5 * fwidth(lineDist);
+    float mask = 1.0 - smoothstep(0.0, lineWidth, lineDist);
+    vec3 color = mix(baseColor, GRID_COLOR, mask * GRID_INTENSITY);
     gl_FragColor = vec4(color, 1.0);
 
     // Write the implicit-surface depth, not the bounding cube's. Quest's
     // asynchronous spacewarp reprojects per-pixel from the depth buffer; with
     // the cube's depth (meters off from the visible surface), reprojection
     // smears the surface into a translucent / negative-space ghost.
-    vec3 hitWorld = pHit + uSurfaceCenter;
     vec4 clip = projectionMatrix * viewMatrix * vec4(hitWorld, 1.0);
     gl_FragDepth = (clip.z / clip.w) * 0.5 + 0.5;
   }


### PR DESCRIPTION
## Summary
- Fragment-shader-only change: anti-aliased gridlines mixed into the surface color via distance-to-nearest-integer-plane + `fwidth()` (#34).
- Grid anchored to world `(0, 0, 0)` — not the surface center — so the surface reads as carved out of a fixed coordinate frame; walking around the surface in roomscale gives parallax through the grid.
- Hardcoded constants for v0.1: `GRID_FREQ = 2.0` (→ 0.5 m line spacing), `GRID_INTENSITY = 0.6`, near-black `GRID_COLOR`.
- `hitWorld` is now computed once before color and reused for the depth write (no extra cost).
- SPEC.md: new "Surface rendering" section; the v0.2 candidate disambiguates this decorative grid from future *measurement* gridlines.

## Test plan
- [ ] Headset smoke after merge (Quest 3S): grid visible on the default ellipsoid; lines appear "carved" rather than overlaid.
- [ ] Walking around the surface gives clear parallax through the grid (the 3D feel is stronger than baseline).
- [ ] No frame-rate regression; ≥ 72 Hz holds (verified end-to-end in #8).
- [ ] No moiré at typical viewing distance; lines remain ~1 pixel wide at all angles (anti-aliasing intact).
- [ ] All quadric families still render correctly under the new shading.

Closes #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)