### PR TITLE
ci: run build on pull_request (closes #40)

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,20 @@
+name: build-check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - run: npm ci
+      - run: npm run build


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/build-check.yml` — runs `npm ci && npm run build` on PRs targeting `main`.
- Keeps `pages.yml` single-purpose (deploy on `push: main`); split is cleaner than overloading the deploy workflow with a PR-only path.
- No artifact upload, no deploy from PRs.

Closes #40.

## Test plan

- [x] `npm run build` passes locally.
- [x] This PR's own `build-check / build` run goes green (validates the workflow).
- [ ] Follow-up: add `build-check / build` as a required status check on the `skyline-oss-default` ruleset (UI step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)