### PR TITLE
ci: rename build-check job for picker clarity

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  build-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Renames the job in `.github/workflows/build-check.yml` from `build` → `build-check`.
- Disambiguates from `pages.yml`'s `build` job in GitHub's required-status-check picker.

## Expected gate behavior on this PR

This PR is intentionally a test of the required-check gate:

1. The renamed job produces a `build-check` check, not a `build` check.
2. The current ruleset requires `build` — which no workflow on this PR produces.
3. PR should therefore show \"Required status check expected\" and block merge.
4. Swap the required check in the ruleset from `build` to `build-check`, and the PR should unblock.

## Test plan

- [x] `build-check` check fires and passes on this PR.
- [x] PR is blocked from merging while ruleset still requires `build`.
- [x] After swapping the required check to `build-check`, PR can merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)