### PR TITLE
chore: gate ESLint via CI + pre-commit (phase 2 of #42, closes)

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -17,4 +17,5 @@ jobs:
           node-version: '20'
           cache: npm
       - run: npm ci
+      - run: npm run lint
       - run: npm run build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,12 @@ repos:
         args: ['--maxkb=500']
       - id: check-yaml
       - id: check-json
+
+  - repo: local
+    hooks:
+      - id: eslint
+        name: eslint
+        entry: npm run lint --silent
+        language: system
+        types: [ts]
+        pass_filenames: false


### PR DESCRIPTION
## Summary

Phase 2 of #42 — flip ESLint on as a gate now that phase 1 confirmed zero violations.

- `build-check.yml`: run `npm run lint` between `npm ci` and `npm run build`. Lint fast-fails before the heavier build step.
- `.pre-commit-config.yaml`: add a `local` eslint hook (runs `npm run lint`, scoped to commits touching TS files).

Closes #42.

## Test plan

- [x] `pre-commit run eslint --all-files` passes locally.
- [x] Pre-commit on this commit (YAML only) skipped the eslint hook as intended (`types: [ts]` filter).
- [x] CI's `build-check` passes on this PR — i.e. lint runs and is green.
- [ ] After merge: a future PR with a deliberate lint violation (unused var) should be blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)