### PR TITLE
perf(quadrics): foveation + throttled slider label sync (#38)

### DIFF
--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -150,10 +150,13 @@ only — labels / measurement come in v0.2.
 Two surgical knobs land in v0.1.1 to tighten the labels-vs-surface
 asymmetry first reported post-#8 (smooth surface, slightly-jank UI):
 
-- **Quest fixed foveated rendering** at maximum
-  (`renderer.xr.setFoveation(1.0)` in the shell). Frees GPU budget on
-  the periphery; applies to every exhibit, not just this one. Static
-  / center-of-view foveation (Quest 3S has no eye tracking).
+- **Quest fixed foveated rendering** at a mild setting
+  (`renderer.xr.setFoveation(0.3)` in the shell — wide detailed
+  fraction, gentle falloff). Frees GPU budget on the periphery
+  without making it read as visibly blurry; applies to every exhibit,
+  not just this one. Static / center-of-view foveation (Quest 3S has
+  no eye tracking). Ramp the level up if profiling says more headroom
+  is needed.
 - **Throttled per-slider value-label refresh** during an active drag
   (≤30 Hz, see `LABEL_SYNC_INTERVAL_MS` in `Slider.ts`). Bounds the
   rate of troika SDF `.sync()` calls — head-pose billboarding still

--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -145,6 +145,26 @@ uniformly-lit single-color quadric). Line spacing 0.5 m, near-black
 "carved" line color, anti-aliased via `fwidth`. Decorative depth cue
 only — labels / measurement come in v0.2.
 
+## Frame-pacing knobs (#38)
+
+Two surgical knobs land in v0.1.1 to tighten the labels-vs-surface
+asymmetry first reported post-#8 (smooth surface, slightly-jank UI):
+
+- **Quest fixed foveated rendering** at maximum
+  (`renderer.xr.setFoveation(1.0)` in the shell). Frees GPU budget on
+  the periphery; applies to every exhibit, not just this one. Static
+  / center-of-view foveation (Quest 3S has no eye tracking).
+- **Throttled per-slider value-label refresh** during an active drag
+  (≤30 Hz, see `LABEL_SYNC_INTERVAL_MS` in `Slider.ts`). Bounds the
+  rate of troika SDF `.sync()` calls — head-pose billboarding still
+  runs every frame, so motion smoothness is untouched. Outside an
+  active drag the label refreshes every tick so the post-release
+  value is exact.
+
+Both are reversible knobs. Profile-guided follow-ups (ray-march
+`STEPS`, framebuffer scale factor, etc.) deferred to a follow-on PR
+if these don't fully close the gap.
+
 ## Label content
 
 One classification readout plus one label per slider:

--- a/src/exhibits/quadrics/Slider.ts
+++ b/src/exhibits/quadrics/Slider.ts
@@ -22,6 +22,14 @@ const DEFAULT_DRAG_GAIN = 1.75;
 // Lets the user park exactly on a degeneracy boundary instead of approximating.
 const ZERO_DETENT = 0.05;
 
+// Per-slider value-label refresh cap during a drag. The displayed value is
+// re-formatted at most once per this interval, keeping the troika SDF
+// `.sync()` rate bounded while head-pose billboarding still runs every frame.
+// Outside an active drag the label always refreshes (so the post-release
+// value is exact). 33 ms ≈ 30 Hz — humans can't read faster than that
+// anyway, and ~3× fewer SDF re-syncs is the whole point (issue #38).
+const LABEL_SYNC_INTERVAL_MS = 33;
+
 // Ray–thumb hit-test radius is this multiple of the thumb's visual radius.
 // Wider than the visual makes re-grab forgiving when the hand drifts off-aim
 // during release — especially after a zero-snap, where the thumb jumps to
@@ -65,6 +73,7 @@ export class Slider {
   private lastControllerLocalX = 0;
   private hovered = false;
   private displayLabel: Label | undefined;
+  private lastLabelSyncMs = 0;
 
   constructor(options: SliderOptions) {
     this.opts = {
@@ -142,10 +151,22 @@ export class Slider {
    * Per-frame label tick: refresh the displayed value and re-billboard.
    * Caller decides whether to tick (e.g. exhibit may skip when no camera
    * is available yet). No-op if `mountLabel()` was never called.
+   *
+   * The value-string refresh is throttled while a drag is active (see
+   * `LABEL_SYNC_INTERVAL_MS`) so troika SDF `.sync()` work is bounded.
+   * Billboarding (`faceCamera`) runs every frame regardless — head pose
+   * tracks at full rate.
    */
   tickLabel(camera: THREE.Camera): void {
     if (!this.displayLabel) return;
-    this.refreshLabelValue();
+    const now = performance.now();
+    const dueForSync =
+      this.grabbedBy === null ||
+      now - this.lastLabelSyncMs >= LABEL_SYNC_INTERVAL_MS;
+    if (dueForSync) {
+      this.refreshLabelValue();
+      this.lastLabelSyncMs = now;
+    }
     this.displayLabel.faceCamera(camera);
   }
 

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -21,10 +21,11 @@ export function bootShell(): void {
   renderer.xr.enabled = true;
   // Quest fixed foveated rendering: lowers peripheral pixel rate to free GPU
   // budget for the center of view. Stored now and applied by Three.js when
-  // the XR projection layer is created at session start. Trade-off is some
-  // peripheral softness; on Quest 3S the win on frame deadlines is the
-  // dominant signal (issue #38). Range 0..1; 1 = maximum foveation.
-  renderer.xr.setFoveation(1.0);
+  // the XR projection layer is created at session start. Range 0..1; higher
+  // = more aggressive periphery downsampling. Starting mild — wide detailed
+  // fraction, gentle falloff — so the periphery doesn't read as visibly
+  // blurry; ramp up if profiling says we still need more headroom (#38).
+  renderer.xr.setFoveation(0.3);
   document.body.appendChild(renderer.domElement);
   document.body.appendChild(VRButton.createButton(renderer));
 

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -19,6 +19,12 @@ export function bootShell(): void {
   renderer.setSize(window.innerWidth, window.innerHeight);
   renderer.setPixelRatio(window.devicePixelRatio);
   renderer.xr.enabled = true;
+  // Quest fixed foveated rendering: lowers peripheral pixel rate to free GPU
+  // budget for the center of view. Stored now and applied by Three.js when
+  // the XR projection layer is created at session start. Trade-off is some
+  // peripheral softness; on Quest 3S the win on frame deadlines is the
+  // dominant signal (issue #38). Range 0..1; 1 = maximum foveation.
+  renderer.xr.setFoveation(1.0);
   document.body.appendChild(renderer.domElement);
   document.body.appendChild(VRButton.createButton(renderer));
 


### PR DESCRIPTION
## Summary

Two surgical, reversible knobs from the candidate list in #38 to tighten the smooth-surface-vs-jank-UI asymmetry first reported post-#8:

- **Shell:** enable Quest fixed foveated rendering at a mild setting (`renderer.xr.setFoveation(0.3)`). Wide detailed fraction + gentle peripheral falloff so the periphery doesn't read as visibly blurry; ramp up after profiling if labels-vs-surface still feels off. Static / center-of-view only — Quest 3S has no eye tracking.
- **Slider:** throttle per-slider value-label refresh during an active drag to ~30 Hz (`LABEL_SYNC_INTERVAL_MS = 33`). Bounds troika SDF `.sync()` work without touching head-pose billboarding (`faceCamera` still runs every frame). Outside an active drag the label refreshes every tick so the post-release value remains exact.

Profile-guided follow-ups (ray-march `STEPS`, framebuffer scale factor, switching off troika) deferred to a follow-on PR if these don't fully close the gap in headset.

Closes-when-merged: depending on headset feedback. If labels still read jank after this lands, leave #38 open and chase candidate (3) / (4) / (5). If smooth, close it.

## Test plan

- [x] `npm run build` — clean (tsc + vite).
- [x] `npm run lint` — clean.
- [ ] On-device on Quest 3S: walk around the surface roomscale; confirm smoothness is preserved.
- [ ] On-device: drag a slider through its range; confirm label updates feel acceptable at the 30 Hz cap and post-release value is exact.
- [ ] Eyeball the periphery during slow head-turns; confirm 0.3 doesn't read as obviously blurry.