### PR TITLE
feat(quadrics): persistent X / Y / Z axis labels (#43)

### DIFF
--- a/src/exhibits/quadrics/WorldAxes.ts
+++ b/src/exhibits/quadrics/WorldAxes.ts
@@ -1,0 +1,108 @@
+import * as THREE from 'three';
+import { Text } from 'troika-three-text';
+
+// World-anchored X / Y / Z axis indicator (#43). Three thin lines from world
+// origin out along +X, +Y, +Z, with a single-letter troika label at each end.
+// Lets the viewer map a slider (a/b/c) to a spatial direction without having
+// to infer it from surface morphing alone — and stays a stable reference if
+// the v0.2 comfort pass (#44) rotates the world or shifts the surface.
+
+const AXIS_LENGTH = 2.0;
+const AXIS_COLOR = 0xffffff;
+const LINE_OPACITY = 0.5;
+
+// Lifts the floor-grazing X and Z lines off y=0 so they don't z-fight with
+// the floor plane. Y line extends purely upward from the same offset so the
+// triad meets at a single visible point above the floor.
+const FLOOR_OFFSET = 0.005;
+
+// Sized for readability across the three viewing distances from the spawn
+// pose (~1.9 m for Z, ~3.0 m for Y, ~3.9 m for X). A bit larger than Label's
+// 0.16 primary default so the longest leg still reads clearly.
+const FONT_SIZE = 0.18;
+const OUTLINE_WIDTH = '6%';
+const OUTLINE_COLOR = 0x000000;
+
+interface AxisSpec {
+  readonly name: 'X' | 'Y' | 'Z';
+  readonly dir: THREE.Vector3;
+}
+
+const AXES: readonly AxisSpec[] = [
+  { name: 'X', dir: new THREE.Vector3(1, 0, 0) },
+  { name: 'Y', dir: new THREE.Vector3(0, 1, 0) },
+  { name: 'Z', dir: new THREE.Vector3(0, 0, 1) },
+];
+
+/**
+ * Persistent world-axis indicator. Owns a `THREE.Group` you add to the
+ * scene; call `faceCamera(camera)` per-frame to billboard the letter
+ * labels (yaw-only, matching the family / per-slider labels — head pitch
+ * and roll stay out of the labels for the same #29 reason).
+ */
+export class WorldAxes {
+  readonly group: THREE.Group;
+
+  private readonly labels: Text[];
+  private readonly lineGeoms: THREE.BufferGeometry[];
+  private readonly lineMat: THREE.LineBasicMaterial;
+
+  // Hoisted out of `faceCamera` so per-frame billboarding does no allocation.
+  private readonly camWorld = new THREE.Vector3();
+  private readonly labelWorld = new THREE.Vector3();
+
+  constructor() {
+    this.group = new THREE.Group();
+    this.group.name = 'world-axes';
+    this.group.position.set(0, FLOOR_OFFSET, 0);
+
+    this.lineMat = new THREE.LineBasicMaterial({
+      color: AXIS_COLOR,
+      transparent: true,
+      opacity: LINE_OPACITY,
+    });
+
+    this.labels = [];
+    this.lineGeoms = [];
+
+    for (const { name, dir } of AXES) {
+      const end = dir.clone().multiplyScalar(AXIS_LENGTH);
+
+      const lineGeom = new THREE.BufferGeometry().setFromPoints([
+        new THREE.Vector3(0, 0, 0),
+        end,
+      ]);
+      this.lineGeoms.push(lineGeom);
+      this.group.add(new THREE.Line(lineGeom, this.lineMat));
+
+      const label = new Text();
+      label.text = name;
+      label.fontSize = FONT_SIZE;
+      label.color = AXIS_COLOR;
+      label.anchorX = 'center';
+      label.anchorY = 'middle';
+      label.outlineWidth = OUTLINE_WIDTH;
+      label.outlineColor = OUTLINE_COLOR;
+      label.position.copy(end);
+      label.sync();
+      this.group.add(label);
+      this.labels.push(label);
+    }
+  }
+
+  faceCamera(camera: THREE.Camera): void {
+    camera.getWorldPosition(this.camWorld);
+    for (const label of this.labels) {
+      label.getWorldPosition(this.labelWorld);
+      const dx = this.camWorld.x - this.labelWorld.x;
+      const dz = this.camWorld.z - this.labelWorld.z;
+      label.rotation.set(0, Math.atan2(dx, dz), 0);
+    }
+  }
+
+  dispose(): void {
+    for (const label of this.labels) label.dispose();
+    for (const geom of this.lineGeoms) geom.dispose();
+    this.lineMat.dispose();
+  }
+}

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -4,6 +4,7 @@ import { registerExhibit } from '../../shell/registry';
 import { classify } from './classify';
 import { Label } from './Label';
 import { Slider } from './Slider';
+import { WorldAxes } from './WorldAxes';
 
 const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -3);
 const SLIDER_RACK_CENTER = new THREE.Vector3(0, 1.0, -0.7);
@@ -194,6 +195,7 @@ let material: THREE.ShaderMaterial | undefined;
 let sliders: Slider[] = [];
 let controllers: THREE.Object3D[] = [];
 let rackLabel: Label | undefined;
+let worldAxes: WorldAxes | undefined;
 let camera: THREE.Camera | undefined;
 let elapsed = 0;
 
@@ -260,6 +262,9 @@ const quadricsExhibit: Exhibit = {
     rackLabel = new Label({ primaryFontSize: RACK_LABEL_PRIMARY_FONT_SIZE });
     rackLabel.group.position.copy(RACK_LABEL_POSITION);
     scene.add(rackLabel.group);
+
+    worldAxes = new WorldAxes();
+    scene.add(worldAxes.group);
   },
 
   update({ delta }) {
@@ -282,6 +287,7 @@ const quadricsExhibit: Exhibit = {
       rackLabel.setPrimary(family);
       if (camera) rackLabel.faceCamera(camera);
     }
+    if (worldAxes && camera) worldAxes.faceCamera(camera);
   },
 };
 


### PR DESCRIPTION
## Summary

- New `WorldAxes` primitive: three thin lines from world origin out along +X / +Y / +Z, with a single-letter troika label at each end. Yaw-billboarded (matching the family / per-slider labels).
- Wired into the quadrics exhibit's `mount()` and `update()`.
- Floor-grazing X / Z lines lifted 5 mm above y=0 to avoid z-fighting with the floor plane.

Closes #43.

## Design notes

- **Anchor:** world origin (0, 0, 0). All three axis +ends are visible from the default spawn pose at (0, 1.6, 3). The Y line stands forward of the user; the X and Z lines extend along the floor.
- **Reuse:** uses `troika-three-text`'s `Text` directly (per the issue's "reuse the existing primitive" guidance). `Label.ts` is a two-line composite — overloading it for single-letter labels would have bloated the API.
- **Sizing:** font 0.18, axis length 2 m. Bigger than `Label`'s 0.16 primary default to stay readable on the longest leg (~3.9 m for X from spawn).
- **Out of scope per the issue:** signed labels (+X / -X), tick marks / numeric units, RGB color-coding (Blender convention). Saving those for follow-on issues.

## Trial / iterate

Headset feedback may push on:
- Font size / line opacity / axis length.
- Whether axes through the world origin (current) feels disconnected from the surface at z=-3 — vs. anchoring at the surface bounding cube. World-anchored is the safer default since #44's comfort pass may rotate the world.

## Test plan

- [x] `npm run build` — passes locally.
- [x] `npm run lint` — passes locally.
- [x] CI build-check job green on PR.
- [ ] **On-device (Quest 3S):** all three labels readable from spawn pose without head movement.
- [ ] **On-device:** labels remain readable when surface is at extreme parameters (eccentric ellipsoid, hyperboloid of two sheets) — i.e. not occluded by surface or floor.
- [ ] **On-device:** labels billboard correctly (don't roll with head tilt) and stay upright.
- [ ] **On-device:** no visible z-fighting between X / Z axis lines and the floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)