### PR TITLE
docs(quadrics): note secondary benefit of the push-back (#44)

### DIFF
--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -9,11 +9,15 @@ import { WorldAxes } from './WorldAxes';
 
 // Pushed back from z=-3 to z=-4 as the v0.1.x comfort buffer (#44) — gives
 // extreme-parameter expansions ~1 m of headroom before they invade the
-// viewer's space at default spawn. The companion 45° yaw originally landed
-// alongside this push-back was reverted post-headset (didn't add the comfort /
-// intuition it was meant to, and broke the rectilinear math/standing-frame
-// alignment); door open for non-rectilinear perspectives once teleportation
-// lets the user self-position.
+// viewer's space at default spawn. Secondary benefit observed in headset:
+// a wider parameter band on slider `b` (math-Y, the axis pointing at the
+// user) where the user remains *outside* the surface entirely, avoiding
+// the more-disorienting "rendering the inside of the ellipsoid" failure
+// mode. The companion 45° yaw originally landed alongside this push-back
+// was reverted post-headset (didn't add the comfort / intuition it was
+// meant to, and broke the rectilinear math/standing-frame alignment);
+// door open for non-rectilinear perspectives once teleportation lets the
+// user self-position.
 const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
 const SLIDER_RACK_CENTER = new THREE.Vector3(0, 1.0, -0.7);
 


### PR DESCRIPTION
## Summary

Comment-only follow-up to #60. Captures a secondary benefit of the push-back that surfaced during your headset smoke and isn't obvious from the geometry alone:

> Pushing the surface center to math-Y=4 widens the parameter band on slider \`b\` where the user remains *outside* the surface entirely. That avoids the more-disorienting failure mode where the spawn point sits inside the ellipsoid and the renderer shows its interior.

Quantitatively modest in the elliptic cases (~5–10% wider safe band on \`b\` at d=1 / d=2) but qualitatively bigger than the percentage suggests, since being inside an ellipsoid is a meaningfully worse experience than the surface just being close. Captured next to the constant so it outlives PR threads.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- No runtime change — comment-only.