### PR TITLE
refactor(quadrics): switch parametric ↔ world-axis grid by family (#45 follow-up)

### DIFF
--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -135,29 +135,35 @@ bounding cube. Per-fragment depth is written from the implicit-surface
 hit point so Quest's async spacewarp reprojects against the visible
 surface rather than the bounding cube (#3 / earlier).
 
-**World-axis gridlines** (#34) are mixed into the surface color at every
-fragment whose hit point is near an integer multiple of the grid spacing
-on any of the three world axes. The grid is anchored to world `(0, 0, 0)`
-— not to the surface center — so the surface reads as carved out of a
-fixed 3D coordinate frame, and walking around the surface in roomscale
-gives parallax through the grid lines (stronger 3D readout than a
-uniformly-lit single-color quadric). Line spacing 0.5 m, near-black
-"carved" line color, anti-aliased via `fwidth`. Decorative depth cue
-only — labels / measurement come in v0.2.
+**Gridlines** are drawn as a depth cue using one of two systems,
+chosen per-fragment by family — never co-rendered. Both share the
+same near-black "carved" color and intensity so the visual style
+stays consistent across family transitions; only the *frame* the
+lines align to changes, reinforcing the family-classification flip
+already shown in the rack readout.
 
-**Parametric gridlines** (#45) overlay light "highlight" bands using a
-family-aware natural parameterization of the surface — pedagogically
-distinct from the world-axis grid: the world-axis lines stay anchored in
-world space as parameters morph, while the parametric lines flow *with*
-the surface, treating it as a 2-manifold being stretched. Lines of
-constant `θ` ("latitude") and constant `φ` ("longitude") on the
-ellipsoid; lines of constant `u` and `v` on the 1-sheet and 2-sheet
-hyperboloids. Cylinders / cones / planes / degenerate cases fall back to
-world-axis grid only. Family + special-axis dispatch is derived
-in-shader from `sign(uA, uB, uC, uD)` so the JS-side classifier API
-stays unchanged. Polar axis on the ellipsoid is world-Y (math-Z up, per
-#43's axis convention). Decorative — same posture as the world-axis
-grid; labels / measurement deferred.
+- **Parametric** (#45) — used on the ellipsoid and both hyperboloids.
+  Lines of constant `θ` ("latitude") and constant `φ` ("longitude")
+  on the ellipsoid; lines of constant `u` and `v` on the 1-sheet and
+  2-sheet hyperboloids, in a family-aware natural parameterization.
+  Lines flow *with* the surface as parameters morph — the
+  deformation is visible in the gridline pattern, not just the
+  silhouette. Polar axis on the ellipsoid is world-Y (math-Z up, per
+  #43's axis convention).
+
+- **World-axis** (#34) — used on cylinders, cones, planes, and
+  degenerate / empty cases (where a parametric form isn't natural).
+  Distance from each fragment's hit-world coordinate to the nearest
+  integer multiple of `1 / GRID_FREQ` on any of the three world
+  axes; anchored to world `(0, 0, 0)`. Spacing 0.5 m.
+
+Family + special-axis dispatch is derived in-shader from
+`sign(uA, uB, uC, uD)` so the JS-side classifier API stays unchanged.
+Both systems use `fwidth` for screen-space anti-aliasing so lines stay
+one-pixel-wide regardless of viewing angle or distance; walking around
+the surface in roomscale gives parallax through whichever grid is
+currently active. Decorative depth cue only — labels / measurement
+come in v0.2.
 
 ## Frame-pacing knobs (#38)
 

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -117,29 +117,20 @@ const FRAGMENT_SHADER = /* glsl */ `
   uniform vec3  uLightDir;
   uniform vec3  uBaseColor;
 
-  // World-axis gridlines (#34). GRID_FREQ = 2.0 → lines every 0.5 m.
-  // GRID_COLOR is near-black so the lines read as "carved into" the
-  // surface; GRID_INTENSITY caps how much they darken at line-center.
-  // Hardcoded for v0.1 — promote to uniforms only if headset iteration
-  // wants live tuning.
-  const float GRID_FREQ = 2.0;
+  // Gridline color + intensity — shared between world-axis (#34) and
+  // parametric (#45) gridlines, which never co-render (#45 switch
+  // behavior). Near-black so the lines read as "carved into" the surface;
+  // intensity caps the darkening at line-center.
+  const float GRID_FREQ = 2.0;            // World-axis: lines every 0.5 m.
   const float GRID_INTENSITY = 0.6;
   const vec3  GRID_COLOR = vec3(0.05);
 
-  // Parametric (latitude / longitude) gridlines (#45). Family-aware natural
-  // parameterization — lines flow with the surface as parameters morph,
-  // pedagogically distinct from the world-axis grid above which stays
-  // anchored in world space. PARAM_GRID_COLOR is a warm near-white so the
-  // bands read as highlights painted on the surface (contrast with #34's
-  // dark carved bands). LAT/LON line counts are starting guesses — tune in
-  // headset.
-  const float PARAM_GRID_INTENSITY = 0.55;
-  const vec3  PARAM_GRID_COLOR     = vec3(0.95, 0.92, 0.78);
+  // Parametric grid line counts. LAT/LON are uniform on bounded angular
+  // ranges; hyperboloid u is unbounded, so spaced by density rather than
+  // fixed count. Density 1.5 ⇒ a line every ~0.67 in hyperbolic-arc units,
+  // ~8 lines across the visible surface at default scale.
   const int   PARAM_LAT_LINES      = 12;
   const int   PARAM_LON_LINES      = 12;
-  // Hyperboloids: u is unbounded, so we space lines by u-density rather
-  // than fixed count. 1.5 ⇒ a line every ~0.67 in hyperbolic-arc units;
-  // matches roughly 8 lines across the visible surface at default scale.
   const float PARAM_HYP_DENSITY    = 1.5;
   // Generous compared to the classifier's 1e-6 — slider snap-detent already
   // pins zeros exactly, so anything between PARAM_SIGN_EPSILON and 0.05
@@ -184,24 +175,25 @@ const FRAGMENT_SHADER = /* glsl */ `
 
   // Family dispatch derived from sign(uA, uB, uC, uD) directly — keeps the
   // shader self-contained (no extra uniforms) and avoids duplicating the
-  // taxonomy from classify.ts. Three buckets:
+  // taxonomy from classify.ts. Three buckets where parametric is natural:
   //   * ellipsoid → spherical (θ, φ); polar axis = world-Y (math-Z up
   //     per #43's axis convention).
   //   * 1-sheet hyperboloid → (u, v); axis of revolution = the
   //     opposite-sign-from-uD coefficient.
   //   * 2-sheet hyperboloid → (u, v); axis of separation (sheet axis) =
   //     the same-sign-as-uD coefficient.
-  // Cylinders / cones / planes / degenerates fall back to world-axis only,
-  // matching the issue's "fall back if a parametric form isn't natural"
-  // allowance.
-  float parametricGridMask(vec3 p) {
+  // Cylinders / cones / planes / degenerates / empty set get .y = 0.0
+  // ("family inactive") and the caller draws the world-axis grid instead.
+  // Returns vec2(gridMask, familyActive) — when inactive, gridMask is
+  // unspecified and the caller must gate on familyActive.
+  vec2 parametricGrid(vec3 p) {
     float aSign = (abs(uA) < PARAM_SIGN_EPSILON) ? 0.0 : sign(uA);
     float bSign = (abs(uB) < PARAM_SIGN_EPSILON) ? 0.0 : sign(uB);
     float cSign = (abs(uC) < PARAM_SIGN_EPSILON) ? 0.0 : sign(uC);
     float dSign = (abs(uD) < PARAM_SIGN_EPSILON) ? 0.0 : sign(uD);
 
     if (aSign == 0.0 || bSign == 0.0 || cSign == 0.0 || dSign == 0.0) {
-      return 0.0;
+      return vec2(0.0, 0.0);
     }
 
     // Normalize to RHS = +|uD| by absorbing sgn(uD): post-normalize,
@@ -210,7 +202,7 @@ const FRAGMENT_SHADER = /* glsl */ `
     float bN = bSign * dSign;
     float cN = cSign * dSign;
     int neg = int(aN < 0.0) + int(bN < 0.0) + int(cN < 0.0);
-    if (neg == 3) return 0.0;  // Empty set — never rasterizes anyway.
+    if (neg == 3) return vec2(0.0, 0.0);  // Empty set — never rasterizes.
 
     // Dimensionless on-surface coords. q.x = p.x / r_x where
     // r_x = sqrt(|uD|/|uA|). On the ellipsoid: q.x²+q.y²+q.z² = 1.
@@ -226,7 +218,7 @@ const FRAGMENT_SHADER = /* glsl */ `
       float phi   = atan(q.z, q.x);
       float mLat = lineMaskAA(theta / PI * float(PARAM_LAT_LINES));
       float mLon = lineMaskAA((phi + PI) / TWO_PI * float(PARAM_LON_LINES));
-      return max(mLat, mLon);
+      return vec2(max(mLat, mLon), 1.0);
     }
 
     if (neg == 1) {
@@ -243,7 +235,7 @@ const FRAGMENT_SHADER = /* glsl */ `
       float v = atan(qOnB, qOnA);
       float mU = lineMaskAA(u * PARAM_HYP_DENSITY);
       float mV = lineMaskAA((v + PI) / TWO_PI * float(PARAM_LON_LINES));
-      return max(mU, mV);
+      return vec2(max(mU, mV), 1.0);
     }
 
     // neg == 2 → 2-sheet hyperboloid. Special axis (sheet axis) = the only
@@ -261,7 +253,7 @@ const FRAGMENT_SHADER = /* glsl */ `
     float v = atan(qOnB, qOnA);
     float mU = lineMaskAA(u * PARAM_HYP_DENSITY);
     float mV = lineMaskAA((v + PI) / TWO_PI * float(PARAM_LON_LINES));
-    return max(mU, mV);
+    return vec2(max(mU, mV), 1.0);
   }
 
   bool rayAABB(vec3 ro, vec3 rd, float r, out float tNear, out float tFar) {
@@ -330,27 +322,38 @@ const FRAGMENT_SHADER = /* glsl */ `
     float lambert = max(dot(n, normalize(uLightDir)), 0.0);
     vec3 baseColor = uBaseColor * (0.2 + 0.8 * lambert);
 
-    // World-axis gridlines as a depth cue (#34): distance from each
-    // hit-world coordinate to the nearest integer multiple of
-    // (1 / GRID_FREQ). Anti-aliased via fwidth so the line stays one
-    // pixel regardless of viewing angle or distance. Mix darkens the
-    // surface where it crosses a gridline — reads as "carved into" the
-    // surface rather than overlaid on it. Walking around the surface
-    // gives parallax through the grid: stronger 3D readout than a
-    // uniformly-lit single-color quadric.
+    // Gridlines as a depth cue. Two systems, never co-rendered (#45
+    // headset feedback: simultaneous display read as cluttered):
+    //
+    //   * Parametric (#45) — lines of constant θ/φ (ellipsoid) or u/v
+    //     (hyperboloids) in a family-aware natural parameterization.
+    //     Lines flow with the surface as parameters morph.
+    //   * World-axis (#34) — distance to the nearest integer multiple of
+    //     (1 / GRID_FREQ) on each world axis. Anchored to world (0,0,0),
+    //     so the surface reads as carved out of a fixed 3D coordinate
+    //     frame. Used as the fallback when the family doesn't admit a
+    //     natural parametric form (cylinders / cones / planes / degenerates).
+    //
+    // Both systems share GRID_COLOR / GRID_INTENSITY so the line character
+    // stays consistent across family transitions — only the *frame* the
+    // lines align to changes, reinforcing the family-classification flip
+    // already shown in the rack readout above.
+    //
+    // fwidth-based AA keeps lines one-pixel-wide regardless of viewing
+    // angle or distance; walking around the surface gives parallax through
+    // whichever grid is currently active.
     vec3 hitWorld = pHit + uSurfaceCenter;
-    vec3 g = abs(fract(hitWorld * GRID_FREQ) - 0.5);
-    float lineDist = min(min(g.x, g.y), g.z);
-    float lineWidth = 1.5 * fwidth(lineDist);
-    float mask = 1.0 - smoothstep(0.0, lineWidth, lineDist);
-    vec3 color = mix(baseColor, GRID_COLOR, mask * GRID_INTENSITY);
-
-    // Parametric (latitude / longitude) gridlines (#45) — overlay light
-    // highlight bands on top of the world-axis grid. Both display by
-    // default per the issue; if simultaneous display feels cluttered in
-    // headset, revisit toggle vs. replace.
-    float paramMask = parametricGridMask(pHit);
-    color = mix(color, PARAM_GRID_COLOR, paramMask * PARAM_GRID_INTENSITY);
+    vec2 paramGrid = parametricGrid(pHit);
+    float gridMask;
+    if (paramGrid.y > 0.5) {
+      gridMask = paramGrid.x;
+    } else {
+      vec3 g = abs(fract(hitWorld * GRID_FREQ) - 0.5);
+      float lineDist = min(min(g.x, g.y), g.z);
+      float lineWidth = 1.5 * fwidth(lineDist);
+      gridMask = 1.0 - smoothstep(0.0, lineWidth, lineDist);
+    }
+    vec3 color = mix(baseColor, GRID_COLOR, gridMask * GRID_INTENSITY);
 
     gl_FragColor = vec4(color, 1.0);
 


### PR DESCRIPTION
## Summary

Follow-up to #62 (initial #45 implementation). First-headset feedback on that pass: showing both grids simultaneously read as cluttered. But pure replacement would leave cylinders / cones / planes / degenerates with no gridlines, since parametric isn't natural on those families.

So: **switch behavior**. One grid at a time, family chooses which.

- **Parametric** — used on the **ellipsoid** and **both hyperboloids**.
- **World-axis** (the existing #34 grid) — used on **cylinders, cones, planes, and degenerate / empty cases** where parametric isn't natural.

Both systems now share the existing near-black "carved" `GRID_COLOR` / `GRID_INTENSITY` so the visual style stays consistent across family transitions — only the *frame* the lines align to changes. The warm-highlight contrast color from #62 became unnecessary noise once the two systems stopped co-rendering, so it's gone.

Pedagogical bonus: the grid character snaps at family-classification boundaries — drag through the cone (`d=0`) and the lines stop flowing-with-the-surface and lock to the world frame, matching the family-label flip already shown in the rack readout above.

## Implementation

- `parametricGridMask` → `parametricGrid` returning `vec2(mask, familyActive)`. Caller in `main()` gates on `familyActive` and falls through to the world-axis branch when inactive.
- `PARAM_GRID_COLOR` / `PARAM_GRID_INTENSITY` removed; both grid systems now use `GRID_COLOR` / `GRID_INTENSITY`.
- SPEC.md "Surface rendering" section rewritten to describe the switch behavior.

## Test plan

- [ ] Crossing degeneracy boundaries (drag a coefficient through 0, or `d` through 0): grid system switches cleanly between parametric and world-axis without flicker; the snap coincides with the family-label flip in the rack readout.
- [ ] Cylinder / cone / "Pair of planes" presets — confirm world-axis grid is shown (not parametric, not blank).
- [ ] Ellipsoid / H 1-sheet / H 2-sheets presets — confirm parametric grid is shown (not world-axis).
- [ ] Frame rate ≥ 72 Hz holds.
- [ ] Hard switch at boundaries — note for future iteration if it feels jarring (could soften to a crossfade if needed).

## Headset-iterate notes

Still using starting values from #62 — line counts (12 lat × 12 lon, hyp density 1.5), dispatch epsilon. Tune in headset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)