### PR TITLE
feat(quadrics): live equation readout + RGB-coded sliders (#58)

### DIFF
--- a/src/exhibits/quadrics/EquationReadout.ts
+++ b/src/exhibits/quadrics/EquationReadout.ts
@@ -1,0 +1,148 @@
+import * as THREE from 'three';
+import { Text } from 'troika-three-text';
+
+// Live equation readout above the slider rack (#58). Renders the equation
+// `±N.NN x² + ±N.NN y² + ±N.NN z² = ±N.NN` with the four coefficient
+// numerics colored to match their sliders, and the static algebraic
+// glue (variables, operators) neutral white. The whole thing is yaw-only
+// billboarded as a single unit so the equation reads from one consistent
+// direction.
+//
+// troika-three-text doesn't support inline rich text / per-span color, so
+// the equation is built from seven independent Text instances laid out
+// at fixed offsets: 4 numeric slots interleaved with 3 separators.
+// Numeric slots are sized to comfortably hold the worst-case value
+// `−N.NN` / `+N.NN`; separator slots size to their fixed content. The
+// constants are em-based so retuning fontSize stays self-consistent.
+
+export interface EquationReadoutOptions {
+  // Per-coefficient diffuse colors, indexed (a, b, c, d). Match the slider
+  // thumb colors so the user can read the equation top-to-bottom or
+  // left-to-right and see the same color story either way.
+  coefficientColors: readonly [number, number, number, number];
+  fontSize?: number;
+}
+
+const DEFAULT_FONT_SIZE = 0.028;
+
+// Slot widths in em (multiples of fontSize), tuned to Roboto-ish defaults
+// in troika. Numeric slot accommodates the worst-case `−N.NN`; separator
+// slot fits ` x² + ` / ` z² = ` with a touch of breathing room. Refine in
+// headset if pieces look crowded or splayed.
+const NUMERIC_SLOT_EM = 2.6;
+const SEPARATOR_SLOT_EM = 2.4;
+
+const SEPARATOR_CONTENT = [' x² + ', ' y² + ', ' z² = '] as const;
+const SEPARATOR_COLOR = 0xffffff;
+const OUTLINE_WIDTH = '8%';
+const OUTLINE_COLOR = 0x000000;
+
+// Throttle the numeric .sync() calls to ≈30 Hz, mirroring the per-slider
+// value-label cap in #38 (and now retired alongside it). Bounds troika SDF
+// re-build work; head-pose billboarding (faceCamera) still runs every
+// frame so motion smoothness is unaffected.
+const SYNC_INTERVAL_MS = 33;
+
+export class EquationReadout {
+  readonly group: THREE.Group;
+
+  private readonly numericTexts: readonly Text[];
+  private readonly numericValues: number[] = [NaN, NaN, NaN, NaN];
+  private readonly separatorTexts: readonly Text[];
+  private lastSyncMs = 0;
+
+  // Hoisted out of `faceCamera` so per-frame billboarding does no allocation.
+  private readonly camWorld = new THREE.Vector3();
+  private readonly groupWorld = new THREE.Vector3();
+
+  constructor(opts: EquationReadoutOptions) {
+    const fontSize = opts.fontSize ?? DEFAULT_FONT_SIZE;
+    const numericW = NUMERIC_SLOT_EM * fontSize;
+    const separatorW = SEPARATOR_SLOT_EM * fontSize;
+    const totalW = 4 * numericW + 3 * separatorW;
+
+    this.group = new THREE.Group();
+    this.group.name = 'equation-readout';
+
+    // Slot centers, left-to-right: a, " x² + ", b, " y² + ", c, " z² = ", d.
+    // Slot indices alternate numeric (even) and separator (odd).
+    const slotCentersX: number[] = [];
+    let cursor = -totalW / 2;
+    for (let i = 0; i < 7; i++) {
+      const w = i % 2 === 0 ? numericW : separatorW;
+      slotCentersX.push(cursor + w / 2);
+      cursor += w;
+    }
+
+    const numericTexts: Text[] = [];
+    for (let i = 0; i < 4; i++) {
+      const t = new Text();
+      t.fontSize = fontSize;
+      t.color = opts.coefficientColors[i];
+      t.anchorX = 'center';
+      t.anchorY = 'middle';
+      t.outlineWidth = OUTLINE_WIDTH;
+      t.outlineColor = OUTLINE_COLOR;
+      t.position.set(slotCentersX[i * 2], 0, 0);
+      this.group.add(t);
+      numericTexts.push(t);
+    }
+    this.numericTexts = numericTexts;
+
+    const separatorTexts: Text[] = [];
+    for (let i = 0; i < 3; i++) {
+      const t = new Text();
+      t.fontSize = fontSize;
+      t.color = SEPARATOR_COLOR;
+      t.anchorX = 'center';
+      t.anchorY = 'middle';
+      t.outlineWidth = OUTLINE_WIDTH;
+      t.outlineColor = OUTLINE_COLOR;
+      t.position.set(slotCentersX[i * 2 + 1], 0, 0);
+      t.text = SEPARATOR_CONTENT[i];
+      t.sync();
+      this.group.add(t);
+      separatorTexts.push(t);
+    }
+    this.separatorTexts = separatorTexts;
+  }
+
+  /**
+   * Update the four coefficient values. Throttled to ≈30 Hz; pre-throttle
+   * the work would dominate troika SDF rebuild cost during fast drags
+   * (#38 rationale, ported from Slider's per-slider label cap). Sign is
+   * always shown explicitly (matching the old per-slider label format)
+   * so transitions across zero are unambiguous.
+   */
+  setValues(a: number, b: number, c: number, d: number): void {
+    const now = performance.now();
+    if (now - this.lastSyncMs < SYNC_INTERVAL_MS) return;
+    this.lastSyncMs = now;
+
+    const values = [a, b, c, d];
+    for (let i = 0; i < 4; i++) {
+      const v = values[i];
+      if (v === this.numericValues[i]) continue;
+      this.numericValues[i] = v;
+      const sign = v < 0 ? '−' : '+';
+      this.numericTexts[i].text = `${sign}${Math.abs(v).toFixed(2)}`;
+      this.numericTexts[i].sync();
+    }
+  }
+
+  // Yaw-only billboard, matching the family-classifier label behavior
+  // (#29). The whole equation reads from one consistent direction — head
+  // pitch and roll stay out.
+  faceCamera(camera: THREE.Camera): void {
+    camera.getWorldPosition(this.camWorld);
+    this.group.getWorldPosition(this.groupWorld);
+    const dx = this.camWorld.x - this.groupWorld.x;
+    const dz = this.camWorld.z - this.groupWorld.z;
+    this.group.rotation.set(0, Math.atan2(dx, dz), 0);
+  }
+
+  dispose(): void {
+    for (const t of this.numericTexts) t.dispose();
+    for (const t of this.separatorTexts) t.dispose();
+  }
+}

--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -108,22 +108,32 @@ drags through a degeneracy.
   degeneracy boundary cases (cone, intersecting planes, single plane)
   reachable precisely instead of by approximation. The detent applies only
   at zero — no other snapping in v0.1.
-- **Per-slider visual:** horizontal track with a draggable thumb, labeled
-  with its variable name (`a`, `b`, `c`, `d`) and current numeric value to
-  two decimal places. The label is mounted just left of the track,
-  parented to the slider's group so it tracks position automatically;
-  variable name on the primary line (large), signed value on the
-  secondary line (small). Yaw-only billboarded, sharing the same
-  `Label` primitive as the family label.
+- **Per-slider visual:** horizontal track with a draggable thumb. Each
+  slider in the rack is identified by **color** (Wong / Okabe-Ito
+  colorblind-safe palette: vermillion / bluish-green / sky-blue / yellow
+  for `a` / `b` / `c` / `d` respectively) and by **thumb shape** as a
+  redundancy cue (sphere / cube / octahedron / cylinder, in the same
+  order). The slider→coefficient mapping is therefore readable even with
+  colors stripped — important on hardware that defeats hue or for
+  viewers with color-vision deficits.
+- **No per-slider numeric labels.** The equation readout above the rack
+  carries the live coefficient values (see "Label content" below) — the
+  variable-name + value labels that sat left of each track in v0.1 were
+  removed in #58 since they duplicated information now centralized in
+  the equation. Hover/grab affordance is conveyed by the thumb's
+  emissive (pre-light on hover, stronger glow on grab) — derived as a
+  scalar of the slider's own base color, so each slider's affordance
+  reads in its own hue.
 
 ## Scene geometry
 
-| Object         | Position (x, y, z)  | Notes                                 |
-|----------------|---------------------|---------------------------------------|
-| Surface center | `(0, 1.5, −3)`      | ~2 m in front of the standing user; close enough to walk up to, far enough that the bounding volume doesn't clip through the spawn point. |
-| Slider rack    | `(0, 1.0, −0.7)`    | Below-and-in-front; reachable with controllers without a step. |
-| Rack readout   | `(0, 1.4, −0.7)`    | Single classification readout above the slider rack — the family name sits in the user's gaze area while interacting (#33). Family name only; per-slider labels render values inline. Yaw-only billboarded (#29). A second surface-anchored "hero" label was tried alongside this one in v0.1 development and removed as redundant per first-headset feedback. |
-| Floor          | `y = 0`             | Inherited from the shell convention; visual horizon and comfort anchor. |
+| Object             | Position (x, y, z)  | Notes                             |
+|--------------------|---------------------|-----------------------------------|
+| Surface center     | `(0, 1.5, −3)`      | ~2 m in front of the standing user; close enough to walk up to, far enough that the bounding volume doesn't clip through the spawn point. |
+| Family classifier  | `(0, 1.5, −0.7)`    | Top of the rack stack. Single classification readout — the family name sits in the user's gaze area while interacting (#33). Yaw-only billboarded (#29). A second surface-anchored "hero" label was tried alongside this one in v0.1 development and removed as redundant per first-headset feedback. Pushed up from `y = 1.4` in #58 to make room for the equation readout below it. |
+| Equation readout   | `(0, 1.4, −0.7)`    | Live `±N.NN x² + ±N.NN y² + ±N.NN z² = ±N.NN` between the family classifier and the top slider (#58). Four numeric coefficients colored to match their sliders (a / b / c / d → vermillion / bluish-green / sky-blue / yellow); algebraic glue (variables, operators, equals sign) is neutral white. Yaw-only billboarded as one unit. |
+| Slider rack        | `(0, 1.0, −0.7)`    | Below-and-in-front; reachable with controllers without a step. |
+| Floor              | `y = 0`             | Inherited from the shell convention; visual horizon and comfort anchor. |
 
 Units are meters. The user's head start position is the WebXR session
 origin (`y ≈ 1.6` for a standing user).
@@ -171,12 +181,13 @@ asymmetry first reported post-#8 (smooth surface, slightly-jank UI):
   not just this one. Static / center-of-view foveation (Quest 3S has
   no eye tracking). Ramp the level up if profiling says more headroom
   is needed.
-- **Throttled per-slider value-label refresh** during an active drag
-  (≤30 Hz, see `LABEL_SYNC_INTERVAL_MS` in `Slider.ts`). Bounds the
-  rate of troika SDF `.sync()` calls — head-pose billboarding still
-  runs every frame, so motion smoothness is untouched. Outside an
-  active drag the label refreshes every tick so the post-release
-  value is exact.
+- **Throttled equation-readout refresh** to ≈30 Hz
+  (`SYNC_INTERVAL_MS` in `EquationReadout.ts`). Bounds the rate of
+  troika SDF `.sync()` calls on the four numeric coefficients — head-
+  pose billboarding still runs every frame, so motion smoothness is
+  untouched. The cap originally applied to the per-slider value
+  labels in v0.1; #58 retired those labels in favor of the equation
+  readout and ported the cap to the new readout for the same reason.
 
 Both are reversible knobs. Profile-guided follow-ups (ray-march
 `STEPS`, framebuffer scale factor, etc.) deferred to a follow-on PR
@@ -184,19 +195,29 @@ if these don't fully close the gap.
 
 ## Label content
 
-One classification readout plus one label per slider:
+Two text readouts above the slider rack — family classifier on top,
+live equation below:
 
-- **Rack readout** — single line, billboarded, anchored above the
-  slider rack. The family name sits in the user's gaze area during
-  interaction. Renders one of the `Family` strings from the taxonomy
-  (e.g., `Hyperboloid (1 sheet)`, `Cone`, `Empty set`, `Degenerate`).
+- **Family classifier** — single line, billboarded, anchored at the top
+  of the stack above the rack. The family name sits in the user's gaze
+  area during interaction. Renders one of the `Family` strings from the
+  taxonomy (e.g., `Hyperboloid (1 sheet)`, `Cone`, `Empty set`,
+  `Degenerate`). Re-classified every frame.
 
-- **Per-slider labels** — variable name (large) and signed value to
-  two decimals (small), parented to each slider's group. Sign is
-  always shown explicitly so the visual jump from `+0.05` to `−0.05`
-  is unambiguous to the learner. See "Slider model" above.
-
-All labels re-classify / re-format every frame.
+- **Equation readout** — `±N.NN x² + ±N.NN y² + ±N.NN z² = ±N.NN` (#58).
+  Built from seven independent troika `Text` instances (4 numeric slots
+  + 3 separators) since troika doesn't support inline rich text. The
+  four numerics carry per-slider color; the algebraic glue is neutral
+  white. Sign is always shown explicitly so transitions across zero are
+  unambiguous. Numeric `.sync()` calls are throttled to ≈30 Hz
+  (`SYNC_INTERVAL_MS` in `EquationReadout.ts`) — same rationale as the
+  per-slider label cap from #38, now retired alongside this change.
+  Yaw-only billboarded as a single unit so the equation reads from one
+  consistent direction regardless of where the viewer stands. Replaces
+  v0.1's per-slider variable-name + value labels (those left-of-track
+  `a +1.00` mounts are gone — the equation centralizes the same info
+  with the added pedagogy that the user sees the symbolic form they're
+  manipulating, not just the numeric coefficients in isolation).
 
 ## Controller interaction
 

--- a/src/exhibits/quadrics/Slider.ts
+++ b/src/exhibits/quadrics/Slider.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
-import { Label } from './Label';
+
+export type ThumbShape = 'sphere' | 'cube' | 'octahedron' | 'cylinder';
 
 export interface SliderOptions {
   label: string;
@@ -12,23 +13,25 @@ export interface SliderOptions {
   // less hand travel per unit value (i.e. the slider feels more sensitive).
   // 1 = thumb tracks controller 1:1 across the visible track length.
   dragGain?: number;
+  // Base diffuse color for the thumb. Hover/grab emissives are scaled
+  // copies of this (see THUMB_HOVER_SCALE / THUMB_GRAB_SCALE), so a single
+  // base color suffices to retune per-slider visuals (#58).
+  baseColor?: number;
+  // Geometry of the thumb. Color is the at-a-glance hint; shape is the
+  // unambiguous redundancy cue per #58 / Q4 — readable even with the
+  // colors stripped (e.g. on a colorblind viewer's display).
+  thumbShape?: ThumbShape;
 }
 
 const DEFAULT_TRACK_LENGTH = 0.3;
 const DEFAULT_THUMB_RADIUS = 0.025;
 const DEFAULT_DRAG_GAIN = 1.75;
+const DEFAULT_BASE_COLOR = 0xeeaa33;
+const DEFAULT_THUMB_SHAPE: ThumbShape = 'sphere';
 
 // Snap-to-zero detent half-width, per quadrics SPEC.md "Slider model".
 // Lets the user park exactly on a degeneracy boundary instead of approximating.
 const ZERO_DETENT = 0.05;
-
-// Per-slider value-label refresh cap during a drag. The displayed value is
-// re-formatted at most once per this interval, keeping the troika SDF
-// `.sync()` rate bounded while head-pose billboarding still runs every frame.
-// Outside an active drag the label always refreshes (so the post-release
-// value is exact). 33 ms ≈ 30 Hz — humans can't read faster than that
-// anyway, and ~3× fewer SDF re-syncs is the whole point (issue #38).
-const LABEL_SYNC_INTERVAL_MS = 33;
 
 // Ray–thumb hit-test radius is this multiple of the thumb's visual radius.
 // Wider than the visual makes re-grab forgiving when the hand drifts off-aim
@@ -41,12 +44,13 @@ const GRAB_RADIUS_MULTIPLIER = 2.75;
 const HAPTIC_AMPLITUDE = 0.5;
 const HAPTIC_DURATION_MS = 10;
 
-const THUMB_BASE_COLOR = 0xeeaa33;
-const THUMB_HOVER_EMISSIVE = 0x884422;
-// Same warm hue as hover, brighter — reads as "engaged" rather than a
-// different affordance. Cool/contrasting hues risked looking like a
-// separate UI element.
-const THUMB_GRAB_EMISSIVE = 0xffaa44;
+// Hover/grab emissive = base × scale. Uniform scale across hues keeps the
+// affordance ("subtle glow" / "strong glow") consistent regardless of the
+// base color (#58). Hover is a soft pre-light; grab clearly reads as
+// engaged. Tune in headset; per-color overrides are easy to add if any
+// hue (e.g. yellow) ends up reading washed out at these scales.
+const THUMB_HOVER_SCALE = 0.4;
+const THUMB_GRAB_SCALE = 0.7;
 
 interface ControllerWithGamepad extends THREE.Object3D {
   userData: { gamepad?: Gamepad };
@@ -61,6 +65,8 @@ export class Slider {
   private readonly thumbWorld = new THREE.Vector3();
   private readonly controllerWorld = new THREE.Vector3();
   private readonly localPoint = new THREE.Vector3();
+  private readonly hoverEmissive: THREE.Color;
+  private readonly grabEmissive: THREE.Color;
 
   // `rawValue` integrates hand motion every frame, untouched by the detent.
   // `currentValue` is the emitted value — snapped to exactly 0 inside the
@@ -72,14 +78,14 @@ export class Slider {
   private grabbedBy: THREE.Object3D | null = null;
   private lastControllerLocalX = 0;
   private hovered = false;
-  private displayLabel: Label | undefined;
-  private lastLabelSyncMs = 0;
 
   constructor(options: SliderOptions) {
     this.opts = {
       trackLength: DEFAULT_TRACK_LENGTH,
       thumbRadius: DEFAULT_THUMB_RADIUS,
       dragGain: DEFAULT_DRAG_GAIN,
+      baseColor: DEFAULT_BASE_COLOR,
+      thumbShape: DEFAULT_THUMB_SHAPE,
       ...options,
     };
     this.rawValue = clamp(options.initial, options.min, options.max);
@@ -104,9 +110,13 @@ export class Slider {
     );
     this.group.add(this.track);
 
+    const baseColor = new THREE.Color(this.opts.baseColor);
+    this.hoverEmissive = baseColor.clone().multiplyScalar(THUMB_HOVER_SCALE);
+    this.grabEmissive = baseColor.clone().multiplyScalar(THUMB_GRAB_SCALE);
+
     this.thumb = new THREE.Mesh(
-      new THREE.SphereGeometry(this.opts.thumbRadius, 16, 12),
-      new THREE.MeshStandardMaterial({ color: THUMB_BASE_COLOR }),
+      buildThumbGeometry(this.opts.thumbShape, this.opts.thumbRadius),
+      new THREE.MeshStandardMaterial({ color: baseColor }),
     );
     this.group.add(this.thumb);
 
@@ -120,63 +130,6 @@ export class Slider {
     return this.opts.label;
   }
 
-  /**
-   * Attach a billboarded text label to this slider, parented to its group so
-   * it tracks the slider's world position automatically. Primary line is the
-   * variable name (large); secondary is the current value with explicit sign
-   * to two decimals, refreshed by `tickLabel()`. Font sizes are tuned for
-   * the ~1.5 m controller-reach viewing distance per SPEC.md.
-   */
-  mountLabel(): void {
-    if (this.displayLabel) return;
-    this.displayLabel = new Label({
-      primaryFontSize: 0.04,
-      secondaryFontSize: 0.02,
-      lineGap: 0.01,
-    });
-    this.displayLabel.setPrimary(this.opts.label);
-    // Just left of the track. Track spans local x ∈ [−L/2, +L/2]; offset
-    // the label center 0.05 m beyond the left end so glyphs clear the
-    // track and the thumb at its leftmost position.
-    this.displayLabel.group.position.set(
-      -this.opts.trackLength / 2 - 0.05,
-      0,
-      0,
-    );
-    this.group.add(this.displayLabel.group);
-    this.refreshLabelValue();
-  }
-
-  /**
-   * Per-frame label tick: refresh the displayed value and re-billboard.
-   * Caller decides whether to tick (e.g. exhibit may skip when no camera
-   * is available yet). No-op if `mountLabel()` was never called.
-   *
-   * The value-string refresh is throttled while a drag is active (see
-   * `LABEL_SYNC_INTERVAL_MS`) so troika SDF `.sync()` work is bounded.
-   * Billboarding (`faceCamera`) runs every frame regardless — head pose
-   * tracks at full rate.
-   */
-  tickLabel(camera: THREE.Camera): void {
-    if (!this.displayLabel) return;
-    const now = performance.now();
-    const dueForSync =
-      this.grabbedBy === null ||
-      now - this.lastLabelSyncMs >= LABEL_SYNC_INTERVAL_MS;
-    if (dueForSync) {
-      this.refreshLabelValue();
-      this.lastLabelSyncMs = now;
-    }
-    this.displayLabel.faceCamera(camera);
-  }
-
-  private refreshLabelValue(): void {
-    if (!this.displayLabel) return;
-    const v = this.currentValue;
-    const sign = v < 0 ? '−' : '+';
-    this.displayLabel.setSecondary(`${sign}${Math.abs(v).toFixed(2)}`);
-  }
-
   get value(): number {
     return this.currentValue;
   }
@@ -188,7 +141,7 @@ export class Slider {
   /**
    * Programmatically set the value (e.g. from a preset, #46). Snaps the raw
    * accumulator and applies the zero detent identically to a drag tick, then
-   * updates the visible thumb + numeric label. Safe mid-drag: rebases
+   * updates the visible thumb. Safe mid-drag: rebases
    * `lastControllerLocalX` so the next `update()` computes deltas from the
    * new state, not the pre-jump one.
    */
@@ -200,7 +153,6 @@ export class Slider {
       this.lastControllerLocalX = this.controllerLocalX(this.grabbedBy);
     }
     this.syncThumbPosition();
-    this.refreshLabelValue();
   }
 
   /**
@@ -251,12 +203,13 @@ export class Slider {
   // and `updateHover` — so the visual always matches state.
   private refreshThumbEmissive(): void {
     const mat = this.thumb.material as THREE.MeshStandardMaterial;
-    const hex = this.grabbedBy
-      ? THUMB_GRAB_EMISSIVE
-      : this.hovered
-        ? THUMB_HOVER_EMISSIVE
-        : 0x000000;
-    mat.emissive.setHex(hex);
+    if (this.grabbedBy) {
+      mat.emissive.copy(this.grabEmissive);
+    } else if (this.hovered) {
+      mat.emissive.copy(this.hoverEmissive);
+    } else {
+      mat.emissive.setHex(0x000000);
+    }
   }
 
   private rayHitsThumb(controller: THREE.Object3D): boolean {
@@ -305,13 +258,12 @@ export class Slider {
 
   // Thumb tracks the *displayed* value (i.e. `currentValue`'s would-be
   // snapped projection of `rawValue`), not raw. Inside the detent the thumb
-  // parks at zero so it stays aligned with what the future two-decimal
-  // numeric label will read (per SPEC.md "Slider model"). The slow-drag-
-  // escape behavior of #24 is preserved by `rawValue` accumulating in
-  // `update()` underneath — once raw clears ±ZERO_DETENT, the thumb tracks
-  // it again. Bonus: the visible "park at zero on approach" is part of the
-  // detent's affordance — the user feels the boundary before reading the
-  // label.
+  // parks at zero so it stays aligned with what the equation readout will
+  // display (per SPEC.md "Slider model"). The slow-drag-escape behavior of
+  // #24 is preserved by `rawValue` accumulating in `update()` underneath —
+  // once raw clears ±ZERO_DETENT, the thumb tracks it again. Bonus: the
+  // visible "park at zero on approach" is part of the detent's affordance —
+  // the user feels the boundary before reading the equation.
   private syncThumbPosition(): void {
     const halfLen = this.opts.trackLength / 2;
     const displayValue =
@@ -319,6 +271,34 @@ export class Slider {
     const t =
       (displayValue - this.opts.min) / (this.opts.max - this.opts.min);
     this.thumb.position.x = -halfLen + t * this.opts.trackLength;
+  }
+}
+
+// Each shape is sized so its bounding sphere ≈ thumbRadius — same hit-test
+// region (`thumbRadius * GRAB_RADIUS_MULTIPLIER`) feels consistent across
+// shapes when sweeping the controller across the rack.
+function buildThumbGeometry(
+  shape: ThumbShape,
+  thumbRadius: number,
+): THREE.BufferGeometry {
+  switch (shape) {
+    case 'sphere':
+      return new THREE.SphereGeometry(thumbRadius, 16, 12);
+    case 'cube': {
+      // Side = 2r/√3 inscribes the cube in a sphere of radius r — keeps the
+      // visual scale matched to the sphere thumb.
+      const side = (2 * thumbRadius) / Math.sqrt(3);
+      return new THREE.BoxGeometry(side, side, side);
+    }
+    case 'octahedron':
+      return new THREE.OctahedronGeometry(thumbRadius);
+    case 'cylinder': {
+      // Knob/puck profile: short, wider radius. Bounding sphere radius =
+      // sqrt(r² + (h/2)²); pick r and h so that ≈ thumbRadius.
+      const r = thumbRadius * 0.85;
+      const h = thumbRadius * 1.1;
+      return new THREE.CylinderGeometry(r, r, h, 16);
+    }
   }
 }
 

--- a/src/exhibits/quadrics/WorldAxes.ts
+++ b/src/exhibits/quadrics/WorldAxes.ts
@@ -11,10 +11,21 @@ import { Text } from 'troika-three-text';
 // so that slider `a` drives X² (world-X), `b` drives Y² (world-Z), and
 // `c` drives Z² (world-Y). The labels here are the visible half of that
 // contract.
+//
+// Axis line + letter colors are per-axis and supplied by the caller (#58):
+// matches the slider-thumb / equation palette so the user sees one color
+// story across the whole exhibit (slider `a` red ⇔ equation `a`-numeric
+// red ⇔ X axis red, etc.).
+
+export type AxisName = 'X' | 'Y' | 'Z';
+
+export interface WorldAxesOptions {
+  // Per-axis line + label color, keyed by axis name.
+  axisColors: Record<AxisName, number>;
+}
 
 const AXIS_LENGTH = 0.15;
-const AXIS_COLOR = 0xffffff;
-const LINE_OPACITY = 0.7;
+const LINE_OPACITY = 0.85;
 
 // Just larger than the per-slider labels' 0.04 primary, so the letters
 // read as a distinct UI element rather than as another slider value.
@@ -23,7 +34,7 @@ const OUTLINE_WIDTH = '8%';
 const OUTLINE_COLOR = 0x000000;
 
 interface AxisSpec {
-  readonly name: 'X' | 'Y' | 'Z';
+  readonly name: AxisName;
   readonly dir: THREE.Vector3;
 }
 
@@ -48,26 +59,22 @@ export class WorldAxes {
 
   private readonly labels: Text[];
   private readonly lineGeoms: THREE.BufferGeometry[];
-  private readonly lineMat: THREE.LineBasicMaterial;
+  private readonly lineMats: THREE.LineBasicMaterial[];
 
   // Hoisted out of `faceCamera` so per-frame billboarding does no allocation.
   private readonly camWorld = new THREE.Vector3();
   private readonly labelWorld = new THREE.Vector3();
 
-  constructor() {
+  constructor(opts: WorldAxesOptions) {
     this.group = new THREE.Group();
     this.group.name = 'world-axes';
 
-    this.lineMat = new THREE.LineBasicMaterial({
-      color: AXIS_COLOR,
-      transparent: true,
-      opacity: LINE_OPACITY,
-    });
-
     this.labels = [];
     this.lineGeoms = [];
+    this.lineMats = [];
 
     for (const { name, dir } of AXES) {
+      const color = opts.axisColors[name];
       const end = dir.clone().multiplyScalar(AXIS_LENGTH);
 
       const lineGeom = new THREE.BufferGeometry().setFromPoints([
@@ -75,12 +82,21 @@ export class WorldAxes {
         end,
       ]);
       this.lineGeoms.push(lineGeom);
-      this.group.add(new THREE.Line(lineGeom, this.lineMat));
+
+      // One material per axis so each carries its own color. Cheap — three
+      // line materials, no per-frame allocation.
+      const lineMat = new THREE.LineBasicMaterial({
+        color,
+        transparent: true,
+        opacity: LINE_OPACITY,
+      });
+      this.lineMats.push(lineMat);
+      this.group.add(new THREE.Line(lineGeom, lineMat));
 
       const label = new Text();
       label.text = name;
       label.fontSize = FONT_SIZE;
-      label.color = AXIS_COLOR;
+      label.color = color;
       label.anchorX = 'center';
       label.anchorY = 'middle';
       label.outlineWidth = OUTLINE_WIDTH;
@@ -105,6 +121,6 @@ export class WorldAxes {
   dispose(): void {
     for (const label of this.labels) label.dispose();
     for (const geom of this.lineGeoms) geom.dispose();
-    this.lineMat.dispose();
+    for (const mat of this.lineMats) mat.dispose();
   }
 }

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -2,10 +2,11 @@ import * as THREE from 'three';
 import type { Exhibit, ExhibitContext } from '../../shell/Exhibit';
 import { registerExhibit } from '../../shell/registry';
 import { classify } from './classify';
+import { EquationReadout } from './EquationReadout';
 import { Label } from './Label';
 import { Preset, type PresetValues } from './Preset';
-import { Slider } from './Slider';
-import { WorldAxes } from './WorldAxes';
+import { Slider, type ThumbShape } from './Slider';
+import { WorldAxes, type AxisName } from './WorldAxes';
 
 // Pushed back from z=-3 to z=-4 as the v0.1.x comfort buffer (#44) — gives
 // extreme-parameter expansions ~1 m of headroom before they invade the
@@ -21,14 +22,16 @@ import { WorldAxes } from './WorldAxes';
 const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
 const SLIDER_RACK_CENTER = new THREE.Vector3(0, 1.0, -0.7);
 
-// Single classification readout, anchored above the rack so the family
-// name sits in the user's gaze area while interacting (#33). A second
-// surface-anchored "hero" label was tried alongside this one and removed
-// post-headset feedback as redundant — once the rack readout is present,
-// the user's attention stays at the rack during drags. y = 1.4 is ~0.175 m
-// above the top slider 'a' (at SLIDER_RACK_CENTER.y + 1.5 * SLIDER_ROW_PITCH
-// = 1.225); enough clearance for the per-slider label glyphs below.
-const RACK_LABEL_POSITION = new THREE.Vector3(0, 1.4, -0.7);
+// Vertical stacking above the slider rack (top → bottom):
+//   y = 1.5  — family classifier readout
+//   y = 1.4  — live equation readout (#58)
+//   y = 1.225 — top slider 'a' (= SLIDER_RACK_CENTER.y + 1.5 * SLIDER_ROW_PITCH)
+// Family classifier was at y = 1.4 in v0.1; pushed up to y = 1.5 to make
+// room for the equation. The equation occupies the slot the per-slider
+// labels used to fill (those left-of-track 'a +1.00' labels are gone in
+// #58 — the equation makes them redundant).
+const RACK_LABEL_POSITION = new THREE.Vector3(0, 1.5, -0.7);
+const EQUATION_READOUT_POSITION = new THREE.Vector3(0, 1.4, -0.7);
 
 // Smaller than Label's 0.16 default; matches the closer ~0.7 m viewing
 // distance from the user's spawn point.
@@ -78,8 +81,49 @@ const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
 // clearance between hit spheres and reads as comfortably spaced in
 // headset.
 const SLIDER_ROW_PITCH = 0.15;
+
+// Wong / Okabe-Ito colorblind-safe palette (#58, Q3). Distinguishable
+// across deuteranopia / protanopia / tritanopia. The fourth slot —
+// yellow on slider `d` — marks the constant term as conceptually
+// distinct from the axis coefficients (Q1).
+const SLIDER_VERMILLION = 0xd55e00;
+const SLIDER_BLUISH_GREEN = 0x009e73;
+const SLIDER_SKY_BLUE = 0x56b4e9;
+const SLIDER_YELLOW = 0xf0e442;
+
+// Per-slider config: name + base color + thumb shape. Color is the
+// at-a-glance identification; shape is the redundancy cue (#58, Q4) so
+// the slider→coefficient mapping survives a colorblind viewer or any
+// rendering that strips the colors. Shape choice is deliberately
+// arbitrary among visually distinct primitives — pick whatever reads
+// best in headset.
 type CoeffName = 'a' | 'b' | 'c' | 'd';
-const COEFF_NAMES: readonly CoeffName[] = ['a', 'b', 'c', 'd'] as const;
+const SLIDER_CONFIG: readonly {
+  readonly name: CoeffName;
+  readonly color: number;
+  readonly shape: ThumbShape;
+}[] = [
+  { name: 'a', color: SLIDER_VERMILLION,   shape: 'sphere' },
+  { name: 'b', color: SLIDER_BLUISH_GREEN, shape: 'cube' },
+  { name: 'c', color: SLIDER_SKY_BLUE,     shape: 'octahedron' },
+  { name: 'd', color: SLIDER_YELLOW,       shape: 'cylinder' },
+];
+
+// Math-frame axis indicator colors, matched to the slider that drives
+// each axis (#58, Q2). Slider `d` is the constant term and has no axis,
+// hence only three entries.
+const AXIS_COLORS: Record<AxisName, number> = {
+  X: SLIDER_VERMILLION,    // slider 'a' (math-X)
+  Y: SLIDER_BLUISH_GREEN,  // slider 'b' (math-Y)
+  Z: SLIDER_SKY_BLUE,      // slider 'c' (math-Z)
+};
+
+const EQUATION_COEFFICIENT_COLORS: readonly [number, number, number, number] = [
+  SLIDER_VERMILLION,
+  SLIDER_BLUISH_GREEN,
+  SLIDER_SKY_BLUE,
+  SLIDER_YELLOW,
+];
 
 // Debug sweep on `a`: gated off once controller sliders took over (#5).
 // Re-enable for shader / boundary-case debugging without controllers.
@@ -368,6 +412,7 @@ let sliders: Slider[] = [];
 let presets: Preset[] = [];
 let controllers: THREE.Object3D[] = [];
 let rackLabel: Label | undefined;
+let equationReadout: EquationReadout | undefined;
 let worldAxes: WorldAxes | undefined;
 let camera: THREE.Camera | undefined;
 let elapsed = 0;
@@ -415,15 +460,25 @@ const quadricsExhibit: Exhibit = {
     scene.add(surface);
 
     // Top → bottom: a, b, c, d. Span centered on SLIDER_RACK_CENTER.
-    const topY = SLIDER_RACK_CENTER.y + ((COEFF_NAMES.length - 1) / 2) * SLIDER_ROW_PITCH;
-    sliders = COEFF_NAMES.map((label, i) => {
-      const slider = new Slider({ label, min: -2, max: 2, initial: 1 });
+    // Per-slider color + shape pull from SLIDER_CONFIG (#58); the
+    // equation readout above the rack now carries the live coefficient
+    // values, so per-slider numeric labels are gone in this version.
+    const topY =
+      SLIDER_RACK_CENTER.y + ((SLIDER_CONFIG.length - 1) / 2) * SLIDER_ROW_PITCH;
+    sliders = SLIDER_CONFIG.map((cfg, i) => {
+      const slider = new Slider({
+        label: cfg.name,
+        min: -2,
+        max: 2,
+        initial: 1,
+        baseColor: cfg.color,
+        thumbShape: cfg.shape,
+      });
       slider.group.position.set(
         SLIDER_RACK_CENTER.x,
         topY - i * SLIDER_ROW_PITCH,
         SLIDER_RACK_CENTER.z,
       );
-      slider.mountLabel();
       scene.add(slider.group);
       return slider;
     });
@@ -444,13 +499,21 @@ const quadricsExhibit: Exhibit = {
 
     controllers = setupControllers(scene, renderer, sliders, presets);
 
-    // Rack readout — family name only. Per-slider labels already render
-    // coefficient values inline, so duplicating them here would be noise.
+    // Family classifier readout sits at the top of the stack above the
+    // rack. The live equation readout (#58) carries the four coefficient
+    // numerics directly below it, replacing the per-slider labels that
+    // used to live left of each track.
     rackLabel = new Label({ primaryFontSize: RACK_LABEL_PRIMARY_FONT_SIZE });
     rackLabel.group.position.copy(RACK_LABEL_POSITION);
     scene.add(rackLabel.group);
 
-    worldAxes = new WorldAxes();
+    equationReadout = new EquationReadout({
+      coefficientColors: EQUATION_COEFFICIENT_COLORS,
+    });
+    equationReadout.group.position.copy(EQUATION_READOUT_POSITION);
+    scene.add(equationReadout.group);
+
+    worldAxes = new WorldAxes({ axisColors: AXIS_COLORS });
     worldAxes.group.position.copy(AXIS_INDICATOR_POSITION);
     scene.add(worldAxes.group);
   },
@@ -458,7 +521,6 @@ const quadricsExhibit: Exhibit = {
   update({ delta }) {
     for (const s of sliders) s.updateHover(controllers);
     for (const s of sliders) s.update();
-    if (camera) for (const s of sliders) s.tickLabel(camera);
     for (const p of presets) p.updateHover(controllers);
     for (const p of presets) p.update();
     if (camera) for (const p of presets) p.faceCamera(camera);
@@ -469,8 +531,8 @@ const quadricsExhibit: Exhibit = {
     //   slider b → math-Y² → world-Z² → uC
     //   slider c → math-Z² → world-Y² → uB
     //   slider d → uD (constant term)
+    const [a, b, c, d] = sliders.map((s) => s.value);
     if (material) {
-      const [a, b, c, d] = sliders.map((s) => s.value);
       material.uniforms.uA.value = a;
       material.uniforms.uC.value = b;
       material.uniforms.uB.value = c;
@@ -478,14 +540,17 @@ const quadricsExhibit: Exhibit = {
     }
     if (DEBUG_SWEEP && material) {
       elapsed += delta;
-      const a = Math.cos((2 * Math.PI * elapsed) / SWEEP_PERIOD);
-      material.uniforms.uA.value = a;
+      const sweep = Math.cos((2 * Math.PI * elapsed) / SWEEP_PERIOD);
+      material.uniforms.uA.value = sweep;
     }
     if (rackLabel) {
-      const [a, b, c, d] = sliders.map((s) => s.value);
       const { family } = classify(a, b, c, d);
       rackLabel.setPrimary(family);
       if (camera) rackLabel.faceCamera(camera);
+    }
+    if (equationReadout) {
+      equationReadout.setValues(a, b, c, d);
+      if (camera) equationReadout.faceCamera(camera);
     }
     if (worldAxes && camera) worldAxes.faceCamera(camera);
   },
@@ -532,7 +597,7 @@ function setupControllers(
       }
       for (const p of presets) {
         if (p.tryActivate(controller)) {
-          // Snap the rack to the preset. Ordering matches COEFF_NAMES
+          // Snap the rack to the preset. Ordering matches SLIDER_CONFIG
           // ('a','b','c','d') so values[i] lands on sliders[i] cleanly.
           for (let i = 0; i < sliders.length; i++) {
             sliders[i].setValue(p.values[i]);


### PR DESCRIPTION
## Summary

Closes #58. Replaces v0.1's per-slider variable-name + value labels (`a +1.00`, `b +1.00`, …) with a centralized live equation readout above the slider rack, and identifies each slider by **color + shape** instead of left-of-track text.

The pedagogy: today the equation only exists in the user's head. With this change, the symbolic form they're manipulating is on screen, and the slider becomes a direct handle on a visible symbol. Color + shape tie each slider to its coefficient in the equation and to its math-frame axis (#43), so the user learns one story across sliders / equation / axis indicator.

## Design choices (issue #58 Q1–Q4)

- **Q1 — slider `d` color:** distinct fourth color (yellow). `d` is the constant term, not an axis coefficient — the palette should say so.
- **Q2 — axis indicator color story:** the math-frame axis indicator (#43) adopts the same RGB as the sliders and equation. One color story to learn, not two.
- **Q3 — palette:** Wong / Okabe-Ito (vermillion / bluish-green / sky-blue / yellow). Distinguishable across deuteranopia / protanopia / tritanopia. No "Traditional RGB" toggle — defer to a settings panel alongside #57.
- **Q4 — accessibility:** redundant per-slider thumb shape (sphere / cube / octahedron / cylinder) so the mapping is readable even with hue stripped. Equation-side shape swatches not implemented — would clutter the readout; revisit only if headset trial says color alone is too subtle.

## What changed

| File | Change |
|------|--------|
| `Slider.ts` | Adds `baseColor` + `thumbShape` options. Drops `mountLabel` / `tickLabel` / `displayLabel` and their state — per-slider Label instances are gone. Hover/grab emissives now derived as base × scalar (0.4 / 0.7) so affordance reads in each slider's own hue. |
| `EquationReadout.ts` (new) | 7 troika `Text` instances (4 numeric + 3 separator) at fixed em-based slot positions. troika has no inline rich text, hence the per-piece split. Numeric `.sync()` throttled to ≈30 Hz, porting the cap from #38. |
| `WorldAxes.ts` | Takes per-axis colors via `axisColors: Record<AxisName, number>`. One `LineBasicMaterial` per axis. |
| `index.ts` | Wong palette + per-slider `SLIDER_CONFIG`. Family classifier pushed from `y=1.4` to `y=1.5` to make room for the equation at `y=1.4`. WorldAxes constructed with the matched palette. `tickLabel` / `mountLabel` calls removed. |
| `SPEC.md` | "Slider model" / "Scene geometry" / "Label content" / "Frame-pacing knobs" reflect the new layout. |

## Tunable in headset (don't relitigate in review)

Per the project's "VR design needs trial" memory — these are starting values, refine post-merge:

- Equation `fontSize` (currently `0.028` → ~0.49 m total width vs the 0.3 m rack).
- Vertical spacing between classifier / equation / rack top.
- Per-color emissive scales — yellow may want a different scalar to read as "subtle pre-light" vs the warmer hues.
- Numeric / separator slot widths in em (`NUMERIC_SLOT_EM = 2.6`, `SEPARATOR_SLOT_EM = 2.4`).

## Test plan

- [x] `npm run build` (tsc --noEmit + vite build) passes locally
- [x] `npm run lint` passes locally
- [ ] On-device smoke on Quest 3S: equation readout legible from default spawn pose, slider thumb colors + shapes distinguishable, math-frame axis indicator colors match sliders, family classifier still legible above the equation, frame rate ≥ 72 Hz
- [ ] Edge cases: cone (`d=0`) — equation shows `+0.00` with sign; transitions across zero look smooth; degenerate / empty-set families render without holes

🤖 Generated with [Claude Code](https://claude.com/claude-code)