### PR TITLE
feat(quadrics): axis-aligned arrow thumbs for the coefficient sliders

### DIFF
--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -111,11 +111,16 @@ drags through a degeneracy.
 - **Per-slider visual:** horizontal track with a draggable thumb. Each
   slider in the rack is identified by **color** (Wong / Okabe-Ito
   colorblind-safe palette: vermillion / bluish-green / sky-blue / yellow
-  for `a` / `b` / `c` / `d` respectively) and by **thumb shape** as a
-  redundancy cue (sphere / cube / octahedron / cylinder, in the same
-  order). The slider→coefficient mapping is therefore readable even with
-  colors stripped — important on hardware that defeats hue or for
-  viewers with color-vision deficits.
+  for `a` / `b` / `c` / `d` respectively) and by **thumb shape**:
+  bidirectional 3D arrows axis-aligned with the world axis each
+  axis-coefficient slider drives. Slider `a` (math-X) is an arrow along
+  the track (left-right); slider `b` (math-Y) is an arrow toward/away
+  from the viewer; slider `c` (math-Z) is an arrow up/down. Slider `d`
+  is the constant term — no spatial direction, so its thumb is a
+  directionless sphere. The shape thus carries pedagogy on top of color
+  redundancy: the user reads each slider's spatial orientation
+  immediately from its thumb, not just by recalling that "color X means
+  axis Y."
 - **No per-slider numeric labels.** The equation readout above the rack
   carries the live coefficient values (see "Label content" below) — the
   variable-name + value labels that sat left of each track in v0.1 were

--- a/src/exhibits/quadrics/Slider.ts
+++ b/src/exhibits/quadrics/Slider.ts
@@ -1,6 +1,14 @@
 import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
 
-export type ThumbShape = 'sphere' | 'cube' | 'octahedron' | 'cylinder';
+// `arrow-{x,y,z}` are bidirectional 3D arrows aligned with their respective
+// world axis. The slider group has no rotation, so slider-local frame =
+// world frame; pick the variant whose axis matches the math-frame axis the
+// slider drives (arrow-x for slider 'a' → math-X, arrow-y for slider 'b' →
+// math-Y, arrow-z for slider 'c' → math-Z). `sphere` is reserved for
+// slider 'd' (the constant term — no spatial direction, so a directionless
+// thumb reads as pedagogically truthful).
+export type ThumbShape = 'sphere' | 'arrow-x' | 'arrow-y' | 'arrow-z';
 
 export interface SliderOptions {
   label: string;
@@ -274,32 +282,78 @@ export class Slider {
   }
 }
 
-// Each shape is sized so its bounding sphere ≈ thumbRadius — same hit-test
-// region (`thumbRadius * GRAB_RADIUS_MULTIPLIER`) feels consistent across
-// shapes when sweeping the controller across the rack.
+// `sphere` matches the hit-test radius exactly. The arrow variants extend
+// past `thumbRadius` along their axis (~1.3r at the cone tip), but the
+// grab zone (`thumbRadius * GRAB_RADIUS_MULTIPLIER` = 2.75r) covers the
+// full visible arrow plus margin, so the entire shape stays grabbable.
 function buildThumbGeometry(
   shape: ThumbShape,
   thumbRadius: number,
 ): THREE.BufferGeometry {
-  switch (shape) {
-    case 'sphere':
-      return new THREE.SphereGeometry(thumbRadius, 16, 12);
-    case 'cube': {
-      // Side = 2r/√3 inscribes the cube in a sphere of radius r — keeps the
-      // visual scale matched to the sphere thumb.
-      const side = (2 * thumbRadius) / Math.sqrt(3);
-      return new THREE.BoxGeometry(side, side, side);
-    }
-    case 'octahedron':
-      return new THREE.OctahedronGeometry(thumbRadius);
-    case 'cylinder': {
-      // Knob/puck profile: short, wider radius. Bounding sphere radius =
-      // sqrt(r² + (h/2)²); pick r and h so that ≈ thumbRadius.
-      const r = thumbRadius * 0.85;
-      const h = thumbRadius * 1.1;
-      return new THREE.CylinderGeometry(r, r, h, 16);
-    }
+  if (shape === 'sphere') {
+    return new THREE.SphereGeometry(thumbRadius, 16, 12);
   }
+  return buildArrowGeometry(thumbRadius, shape);
+}
+
+// Bidirectional 3D arrow (`<->`) for the axis-coefficient sliders. Built
+// along +Y as a merged geometry (shaft cylinder + two outward-pointing
+// cones), then rotated to the requested world axis. Single mesh + single
+// material via `mergeGeometries` keeps Slider's hover/grab emissive logic
+// untouched.
+function buildArrowGeometry(
+  thumbRadius: number,
+  axis: 'arrow-x' | 'arrow-y' | 'arrow-z',
+): THREE.BufferGeometry {
+  const r = thumbRadius;
+  const shaftLength = 1.4 * r;
+  const shaftRadius = 0.2 * r;
+  const coneHeight = 0.6 * r;
+  const coneRadius = 0.5 * r;
+  // Cone center sits at half-shaft + half-cone along Y so its base flushes
+  // against the shaft's end.
+  const coneCenter = shaftLength / 2 + coneHeight / 2;
+
+  const shaft = new THREE.CylinderGeometry(
+    shaftRadius,
+    shaftRadius,
+    shaftLength,
+    12,
+  );
+
+  const upperCone = new THREE.ConeGeometry(coneRadius, coneHeight, 16);
+  upperCone.translate(0, coneCenter, 0);
+
+  // Lower cone: flip 180° around Z so apex points -Y, then translate to
+  // mirror the upper cone across the origin.
+  const lowerCone = new THREE.ConeGeometry(coneRadius, coneHeight, 16);
+  lowerCone.rotateZ(Math.PI);
+  lowerCone.translate(0, -coneCenter, 0);
+
+  const merged = mergeGeometries([shaft, upperCone, lowerCone]);
+  // Sources have identical attribute layouts (position/normal/uv) — merge
+  // can't fail in practice, but the type signature requires the check.
+  if (!merged) {
+    throw new Error('Failed to merge arrow thumb geometries');
+  }
+  shaft.dispose();
+  upperCone.dispose();
+  lowerCone.dispose();
+
+  // Rotate from +Y default to the target world axis. Slider local frame =
+  // world frame (the slider group is positioned but not rotated):
+  //   arrow-x → ±world-X (parallel to track; slider 'a' / math-X)
+  //   arrow-y → ±world-Z (toward/away from viewer; slider 'b' / math-Y per #43,
+  //                       which routes math-Y to world-Z; bidirectional, so
+  //                       sign of the rotation doesn't matter pedagogically)
+  //   arrow-z → ±world-Y (up/down; slider 'c' / math-Z, no rotation needed)
+  if (axis === 'arrow-x') {
+    merged.rotateZ(-Math.PI / 2);
+  } else if (axis === 'arrow-y') {
+    merged.rotateX(Math.PI / 2);
+  }
+
+  return merged;
 }
 
 function clamp(v: number, lo: number, hi: number): number {

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -92,21 +92,25 @@ const SLIDER_SKY_BLUE = 0x56b4e9;
 const SLIDER_YELLOW = 0xf0e442;
 
 // Per-slider config: name + base color + thumb shape. Color is the
-// at-a-glance identification; shape is the redundancy cue (#58, Q4) so
-// the slider→coefficient mapping survives a colorblind viewer or any
-// rendering that strips the colors. Shape choice is deliberately
-// arbitrary among visually distinct primitives — pick whatever reads
-// best in headset.
+// at-a-glance identification; shape additionally maps each axis-coefficient
+// slider's thumb to its spatial direction — bidirectional 3D arrows
+// aligned with the corresponding world axis (slider 'a' = math-X arrow
+// along the track; slider 'b' = math-Y arrow forward/back from the
+// viewer; slider 'c' = math-Z arrow up/down). Slider 'd' is the constant
+// term and has no spatial direction, so a directionless sphere reads
+// pedagogically truthful. Replaces the original sphere/cube/octahedron/
+// cylinder set from #58 (Q4 redundancy cue) — those were visually
+// distinct but didn't carry meaning; the arrows do.
 type CoeffName = 'a' | 'b' | 'c' | 'd';
 const SLIDER_CONFIG: readonly {
   readonly name: CoeffName;
   readonly color: number;
   readonly shape: ThumbShape;
 }[] = [
-  { name: 'a', color: SLIDER_VERMILLION,   shape: 'sphere' },
-  { name: 'b', color: SLIDER_BLUISH_GREEN, shape: 'cube' },
-  { name: 'c', color: SLIDER_SKY_BLUE,     shape: 'octahedron' },
-  { name: 'd', color: SLIDER_YELLOW,       shape: 'cylinder' },
+  { name: 'a', color: SLIDER_VERMILLION,   shape: 'arrow-x' },
+  { name: 'b', color: SLIDER_BLUISH_GREEN, shape: 'arrow-y' },
+  { name: 'c', color: SLIDER_SKY_BLUE,     shape: 'arrow-z' },
+  { name: 'd', color: SLIDER_YELLOW,       shape: 'sphere' },
 ];
 
 // Math-frame axis indicator colors, matched to the slider that drives


### PR DESCRIPTION
## Summary

Quick-win follow-on to #58 (PR #64). Headset feedback was that the per-slider redundancy shapes (sphere / cube / octahedron / cylinder) were visually distinct but didn't carry meaning. Replaces them with **bidirectional 3D arrows axis-aligned to each slider's world axis**, so the slider→spatial-direction mapping is read directly off the thumb instead of recalled from "color X means axis Y."

| Slider | Math axis | Thumb shape |
|--------|-----------|-------------|
| `a` | math-X | arrow along the track (left ↔ right) |
| `b` | math-Y | arrow toward/away from the viewer |
| `c` | math-Z | arrow up/down |
| `d` | (constant) | directionless sphere |

Slider `d` becomes a sphere — the constant term has no spatial direction, so a directionless thumb reads as pedagogically truthful. Same Q1 logic as the yellow-color choice in #58: `d` is *different* from the axis coefficients, and the visual should say so.

## Implementation

- New `buildArrowGeometry` in `Slider.ts`: shaft cylinder + two outward cones, merged via `mergeGeometries` from `three/addons/utils/BufferGeometryUtils`. Single mesh + single material per slider, so hover/grab emissive logic stays untouched.
- `ThumbShape` now `'sphere' | 'arrow-x' | 'arrow-y' | 'arrow-z'`. Removed unused `'cube' | 'octahedron' | 'cylinder'` cases — those were #58 stand-ins, replaced not refactored.
- Visible arrow extends ~1.3r along its axis; grab zone (2.75r) covers the full visible shape with margin.
- `SPEC.md` "Per-slider visual" section reflects the new vocabulary.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [ ] On-device smoke on Quest 3S: arrows visibly point along correct axes from default spawn pose, grabbing each slider works (hit zone covers full visible arrow), no clipping into adjacent sliders or the math-frame axis indicator at extreme slider positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)