### PR TITLE
chore(quadrics): retune arrow thumb proportions

### DIFF
--- a/src/exhibits/quadrics/Slider.ts
+++ b/src/exhibits/quadrics/Slider.ts
@@ -309,13 +309,13 @@ function buildArrowGeometry(
   // Arrow proportions retuned post-headset (#65 follow-up). Shaft thicker
   // and longer, cones wider — arrows now read as substantive 3D objects
   // rather than thin sticks at the ~0.7 m viewing distance from the
-  // user's spawn pose. Cone height unchanged: at coneRadius = 1.0r the
-  // cones are intentionally squat (wider than tall) — bump coneHeight if
-  // the arrowheads look too disc-like in headset.
+  // user's spawn pose. coneRadius = 0.75r keeps the arrowheads
+  // recognizably pointy (h/r = 0.8) after a brief headset pass at 1.0r
+  // showed the cones reading too disc-like at full thumbRadius.
   const shaftLength = 1.75 * r;
   const shaftRadius = 0.25 * r;
   const coneHeight = 0.6 * r;
-  const coneRadius = 1.0 * r;
+  const coneRadius = 0.75 * r;
   // Cone center sits at half-shaft + half-cone along Y so its base flushes
   // against the shaft's end.
   const coneCenter = shaftLength / 2 + coneHeight / 2;

--- a/src/exhibits/quadrics/Slider.ts
+++ b/src/exhibits/quadrics/Slider.ts
@@ -283,7 +283,7 @@ export class Slider {
 }
 
 // `sphere` matches the hit-test radius exactly. The arrow variants extend
-// past `thumbRadius` along their axis (~1.3r at the cone tip), but the
+// past `thumbRadius` along their axis (~1.475r at the cone tip), but the
 // grab zone (`thumbRadius * GRAB_RADIUS_MULTIPLIER` = 2.75r) covers the
 // full visible arrow plus margin, so the entire shape stays grabbable.
 function buildThumbGeometry(
@@ -306,10 +306,16 @@ function buildArrowGeometry(
   axis: 'arrow-x' | 'arrow-y' | 'arrow-z',
 ): THREE.BufferGeometry {
   const r = thumbRadius;
-  const shaftLength = 1.4 * r;
-  const shaftRadius = 0.2 * r;
+  // Arrow proportions retuned post-headset (#65 follow-up). Shaft thicker
+  // and longer, cones wider — arrows now read as substantive 3D objects
+  // rather than thin sticks at the ~0.7 m viewing distance from the
+  // user's spawn pose. Cone height unchanged: at coneRadius = 1.0r the
+  // cones are intentionally squat (wider than tall) — bump coneHeight if
+  // the arrowheads look too disc-like in headset.
+  const shaftLength = 1.75 * r;
+  const shaftRadius = 0.25 * r;
   const coneHeight = 0.6 * r;
-  const coneRadius = 0.5 * r;
+  const coneRadius = 1.0 * r;
   // Cone center sits at half-shaft + half-cone along Y so its base flushes
   // against the shaft's end.
   const coneCenter = shaftLength / 2 + coneHeight / 2;


### PR DESCRIPTION
## Summary

Headset-feedback retune of the arrow thumbs from #65. Arrows were reading too thin at the ~0.7 m rack viewing distance.

| Parameter | Before | After | Note |
|-----------|--------|-------|------|
| `shaftRadius` | `0.20 r` | `0.25 r` | thicker shaft |
| `coneRadius`  | `0.50 r` | `1.00 r` | wider arrowhead |
| `shaftLength` | `1.40 r` | `1.75 r` | factor of 1.25 |
| `coneHeight`  | `0.60 r` | _unchanged_ | flagged below |

## Cone-height callout

With `coneRadius = 1.00 r` and `coneHeight = 0.60 r`, the cones are intentionally squat (wider than tall — `r > h`). They'll still read as cones, but flatter / more chevron-like than the original. Comment in code flags this so headset trial can decide whether to bump `coneHeight` proportionally (`0.60 → 0.75` if you want to match the 1.25× length factor) or leave it.

## Geometry sanity

- Visible arrow tip extends to `shaftLength/2 + coneHeight = 0.875r + 0.6r = 1.475r` along axis (was `1.3r`).
- Grab zone is still `2.75 r` — full visible arrow stays grabbable with margin.
- Vertical (`arrow-z`) extent at `1.475 r ≈ 0.037 m` per side; SLIDER_ROW_PITCH is `0.15 m`, so adjacent-slider clearance `≈ 0.113 m`. No collision.

## Dictation interpretation

Read "the shaft up to 2.5" as `shaftRadius = 0.25 r` (decimal slip from "point two five"); the only reading where "increase a little bit" makes sense, since the prior value was `0.20 r`. Mention so it's traceable in PR history.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean
- [ ] On-device smoke on Quest 3S: arrows read as 3D objects from spawn pose, arrowheads are recognizable as "pointy" not "disc-like" — if the latter, bump `coneHeight` and we ship a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)