### PR TITLE
docs: honest no-headset section in README; track emulator compat in #72

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,21 @@ boundaries (Ellipsoid → Hyperboloid → Cone → ...).
 
 ## Try it
 
-Live at <https://skylinetrailcomputing.github.io/geometer/>. Open in either:
+Live at <https://skylinetrailcomputing.github.io/geometer/>. Click **Enter VR** once the page loads.
 
-- A **Quest browser** (Quest 3, 3S, 2, Pro) — see [`DEV_QUEST_SETUP.md`](DEV_QUEST_SETUP.md) for first-run guidance.
-- **Desktop Chrome** with WebXR enabled — useful for inspection, but a connected headset is needed to enter a real VR session.
+Headset paths that work today:
 
-Click **Enter VR** once the page loads.
+- **Quest browser** (Quest 3, 3S, 2, Pro) — open the link directly on the headset. See [`DEV_QUEST_SETUP.md`](DEV_QUEST_SETUP.md) for first-run guidance.
+- **Desktop Chrome with a tethered headset** — useful for development and inspection.
+
+### Without a headset
+
+WebXR emulator extensions (Meta's [Immersive Web Emulator](https://chromewebstore.google.com/detail/immersive-web-emulator/cgffilbpcibhmcfbgggfhfolhkfbhmik); Mozilla's WebXR API Emulator) would in theory let a desktop browser drive the exhibit without hardware. As of v0.2 neither composes cleanly with our Three.js stack:
+
+- Meta's emulator polyfills the WebXR API but Three.js's session setup hits an `XRWebGLBinding` type mismatch on Enter VR.
+- Mozilla's emulator was removed from the Chrome Web Store in late 2025; it remains on Firefox Add-ons, but Firefox's own WebXR support has separate quirks.
+
+Compatibility work is tracked in [#72](https://github.com/skylinetrailcomputing/geometer/issues/72). For now, a real Quest (3 / 3S / 2 / Pro) is the reliable path.
 
 ## Run locally
 


### PR DESCRIPTION
## Summary

Closes **#70**, the v0.2 blocker on documenting the no-headset WebXR journey. The walk-through found neither major emulator extension composes cleanly with our Three.js stack today, so the README pivots to an honest caveat per the issue's accepted-fallback path. Compatibility investigation gets a real home in **#72** for v0.3.

## What changed

`README.md` "Try it" section is now structured as:

- **Headset paths that work today** — Quest browser, desktop Chrome + tethered headset.
- **Without a headset** — names both emulator extensions, says why each fails right now (Meta's `XRWebGLBinding` mismatch with Three.js; Mozilla's Chrome Web Store delisting), and points readers at #72 to follow the fix work.

Removes the v0.1 line that said "a connected headset is needed to enter a real VR session" — true for now, but the new subsection states it more precisely.

## Why this and not "recommend the working emulator"

#70's accepted criteria explicitly included the honest-caveat outcome:

> If the walkthrough finds the journey doesn't work […] the doc update becomes a transparent caveat instead — "emulators X and Y exist but currently fail at <step>; we'll revisit when <upstream fix>."

Both candidate extensions failed during the v0.2 walk-through; neither was viable to recommend. README captures that clearly so users aren't sent down a dead end.

## Test plan

- [x] Markdown renders correctly (preview locally)
- [x] Issue links resolve (#72 exists)
- [x] No broken anchors / dead links

🤖 Generated with [Claude Code](https://claude.com/claude-code)