### PR TITLE
fix(infra): delete preview Worker via curl, not wrangler-action (#76)

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,5 +1,11 @@
 # Cleanup of per-PR preview Workers when a PR closes (merged or not).
 # Pairs with .github/workflows/pr-preview.yml.
+#
+# Uses a direct DELETE against the Cloudflare API rather than wrangler:
+# wrangler 3.x's `delete` command performs a post-delete probe of KV
+# namespaces, which fails when the API token is scoped to Workers Scripts
+# only (least-privilege). The Worker itself is deleted, but wrangler exits
+# non-zero and the workflow goes red. See #76.
 
 name: pr-preview-cleanup
 
@@ -16,11 +22,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete preview Worker
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: >-
-            delete
-            --name geometer-pr-${{ github.event.pull_request.number }}
-            --force
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WORKER: geometer-pr-${{ github.event.pull_request.number }}
+        run: |
+          set -uo pipefail
+          http_code=$(curl -sS -X DELETE \
+            -o /tmp/cf-resp.json \
+            -w "%{http_code}" \
+            -H "Authorization: Bearer $CF_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/workers/scripts/$WORKER")
+          echo "HTTP $http_code"
+          cat /tmp/cf-resp.json
+          echo
+          # 200 = deleted; 404 = already gone (idempotent for retries / no-deploy PRs).
+          if [ "$http_code" = "200" ] || [ "$http_code" = "404" ]; then
+            echo "Cleanup OK ($http_code) for $WORKER"
+            exit 0
+          fi
+          echo "Cleanup failed for $WORKER (HTTP $http_code)"
+          exit 1


### PR DESCRIPTION
## Summary

Closes #76. Replaces `cloudflare/wrangler-action@v3` in `.github/workflows/pr-preview-cleanup.yml` with a direct `curl DELETE` against the Cloudflare API.

**Why:** wrangler 3.x's `delete` command probes KV namespaces after deleting a Worker, looking for orphan associations. Our least-privilege API token only has `Workers Scripts: Edit` (no KV), so the probe fails with `Authentication error [code: 10000]` — even though the actual `DELETE workers/scripts/<name>` call succeeded. Result: cleanup was succeeding but the workflow exited red on every PR close, including PR #74's.

`curl` calls the same delete endpoint without the post-delete pass. HTTP 200 (deleted) and 404 (already gone) are both treated as success, so the workflow is also idempotent for retries and edge cases like a PR closed before any successful deploy.

The deploy workflow keeps using `wrangler-action` because creating a Worker via the API requires multipart manifest uploads that wrangler handles cleanly — the KV-probe issue doesn't fire on deploy.

## Test plan

- [x] PR builds + deploys successfully via `pr-preview` (proves nothing was broken on the deploy side).
- [x] Verify the preview URL is reachable.
- [ ] **The PR's own close is the smoke test for the fix:** `pr-preview-cleanup` should run green, log `HTTP 200`, and the preview URL should return CF 404 afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)