### PR TITLE
feat(infra): embed QR code in PR-preview comment (#75)

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -69,4 +69,6 @@ jobs:
 
             https://geometer-pr-${{ github.event.pull_request.number }}.${{ vars.CLOUDFLARE_WORKERS_SUBDOMAIN }}.workers.dev
 
-            Open this URL in the Quest browser to smoke-test in headset.
+            ![preview QR code](https://api.qrserver.com/v1/create-qr-code/?size=240x240&data=https%3A%2F%2Fgeometer-pr-${{ github.event.pull_request.number }}.${{ vars.CLOUDFLARE_WORKERS_SUBDOMAIN }}.workers.dev)
+
+            Scan the QR with the Quest's passthrough camera, or open the URL directly in the headset browser.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,9 +53,14 @@ with a URL of the shape
 https://geometer-pr-<PR-number>.<account>.workers.dev
 ```
 
-Open that URL in the Quest browser to smoke-test before requesting
-review or merging. The preview Worker is automatically deleted
-when the PR closes (merged or not).
+The same comment includes a QR code of that URL. If you're
+reviewing the PR on a desktop or laptop, scan the QR with the
+Quest's passthrough camera to open the preview directly in the
+headset — no typing on the virtual keyboard, no copy-paste between
+devices. Otherwise just click the URL.
+
+The preview Worker is automatically deleted when the PR closes
+(merged or not).
 
 Production continues to live at
 <https://skylinetrailcomputing.github.io/geometer/> (GitHub Pages,


### PR DESCRIPTION
## Summary

Closes #75. Adds a QR-code image of the preview URL to the comment posted by the `pr-preview` workflow, so a reviewer can hand off from a laptop session to a Quest session by scanning the code with the headset's passthrough camera — no virtual-keyboard typing, no copy-paste between devices.

Implementation is a one-line markdown image pointing at `api.qrserver.com/v1/create-qr-code/`. Specifically:

```
![preview QR code](https://api.qrserver.com/v1/create-qr-code/?size=240x240&data=<url-encoded preview URL>)
```

GitHub's `camo` proxy fetches and caches the image when the comment renders, so already-rendered QRs stay scannable even if qrserver goes down later. The plain-text URL stays in the comment as the graceful-degradation fallback.

`CONTRIBUTING.md` updated to call out the QR scan flow as the recommended path for reviewers who work on a laptop and smoke on a Quest.

## Acceptance check (against #75)

- [x] PR-preview comment embeds a scannable QR code of the preview URL.
- [ ] Scanning the QR with the Quest's passthrough cam opens the preview in the Quest browser without manual entry. (**Maintainer scan-test required on this PR.**)
- [x] If the QR fails, the URL is still visible as plain text in the same comment (graceful degradation).
- [x] `CONTRIBUTING.md` mentions the QR loop as the recommended smoke flow.

## Test plan

- [x] CF preview deploys, posts a single comment that contains both the URL and a rendered QR image (~240px).
- [ ] On a desktop browser, the QR renders inline in the PR comment.
- [ ] Scanning the QR with the Quest passthrough camera opens the preview URL in the Quest browser. If the cam can't read 240px reliably, follow up by bumping `size=240x240` to `size=320x320` or `400x400`.
- [ ] Cleanup workflow on PR close still exits green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)