### PR TITLE
feat(quadrics): two-phase animated preset transitions (closes #56)

### DIFF
--- a/src/exhibits/quadrics/PresetTween.ts
+++ b/src/exhibits/quadrics/PresetTween.ts
@@ -1,0 +1,150 @@
+import type { PresetValues } from './Preset';
+import type { Slider } from './Slider';
+
+// Animated transition between canonical-pose preset values (#56). v0.2's
+// preset buttons snapped instantly; the tween makes the family transition
+// itself visible — the user *sees* the cone pinch into a hyperboloid as `c`
+// flips sign, with the live family classifier readout morphing along — not
+// just the endpoints.
+//
+// Two-phase animation, ordered to dodge the empty-set / degenerate-point
+// regions that a naive 4D linear lerp would visit (see issue #56 §2). The
+// rule, derived from the documented preset → preset transitions:
+//
+//   1. Source d = 0, target d ≠ 0 (leaving the cone): phase 1 moves d
+//      first, then the rest. Without this, intermediate (a,b,c) at d=0
+//      with same-sign coefficients would render only the origin.
+//   2. Source d ≠ 0, target d = 0 (landing on the cone): phase 1 moves
+//      (a,b,c) first, phase 2 moves d. Lands on the cone last.
+//   3. Otherwise: phase 1 moves (a,b,c), phase 2 moves d. Sphere↔cylinder
+//      and 1-sheet↔2-sheets transits stay smooth — the latter passes
+//      through cone at d=0 with c already negative, no degeneracy.
+//
+// Empty phases are collapsed: a transition that only changes d (e.g., cone →
+// 1-sheet) skips its empty phase rather than leaving 150 ms of dead frames.
+
+const DURATION_MS = 300;
+
+// Cubic ease-in-out — picked because it reads as "deliberate" rather than
+// "snappy" at this duration. Tunable in headset; the issue defers easing
+// experiments to a follow-up.
+function ease(t: number): number {
+  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+}
+
+// Index 3 is `d` in (a,b,c,d). Phase ordering keys off it.
+const D_INDEX = 3;
+const ABC_INDICES: readonly number[] = [0, 1, 2];
+
+interface Phase {
+  // Indices into PresetValues to interpolate during this phase.
+  readonly indices: readonly number[];
+  // Phase span as a fraction of total elapsed time, [start, end] in [0, 1].
+  readonly tStart: number;
+  readonly tEnd: number;
+}
+
+export class PresetTween {
+  private readonly start: PresetValues;
+  private readonly target: PresetValues;
+  private readonly sliders: readonly Slider[];
+  private readonly phases: readonly Phase[];
+  private readonly startedAtMs: number;
+  private done = false;
+
+  constructor(
+    start: PresetValues,
+    target: PresetValues,
+    sliders: readonly Slider[],
+    nowMs: number,
+  ) {
+    this.start = start;
+    this.target = target;
+    this.sliders = sliders;
+    this.startedAtMs = nowMs;
+
+    // Source-at-cone (d=0) is the only signal that flips ordering: leave
+    // the cone before flipping signs, so we never sit at d=0 with same-sign
+    // (a,b,c). Rule 2 (landing on the cone) and rule 3 both fall out of the
+    // else branch — `d` last in either case.
+    const sourceAtCone = start[D_INDEX] === 0;
+    const phase1Indices: readonly number[] = sourceAtCone
+      ? [D_INDEX]
+      : ABC_INDICES;
+    const phase2Indices: readonly number[] = sourceAtCone
+      ? ABC_INDICES
+      : [D_INDEX];
+
+    const phase1Active = phase1Indices.some((i) => start[i] !== target[i]);
+    const phase2Active = phase2Indices.some((i) => start[i] !== target[i]);
+
+    // Edge case: nothing changes. Already-done tween is a no-op on tick().
+    if (!phase1Active && !phase2Active) {
+      this.phases = [];
+      this.done = true;
+      return;
+    }
+
+    let phase1End: number;
+    if (phase1Active && phase2Active) {
+      phase1End = 0.5;
+    } else if (phase1Active) {
+      phase1End = 1;
+    } else {
+      phase1End = 0;
+    }
+
+    const phases: Phase[] = [];
+    if (phase1Active) {
+      phases.push({ indices: phase1Indices, tStart: 0, tEnd: phase1End });
+    }
+    if (phase2Active) {
+      phases.push({ indices: phase2Indices, tStart: phase1End, tEnd: 1 });
+    }
+    this.phases = phases;
+  }
+
+  /**
+   * Advance the tween. Returns true while still animating, false once
+   * complete. On completion the final frame uses `setValue` (not
+   * `setValueRaw`) so the zero-detent re-engages on each slider.
+   */
+  tick(nowMs: number): boolean {
+    if (this.done) return false;
+    const t = Math.min((nowMs - this.startedAtMs) / DURATION_MS, 1);
+
+    for (const phase of this.phases) {
+      const localT = clamp01((t - phase.tStart) / (phase.tEnd - phase.tStart));
+      const eased = ease(localT);
+      for (const i of phase.indices) {
+        const v = lerp(this.start[i], this.target[i], eased);
+        this.sliders[i].setValueRaw(v);
+      }
+    }
+
+    if (t >= 1) {
+      // Land exactly on target values *and* re-engage the detent. Targets
+      // are typically detent-clean (1, 0, -1, …), so setValue is a no-op
+      // beyond that, but it keeps the final state consistent with a manual
+      // preset press.
+      for (let i = 0; i < this.sliders.length; i++) {
+        this.sliders[i].setValue(this.target[i]);
+      }
+      this.done = true;
+      return false;
+    }
+    return true;
+  }
+
+  cancel(): void {
+    this.done = true;
+  }
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function clamp01(v: number): number {
+  return v < 0 ? 0 : v > 1 ? 1 : v;
+}

--- a/src/exhibits/quadrics/PresetTween.ts
+++ b/src/exhibits/quadrics/PresetTween.ts
@@ -23,7 +23,11 @@ import type { Slider } from './Slider';
 // Empty phases are collapsed: a transition that only changes d (e.g., cone →
 // 1-sheet) skips its empty phase rather than leaving 150 ms of dead frames.
 
-const DURATION_MS = 300;
+// 0.9 s after a headset trial of the original 0.3 s — three-times slower
+// reads as deliberate enough to actually watch the family-classifier
+// readout flip across the morph, where 0.3 s was over before the eye could
+// track. Tunable; the issue defers final calibration to in-headset feel.
+const DURATION_MS = 900;
 
 // Cubic ease-in-out — picked because it reads as "deliberate" rather than
 // "snappy" at this duration. Tunable in headset; the issue defers easing

--- a/src/exhibits/quadrics/Slider.ts
+++ b/src/exhibits/quadrics/Slider.ts
@@ -164,6 +164,23 @@ export class Slider {
   }
 
   /**
+   * Detent-bypassing variant of `setValue`, used by programmatic tweens
+   * (#56). The detent's purpose is to let the user park *deliberately* on a
+   * degeneracy boundary; during a multi-frame morph it just creates a dead
+   * window across ±ZERO_DETENT where the thumb visibly sticks at zero. The
+   * tween caller is expected to finish with a normal `setValue` so the
+   * detent re-engages at rest.
+   */
+  setValueRaw(v: number): void {
+    this.rawValue = clamp(v, this.opts.min, this.opts.max);
+    this.currentValue = this.rawValue;
+    if (this.grabbedBy) {
+      this.lastControllerLocalX = this.controllerLocalX(this.grabbedBy);
+    }
+    this.syncThumbPosition();
+  }
+
+  /**
    * Test whether `controller`'s forward ray hits the thumb. On hit, attach
    * the grab to that controller and pulse haptics. Returns whether grabbed.
    */
@@ -264,20 +281,18 @@ export class Slider {
     return this.localPoint.x;
   }
 
-  // Thumb tracks the *displayed* value (i.e. `currentValue`'s would-be
-  // snapped projection of `rawValue`), not raw. Inside the detent the thumb
-  // parks at zero so it stays aligned with what the equation readout will
-  // display (per SPEC.md "Slider model"). The slow-drag-escape behavior of
-  // #24 is preserved by `rawValue` accumulating in `update()` underneath —
-  // once raw clears ±ZERO_DETENT, the thumb tracks it again. Bonus: the
-  // visible "park at zero on approach" is part of the detent's affordance —
-  // the user feels the boundary before reading the equation.
+  // Thumb tracks `currentValue` — the emitted/shader value with the detent
+  // already applied (or bypassed, for setValueRaw). Inside the detent during
+  // a drag the thumb parks at zero so it stays aligned with what the equation
+  // readout will display (per SPEC.md "Slider model"). The slow-drag-escape
+  // behavior of #24 is preserved by `rawValue` accumulating in `update()`
+  // underneath — once raw clears ±ZERO_DETENT, currentValue tracks it again.
+  // Tween-time setValueRaw bypasses the detent so the thumb sweeps through
+  // zero rather than visibly sticking across the ±0.05 window mid-morph (#56).
   private syncThumbPosition(): void {
     const halfLen = this.opts.trackLength / 2;
-    const displayValue =
-      Math.abs(this.rawValue) < ZERO_DETENT ? 0 : this.rawValue;
     const t =
-      (displayValue - this.opts.min) / (this.opts.max - this.opts.min);
+      (this.currentValue - this.opts.min) / (this.opts.max - this.opts.min);
     this.thumb.position.x = -halfLen + t * this.opts.trackLength;
   }
 }

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -5,6 +5,7 @@ import { classify } from './classify';
 import { EquationReadout } from './EquationReadout';
 import { Label } from './Label';
 import { Preset, type PresetValues } from './Preset';
+import { PresetTween } from './PresetTween';
 import { Section } from './Section';
 import { SectionTab } from './SectionTab';
 import { Slider, type ThumbShape } from './Slider';
@@ -444,6 +445,10 @@ let equationReadout: EquationReadout | undefined;
 let worldAxes: WorldAxes | undefined;
 let camera: THREE.Camera | undefined;
 let elapsed = 0;
+// Active preset tween (#56). Replaced on each preset press; canceled on
+// slider grab so the user takes control from wherever the tween last set
+// the thumb. Module-scoped so update() can tick it.
+let presetTween: PresetTween | undefined;
 
 const quadricsExhibit: Exhibit = {
   id: 'quadrics',
@@ -597,6 +602,14 @@ const quadricsExhibit: Exhibit = {
     for (const s of activeSection.sliders) s.updateHover(controllers);
     for (const p of activeSection.presets) p.updateHover(controllers);
     if (camera) for (const p of activeSection.presets) p.faceCamera(camera);
+    // Tween advances its bound section's sliders before the slider→uniform
+    // read below, so this frame's render reflects the morph. The tween
+    // owns its slider reference (set at construction); this loop just
+    // advances time.
+    if (presetTween) {
+      const stillRunning = presetTween.tick(performance.now());
+      if (!stillRunning) presetTween = undefined;
+    }
     // Slider → uniform routing in the math-textbook frame paired with the
     // axis indicator (#43): X right, Y forward, Z up. The shader still
     // evaluates the implicit equation in the Three.js world frame, so:
@@ -670,16 +683,36 @@ function setupControllers(
       // first-hit-wins contract well-defined regardless of layout.
       const activeSection = sections[activeSectionIndex];
       for (const s of activeSection.sliders) {
-        if (s.tryGrab(controller)) return;
+        if (s.tryGrab(controller)) {
+          // Cancel any in-flight preset tween — the user is taking the
+          // wheel, and a still-ticking tween would fight the drag (#56,
+          // "interrupt" interaction policy).
+          presetTween?.cancel();
+          presetTween = undefined;
+          return;
+        }
       }
       for (const p of activeSection.presets) {
         if (p.tryActivate(controller)) {
           // Preset values are section-local (ordering matches the
-          // section's own sliders), so this stays correct as future
-          // sections introduce their own preset palettes.
-          for (let i = 0; i < activeSection.sliders.length; i++) {
-            activeSection.sliders[i].setValue(p.values[i]);
-          }
+          // section's own sliders). Animate the slider rack from its
+          // current values to the preset (#56) instead of snapping —
+          // makes the family transition itself visible. The previous
+          // tween, if any, is replaced; its ticked-state on the
+          // sliders is the new tween's start.
+          const currentValues: PresetValues = [
+            activeSection.sliders[0].value,
+            activeSection.sliders[1].value,
+            activeSection.sliders[2].value,
+            activeSection.sliders[3].value,
+          ];
+          presetTween?.cancel();
+          presetTween = new PresetTween(
+            currentValues,
+            p.values,
+            activeSection.sliders,
+            performance.now(),
+          );
           return;
         }
       }


### PR DESCRIPTION
## Summary

- Replaces v0.2's instant slider snap on preset press with a 900 ms two-phase tween (#56). Family transition itself is visible — `c` flips sign through cylinder/1-sheet, then `d` settles on cone — not just the endpoints.
- New `PresetTween` orders the two phases to dodge empty-set / degenerate-point transit. Walked through every transition in the issue's acceptance list — none traverse `(a,b,c)` all-same-sign with `d=0`.
- `Slider.setValueRaw` bypasses the ±0.05 zero detent for tween frames so the thumb doesn't visibly stick at zero mid-morph; the final frame falls back to `setValue` so the detent re-engages at rest.
- Grab-mid-tween cancels the tween (interrupt policy from the issue body).

## Phase rule

- Source `d=0`, target `d≠0` (leaving the cone): phase 1 moves `d` first, phase 2 the rest.
- Otherwise: phase 1 moves `(a,b,c)`, phase 2 moves `d`.
- Empty phases collapse — cone→1-sheet (d-only) and sphere→cylinder (c-only) get the full duration, no dead frames.

This is the simpler "two-phase" path the issue identified as the right v1 try — slerping the unit-3-sphere reparameterization is the escalation if two-phase reads as awkward in headset.

## Test plan

- [x] \`npm run build\` (tsc --noEmit + vite build) clean
- [x] \`npm run lint\` clean
- [x] Pre-merge on-device smoke via the Cloudflare Workers PR preview (#71). Walked the seven preset buttons and verified:
    - [x] No "empty-set" frames mid-morph for Sphere→Cone, Sphere→Cylinder, Sphere→H 2-sheets, Cone→Cylinder, Cone→Sphere
    - [x] Smooth pass through cone at d=0 for H 1-sheet ↔ H 2-sheets
    - [x] Family classifier readout updates live across the tween
    - [x] 72 Hz frame rate holds
    - [x] Grabbing a slider mid-tween cancels cleanly (no fight)
    - [x] Duration calibration: 0.3 s → 0.9 s after headset trial; reads as a good sweet spot

🤖 Generated with [Claude Code](https://claude.com/claude-code)