### PR TITLE
docs: sharpen no-headset README caveat — name r185 as the unblocker (closes-when-merged: refs #80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ WebXR emulator extensions (Meta's [Immersive Web Emulator](https://chromewebstor
 - Meta's emulator polyfills the WebXR API but Three.js's session setup hits an `XRWebGLBinding` type mismatch on Enter VR.
 - Mozilla's emulator was removed from the Chrome Web Store in late 2025; it remains on Firefox Add-ons, but Firefox's own WebXR support has separate quirks.
 
-Compatibility work is tracked in [#72](https://github.com/skylinetrailcomputing/geometer/issues/72). For now, a real Quest (3 / 3S / 2 / Pro) is the reliable path.
+Compatibility work is tracked in [#80](https://github.com/skylinetrailcomputing/geometer/issues/80). The Meta emulator's `XRWebGLBinding` mismatch is fixed upstream in Three.js [r185](https://github.com/mrdoob/three.js/issues/33414) (closed-completed, unreleased as of this writing — expected mid-2026 based on Three.js's recent ~2-month cadence); once it ships to npm we'll bump our pin and re-verify. For now, a real Quest (3 / 3S / 2 / Pro) is the reliable path.
 
 ## Run locally
 


### PR DESCRIPTION
## Summary

- README's \`Without a headset\` section pointed at the now-closed-superseded #72; updates the link to #80 (the live blocked issue).
- Adds one sentence of concrete context: the Meta-IWE \`XRWebGLBinding\` mismatch is fixed upstream as [mrdoob/three.js#33414](https://github.com/mrdoob/three.js/issues/33414) (closed-completed, milestoned to Three.js r185 — unreleased; expected mid-2026 based on recent cadence). Readers now know *what* we're waiting on and roughly *when*, instead of just "compatibility work tracked elsewhere."
- Scope unchanged: still only describes the emulator path. A built-in non-XR fallback (fly camera, mouse-orbit) remains explicitly out of scope per #80.

Refs #80. Doesn't close it — #80 closes when r185 lands and we bump + re-verify.

## Test plan

- [x] Local diff reviewed; one-line change.
- [ ] Confirm GitHub renders the inline links (#80, three.js #33414) cleanly on the rendered README.