### PR TITLE
feat(quadrics): two-line equation readout for linear terms

### DIFF
--- a/src/exhibits/quadrics/EquationReadout.ts
+++ b/src/exhibits/quadrics/EquationReadout.ts
@@ -1,38 +1,62 @@
 import * as THREE from 'three';
 import { Text } from 'troika-three-text';
 
-// Live equation readout above the slider rack (#58). Renders the equation
-// `±N.NN x² + ±N.NN y² + ±N.NN z² = ±N.NN` with the four coefficient
-// numerics colored to match their sliders, and the static algebraic
-// glue (variables, operators) neutral white. The whole thing is yaw-only
-// billboarded as a single unit so the equation reads from one consistent
-// direction.
+// Live equation readout above the slider rack (#58). Two-line layout (#89)
+// renders the full quadric with linear terms:
+//   line 1 (top):    `±N.NN x² + ±N.NN y² + ±N.NN z²`
+//   line 2 (bottom): `±N.NN x + ±N.NN y + ±N.NN z = ±N.NN`
+// Numerics are colored to match their slider thumbs (vermillion = math-X,
+// bluish-green = math-Y, sky-blue = math-Z; yellow for the constant `d`),
+// so a vermillion numeric on the top line means "coefficient on x²" and
+// a vermillion numeric on the bottom line means "coefficient on x" — same
+// color story across both lines. Algebraic glue (variables, operators) is
+// neutral white. Yaw-only billboarded as one unit so the whole equation
+// reads from a consistent direction.
 //
 // troika-three-text doesn't support inline rich text / per-span color, so
-// the equation is built from seven independent Text instances laid out
-// at fixed offsets: 4 numeric slots interleaved with 3 separators.
-// Numeric slots are sized to comfortably hold the worst-case value
-// `−N.NN` / `+N.NN`; separator slots size to their fixed content. The
-// constants are em-based so retuning fontSize stays self-consistent.
+// the equation is built from independent Text instances laid out at fixed
+// offsets. Each line is independently centered on the readout group's x=0,
+// which leaves the wider bottom line (with its trailing `= d`) extending
+// slightly further right than the top line — natural reading flow for a
+// continued equation. Constants are em-based so retuning fontSize stays
+// self-consistent.
 
 export interface EquationReadoutOptions {
-  // Per-coefficient diffuse colors, indexed (a, b, c, d). Match the slider
-  // thumb colors so the user can read the equation top-to-bottom or
-  // left-to-right and see the same color story either way.
-  coefficientColors: readonly [number, number, number, number];
+  // Diffuse colors for the seven numeric slots in visual reading order:
+  // [a, b, c, u, v, w, d]. Match the slider thumb colors so the user can
+  // cross-reference equation ↔ rack at a glance. Linear-term slots
+  // (u, v, w) reuse a/b/c's axis-coded colors, since both quadratic and
+  // linear coefficients on the same axis share the same math-frame meaning.
+  coefficientColors: readonly [
+    number, number, number, number, number, number, number,
+  ];
   fontSize?: number;
 }
 
 const DEFAULT_FONT_SIZE = 0.028;
 
 // Slot widths in em (multiples of fontSize), tuned to Roboto-ish defaults
-// in troika. Numeric slot accommodates the worst-case `−N.NN`; separator
-// slot fits ` x² + ` / ` z² = ` with a touch of breathing room. Refine in
-// headset if pieces look crowded or splayed.
+// in troika. NUMERIC fits the worst-case `−N.NN`; SEPARATOR fits a full
+// connector like ` x² + ` / ` z = ` with breathing room; SEPARATOR_TAIL is
+// the truncated trailing slot on the top line — ` z²` only, no trailing
+// operator. Refine in headset if pieces look crowded or splayed.
 const NUMERIC_SLOT_EM = 2.6;
 const SEPARATOR_SLOT_EM = 2.4;
+const SEPARATOR_TAIL_EM = 1.2;
 
-const SEPARATOR_CONTENT = [' x² + ', ' y² + ', ' z² = '] as const;
+// Top line (3 numerics + 3 separators): a, ` x² + `, b, ` y² + `, c, ` z²`.
+// Bottom line (4 numerics + 3 separators): u, ` x + `, v, ` y + `, w, ` z = `, d.
+// The trailing `+` on the top line's final separator is dropped — the
+// bottom line's first numeric carries an explicit sign (always-show-sign
+// convention) which serves as the implicit continuation marker.
+const TOP_SEPARATOR_CONTENT = [' x² + ', ' y² + ', ' z²'] as const;
+const BOTTOM_SEPARATOR_CONTENT = [' x + ', ' y + ', ' z = '] as const;
+
+// Vertical gap between the two lines. Larger than 1× fontSize so the lines
+// read as visually distinct rows; smaller than 2.5× to keep the readout's
+// total height under the gap to the family-classifier label at y=1.5.
+const LINE_PITCH = 0.06;
+
 const SEPARATOR_COLOR = 0xffffff;
 const OUTLINE_WIDTH = '8%';
 const OUTLINE_COLOR = 0x000000;
@@ -43,11 +67,24 @@ const OUTLINE_COLOR = 0x000000;
 // frame so motion smoothness is unaffected.
 const SYNC_INTERVAL_MS = 33;
 
+// Numeric-slot indices in visual reading order, used by both the layout
+// loop in the constructor and the value-write loop in setValues.
+const SLOT_A = 0;
+const SLOT_B = 1;
+const SLOT_C = 2;
+const SLOT_U = 3;
+const SLOT_V = 4;
+const SLOT_W = 5;
+const SLOT_D = 6;
+const NUMERIC_SLOT_COUNT = 7;
+
 export class EquationReadout {
   readonly group: THREE.Group;
 
   private readonly numericTexts: readonly Text[];
-  private readonly numericValues: number[] = [NaN, NaN, NaN, NaN];
+  private readonly numericValues: number[] = new Array<number>(
+    NUMERIC_SLOT_COUNT,
+  ).fill(NaN);
   private readonly separatorTexts: readonly Text[];
   private lastSyncMs = 0;
 
@@ -59,73 +96,137 @@ export class EquationReadout {
     const fontSize = opts.fontSize ?? DEFAULT_FONT_SIZE;
     const numericW = NUMERIC_SLOT_EM * fontSize;
     const separatorW = SEPARATOR_SLOT_EM * fontSize;
-    const totalW = 4 * numericW + 3 * separatorW;
+    const separatorTailW = SEPARATOR_TAIL_EM * fontSize;
+
+    // Top line: 3 numerics + 2 full separators + 1 tail separator.
+    // Bottom line: 4 numerics + 3 full separators.
+    const topLineW = 3 * numericW + 2 * separatorW + separatorTailW;
+    const bottomLineW = 4 * numericW + 3 * separatorW;
+    const topY = LINE_PITCH / 2;
+    const bottomY = -LINE_PITCH / 2;
 
     this.group = new THREE.Group();
     this.group.name = 'equation-readout';
 
-    // Slot centers, left-to-right: a, " x² + ", b, " y² + ", c, " z² = ", d.
-    // Slot indices alternate numeric (even) and separator (odd).
-    const slotCentersX: number[] = [];
-    let cursor = -totalW / 2;
-    for (let i = 0; i < 7; i++) {
-      const w = i % 2 === 0 ? numericW : separatorW;
-      slotCentersX.push(cursor + w / 2);
-      cursor += w;
-    }
-
-    const numericTexts: Text[] = [];
-    for (let i = 0; i < 4; i++) {
-      const t = new Text();
-      t.fontSize = fontSize;
-      t.color = opts.coefficientColors[i];
-      t.anchorX = 'center';
-      t.anchorY = 'middle';
-      t.outlineWidth = OUTLINE_WIDTH;
-      t.outlineColor = OUTLINE_COLOR;
-      t.position.set(slotCentersX[i * 2], 0, 0);
-      this.group.add(t);
-      numericTexts.push(t);
-    }
-    this.numericTexts = numericTexts;
-
+    const numericTexts: Text[] = new Array<Text>(NUMERIC_SLOT_COUNT);
     const separatorTexts: Text[] = [];
-    for (let i = 0; i < 3; i++) {
-      const t = new Text();
-      t.fontSize = fontSize;
-      t.color = SEPARATOR_COLOR;
-      t.anchorX = 'center';
-      t.anchorY = 'middle';
-      t.outlineWidth = OUTLINE_WIDTH;
-      t.outlineColor = OUTLINE_COLOR;
-      t.position.set(slotCentersX[i * 2 + 1], 0, 0);
-      t.text = SEPARATOR_CONTENT[i];
-      t.sync();
-      this.group.add(t);
-      separatorTexts.push(t);
+
+    // Top line layout — slots alternate N S N S N S' (S' = tail separator).
+    // Slot ordering: N(a) S(' x² + ') N(b) S(' y² + ') N(c) S(' z²').
+    let cursor = -topLineW / 2;
+    const topSlotIndex = (i: number): number => [SLOT_A, SLOT_B, SLOT_C][i];
+    for (let i = 0; i < 6; i++) {
+      const isNumeric = i % 2 === 0;
+      const isTail = i === 5;
+      const w = isNumeric ? numericW : isTail ? separatorTailW : separatorW;
+      const centerX = cursor + w / 2;
+      cursor += w;
+
+      if (isNumeric) {
+        const slot = topSlotIndex(i / 2);
+        const t = this.makeNumericText(
+          fontSize,
+          opts.coefficientColors[slot],
+        );
+        t.position.set(centerX, topY, 0);
+        this.group.add(t);
+        numericTexts[slot] = t;
+      } else {
+        const t = this.makeSeparatorText(fontSize);
+        t.text = TOP_SEPARATOR_CONTENT[(i - 1) / 2];
+        t.position.set(centerX, topY, 0);
+        t.sync();
+        this.group.add(t);
+        separatorTexts.push(t);
+      }
     }
+
+    // Bottom line layout — same alternation as the original single-line
+    // readout: N S N S N S N. Slot ordering: N(u) S(' x + ') N(v)
+    // S(' y + ') N(w) S(' z = ') N(d).
+    cursor = -bottomLineW / 2;
+    const bottomSlotIndex = (i: number): number =>
+      [SLOT_U, SLOT_V, SLOT_W, SLOT_D][i];
+    for (let i = 0; i < 7; i++) {
+      const isNumeric = i % 2 === 0;
+      const w = isNumeric ? numericW : separatorW;
+      const centerX = cursor + w / 2;
+      cursor += w;
+
+      if (isNumeric) {
+        const slot = bottomSlotIndex(i / 2);
+        const t = this.makeNumericText(
+          fontSize,
+          opts.coefficientColors[slot],
+        );
+        t.position.set(centerX, bottomY, 0);
+        this.group.add(t);
+        numericTexts[slot] = t;
+      } else {
+        const t = this.makeSeparatorText(fontSize);
+        t.text = BOTTOM_SEPARATOR_CONTENT[(i - 1) / 2];
+        t.position.set(centerX, bottomY, 0);
+        t.sync();
+        this.group.add(t);
+        separatorTexts.push(t);
+      }
+    }
+
+    this.numericTexts = numericTexts;
     this.separatorTexts = separatorTexts;
   }
 
+  private makeNumericText(fontSize: number, color: number): Text {
+    const t = new Text();
+    t.fontSize = fontSize;
+    t.color = color;
+    t.anchorX = 'center';
+    t.anchorY = 'middle';
+    t.outlineWidth = OUTLINE_WIDTH;
+    t.outlineColor = OUTLINE_COLOR;
+    return t;
+  }
+
+  private makeSeparatorText(fontSize: number): Text {
+    const t = new Text();
+    t.fontSize = fontSize;
+    t.color = SEPARATOR_COLOR;
+    t.anchorX = 'center';
+    t.anchorY = 'middle';
+    t.outlineWidth = OUTLINE_WIDTH;
+    t.outlineColor = OUTLINE_COLOR;
+    return t;
+  }
+
   /**
-   * Update the four coefficient values. Throttled to ≈30 Hz; pre-throttle
-   * the work would dominate troika SDF rebuild cost during fast drags
-   * (#38 rationale, ported from Slider's per-slider label cap). Sign is
-   * always shown explicitly (matching the old per-slider label format)
-   * so transitions across zero are unambiguous.
+   * Update the seven numeric values. Throttled to ≈30 Hz; pre-throttle the
+   * work would dominate troika SDF rebuild cost during fast drags (#38
+   * rationale, ported from Slider's per-slider label cap). Sign is always
+   * shown explicitly (matching the per-slider label format) so transitions
+   * across zero are unambiguous on every slot, top line and bottom alike.
    */
-  setValues(a: number, b: number, c: number, d: number): void {
+  setValues(
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    u: number,
+    v: number,
+    w: number,
+  ): void {
     const now = performance.now();
     if (now - this.lastSyncMs < SYNC_INTERVAL_MS) return;
     this.lastSyncMs = now;
 
-    const values = [a, b, c, d];
-    for (let i = 0; i < 4; i++) {
-      const v = values[i];
-      if (v === this.numericValues[i]) continue;
-      this.numericValues[i] = v;
-      const sign = v < 0 ? '−' : '+';
-      this.numericTexts[i].text = `${sign}${Math.abs(v).toFixed(2)}`;
+    // Indexed in visual reading order [a, b, c, u, v, w, d] to match the
+    // slot constants above and the coefficientColors array.
+    const values = [a, b, c, u, v, w, d];
+    for (let i = 0; i < NUMERIC_SLOT_COUNT; i++) {
+      const value = values[i];
+      if (value === this.numericValues[i]) continue;
+      this.numericValues[i] = value;
+      const sign = value < 0 ? '−' : '+';
+      this.numericTexts[i].text = `${sign}${Math.abs(value).toFixed(2)}`;
       this.numericTexts[i].sync();
     }
   }

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -164,11 +164,21 @@ const AXIS_COLORS: Record<AxisName, number> = {
   Z: SLIDER_SKY_BLUE,      // slider 'c' (math-Z)
 };
 
-const EQUATION_COEFFICIENT_COLORS: readonly [number, number, number, number] = [
-  SLIDER_VERMILLION,
-  SLIDER_BLUISH_GREEN,
-  SLIDER_SKY_BLUE,
-  SLIDER_YELLOW,
+// Numeric-slot colors for the equation readout, indexed in visual reading
+// order [a, b, c, u, v, w, d] (#89). Linear-term slots (u/v/w) reuse the
+// quadratic-term axis colors so the equation block tells the same axis
+// story twice — once on the top line for the squared coefficients, once on
+// the bottom for the linear ones — matching the slider rack's color story.
+const EQUATION_COEFFICIENT_COLORS: readonly [
+  number, number, number, number, number, number, number,
+] = [
+  SLIDER_VERMILLION,    // a
+  SLIDER_BLUISH_GREEN,  // b
+  SLIDER_SKY_BLUE,      // c
+  SLIDER_VERMILLION,    // u
+  SLIDER_BLUISH_GREEN,  // v
+  SLIDER_SKY_BLUE,      // w
+  SLIDER_YELLOW,        // d
 ];
 
 // Debug sweep on `a`: gated off once controller sliders took over (#5).
@@ -727,7 +737,7 @@ const quadricsExhibit: Exhibit = {
       if (camera) rackLabel.faceCamera(camera);
     }
     if (equationReadout) {
-      equationReadout.setValues(a, b, c, d);
+      equationReadout.setValues(a, b, c, d, u, v, w);
       if (camera) equationReadout.faceCamera(camera);
     }
     if (worldAxes && camera) worldAxes.faceCamera(camera);

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -708,13 +708,23 @@ const quadricsExhibit: Exhibit = {
     //   slider c → math-Z² → world-Y² → uB
     //   slider d → uD (constant term)
     // Linear-term routing (#88) follows the same math→world swap, but on
-    // the first-degree variable rather than its square:
-    //   slider u → math-X → world-X → uU
-    //   slider v → math-Y → world-Z → uW
-    //   slider w → math-Z → world-Y → uV
-    // A non-zero (u, v, w) translates the surface's center along the
-    // matching world axis; classify() is invariant under this shift —
-    // the family is unchanged, only the location moves.
+    // the first-degree variable rather than its square. The squared rows
+    // above are sign-symmetric (b · y² = b · z² regardless of sign), so
+    // they need no per-axis flip. The linear rows do — specifically on
+    // math-Y, which maps to −world-Z (camera looks down −Z, so the
+    // textbook "forward = away from user" direction is negative
+    // world-Z, per WorldAxes.ts):
+    //   slider u → math-X → +world-X    → uU = +u
+    //   slider v → math-Y → −world-Z    → uW = −v   (sign-flipped)
+    //   slider w → math-Z → +world-Y    → uV = +w
+    // The flip on `v` keeps completing-the-square consistent across all
+    // three linear sliders: positive coefficient ⇒ center at −coeff/2
+    // along +math-axis. Without it, only slider `v` would translate
+    // the surface in the +math-direction (away from user) instead of
+    // −math-direction (toward user), inverting the pedagogy and
+    // contradicting the math-frame axis indicator. classify() remains
+    // invariant under any (u, v, w) — family unchanged, only the
+    // location moves.
     const [a, b, c, d] = sliders.map((s) => s.value);
     const [u, v, w] = linearSliders.map((s) => s.value);
     if (material) {
@@ -723,7 +733,7 @@ const quadricsExhibit: Exhibit = {
       material.uniforms.uB.value = c;
       material.uniforms.uD.value = d;
       material.uniforms.uU.value = u;
-      material.uniforms.uW.value = v;
+      material.uniforms.uW.value = -v;
       material.uniforms.uV.value = w;
     }
     if (DEBUG_SWEEP && material) {


### PR DESCRIPTION
## Summary

- Closes #89 — third and final slice of the original A/B/C breakdown for #85.
- Extends `EquationReadout` from a single 4-numeric line to a two-line layout that mirrors the full quadric equation `ax² + by² + cz² + ux + vy + wz = d`.
- **+ folded fix:** sign flip on the math-Y linear-term wire (`slider v → uW = −v`), surfaced during pre-merge smoke. Without the flip, slider `v` positive translated the surface AWAY from the user, contradicting the completing-the-square pedagogy that sliders `u` and `w` correctly follow. Root cause: math-Y maps to **−world-Z** (camera looks down −Z), and the squared route is sign-symmetric so it hid the bug through v0.3.

## Layout

```
+1.00 x² + +1.00 y² + +1.00 z²
+0.00 x  + +0.00 y  + +0.00 z  = +1.00
```

Each line is centered independently on the readout group's `x=0`; the bottom line is wider because of the trailing `= d`, so it extends slightly further right — natural reading flow for a continued equation. The top line's last separator drops the trailing `+` since the bottom line's first numeric carries an explicit sign (always-show-sign convention) which serves as the implicit continuation marker.

`LINE_PITCH = 0.06` keeps the two rows distinct without the readout's total height encroaching on the family classifier at `y = 1.5`.

## API changes

- `EquationReadoutOptions.coefficientColors`: `[4]` → `[7]`, indexed in visual reading order `[a, b, c, u, v, w, d]`. Linear-term slots reuse the axis-coded colors from a/b/c so the equation block tells the same axis story twice (top: squared coefficients, bottom: linear coefficients).
- `setValues(a, b, c, d)` → `setValues(a, b, c, d, u, v, w)`. Throttled-sync loop generalized over all 7 slots.
- Constructor refactored to deduplicate numeric/separator `Text` setup into private factories, now that two lines share the pattern.

## Sign fix details

Routing comment block in `update()` rewritten to call out which math→world axes are sign-flipped:

| Slider | Math axis | World axis | Uniform | Flip? |
|---|---|---|---|---|
| u | math-X | +world-X | uU = +u | no |
| v | math-Y | **−world-Z** | uW = **−v** | **yes** |
| w | math-Z | +world-Y | uV = +w | no |

After the fix, all three linear sliders share the same pedagogy: positive coefficient ⇒ center shifts to −coeff/2 along the +math-axis. Slider v positive now translates the surface **toward** the user (−math-Y direction, since +math-Y is "forward / away" per right-handed convention).

## Test plan

- [x] `npm run build` (tsc + vite) clean.
- [x] `npm run lint` clean.
- [x] **Headset smoke on the Cloudflare preview URL:**
  - [x] **Sign sanity (highest priority — verifies the fold-in fix):** with linear-terms tab active, slider `v = +1` translates the surface **toward** the user (was: away, pre-fix). `u = +1` shifts left, `w = +1` shifts down — both unchanged from previous behavior, both consistent with completing-the-square.
  - [x] Two-line readout renders correctly above the slider rack with default values (`+1.00 x² + +1.00 y² + +1.00 z²` / `+0.00 x + +0.00 y + +0.00 z = +1.00`).
  - [x] All seven numerics update live as the corresponding sliders drag (a/b/c/d on coefficient section, u/v/w on linear section).
  - [x] Color story: vermillion on top-left = a; vermillion on bottom-left = u; same for b/v (bluish-green) and c/w (sky-blue); d on bottom-right = yellow.
  - [x] No collision with the family classifier label at `y = 1.5`.
  - [x] Yaw-only billboarding still works on the multi-line group.
  - [x] 72 Hz holds during full-rate slider drags (now 7 troika syncs per frame at the 30 Hz cap, up from 4).
  - [x] Parabolic cylinders / paraboloids (the new shapes the linear terms unlock) still render correctly across the parameter sweep.

## Out of scope (now tracked separately under #85)

- **#92** — canonical-pose presets reset linear terms to zero on activation.
- **#93** — relocate canonical-pose presets under the section tab row (design-heavy, needs trial).
- **#95** — hide zero-valued terms in the equation readout (surfaced from the smoke of this PR).
- **#96** — classifier upgrade for paraboloids / parabolic cylinders / planes on rank-deficient quadratic parts (also surfaced from smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)