### PR TITLE
docs(readme): link no-headset section to #105 desktop-mode track

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ WebXR emulator extensions (Meta's [Immersive Web Emulator](https://chromewebstor
 
 Compatibility work is tracked in [#80](https://github.com/skylinetrailcomputing/geometer/issues/80). The Meta emulator's `XRWebGLBinding` mismatch is fixed upstream in Three.js [r185](https://github.com/mrdoob/three.js/issues/33414) (closed-completed, unreleased as of this writing — expected mid-2026 based on Three.js's recent ~2-month cadence); once it ships to npm we'll bump our pin and re-verify. For now, a real Quest (3 / 3S / 2 / Pro) is the reliable path.
 
+Separately, [#105](https://github.com/skylinetrailcomputing/geometer/issues/105) is exploring a first-class **desktop interaction mode** (mouse + keyboard, WASD or orbit camera) — a real production path for visitors without a headset, not a developer workaround. Design discussion is open.
+
 ## Run locally
 
 Requires Node 20+ and npm.


### PR DESCRIPTION
## Summary

- Adds a one-paragraph pointer in the **Without a headset** section of the README that links to #105 (desktop / non-VR interaction mode) alongside the existing #80 (emulator compat) reference.
- Frames #105 as a real production path, distinct from #80's dev-tool emulator workflow — same distinction made in the issue body itself.

## Test plan

- [x] README renders cleanly on github.com (no broken markdown around the new paragraph).
- [x] Both #80 and #105 links resolve.
- [x] No other content in the README changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)