### PR TITLE
fix(quadrics): coefficient presets reset linear terms to zero (#92)

### DIFF
--- a/src/exhibits/quadrics/PresetTween.ts
+++ b/src/exhibits/quadrics/PresetTween.ts
@@ -48,11 +48,24 @@ interface Phase {
   readonly tEnd: number;
 }
 
+// Optional secondary rack tweened in parallel with the coefficient phases
+// (#92). Used so coefficient-section presets also drive the linear-terms
+// rack to (0, 0, 0) — otherwise tapping "Sphere" with non-zero (u, v, w)
+// produces a translated sphere instead of the canonical pose. Lerps across
+// the full duration; phase ordering is unnecessary because zeroing linear
+// terms has no degeneracy region to dodge.
+export interface SecondaryRackSpec {
+  readonly start: readonly number[];
+  readonly target: readonly number[];
+  readonly sliders: readonly Slider[];
+}
+
 export class PresetTween {
   private readonly start: PresetValues;
   private readonly target: PresetValues;
   private readonly sliders: readonly Slider[];
   private readonly phases: readonly Phase[];
+  private readonly secondary?: SecondaryRackSpec;
   private readonly startedAtMs: number;
   private done = false;
 
@@ -61,11 +74,13 @@ export class PresetTween {
     target: PresetValues,
     sliders: readonly Slider[],
     nowMs: number,
+    secondary?: SecondaryRackSpec,
   ) {
     this.start = start;
     this.target = target;
     this.sliders = sliders;
     this.startedAtMs = nowMs;
+    this.secondary = secondary;
 
     // Source-at-cone (d=0) is the only signal that flips ordering: leave
     // the cone before flipping signs, so we never sit at d=0 with same-sign
@@ -81,9 +96,11 @@ export class PresetTween {
 
     const phase1Active = phase1Indices.some((i) => start[i] !== target[i]);
     const phase2Active = phase2Indices.some((i) => start[i] !== target[i]);
+    const secondaryActive =
+      !!secondary && secondary.start.some((v, i) => v !== secondary.target[i]);
 
     // Edge case: nothing changes. Already-done tween is a no-op on tick().
-    if (!phase1Active && !phase2Active) {
+    if (!phase1Active && !phase2Active && !secondaryActive) {
       this.phases = [];
       this.done = true;
       return;
@@ -126,6 +143,14 @@ export class PresetTween {
       }
     }
 
+    if (this.secondary) {
+      const easedFull = ease(t);
+      for (let i = 0; i < this.secondary.sliders.length; i++) {
+        const v = lerp(this.secondary.start[i], this.secondary.target[i], easedFull);
+        this.secondary.sliders[i].setValueRaw(v);
+      }
+    }
+
     if (t >= 1) {
       // Land exactly on target values *and* re-engage the detent. Targets
       // are typically detent-clean (1, 0, -1, …), so setValue is a no-op
@@ -133,6 +158,11 @@ export class PresetTween {
       // preset press.
       for (let i = 0; i < this.sliders.length; i++) {
         this.sliders[i].setValue(this.target[i]);
+      }
+      if (this.secondary) {
+        for (let i = 0; i < this.secondary.sliders.length; i++) {
+          this.secondary.sliders[i].setValue(this.secondary.target[i]);
+        }
       }
       this.done = true;
       return false;

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -846,18 +846,31 @@ function setupControllers(
           // makes the family transition itself visible. The previous
           // tween, if any, is replaced; its ticked-state on the
           // sliders is the new tween's start.
+          //
+          // Coefficient presets also drive the linear-terms rack to
+          // (0, 0, 0) (#92): "canonical pose" is only canonical if the
+          // surface is centered, which means linear terms must zero.
+          // Bundled into the same tween so a single cancel() on
+          // mid-drag interrupt drops both racks together.
           const currentValues: PresetValues = [
             activeSection.sliders[0].value,
             activeSection.sliders[1].value,
             activeSection.sliders[2].value,
             activeSection.sliders[3].value,
           ];
+          const linearStart = linearSliders.map((s) => s.value);
+          const linearTarget = linearStart.map(() => 0);
           presetTween?.cancel();
           presetTween = new PresetTween(
             currentValues,
             p.values,
             activeSection.sliders,
             performance.now(),
+            {
+              start: linearStart,
+              target: linearTarget,
+              sliders: linearSliders,
+            },
           );
           return;
         }


### PR DESCRIPTION
Closes #92.

## Summary

- Tapping a coefficient preset (Sphere, Ellipsoid, Cone, …) now also tweens `(u, v, w) → (0, 0, 0)` so canonical-pose presets actually return the surface to a canonical centered form.
- Extends `PresetTween` with an optional `secondary` rack that lerps in parallel across the full duration. No phase ordering: zeroing linear terms has no degeneracy region to dodge.
- Bundling both racks into the same tween means the existing `presetTween?.cancel()` on slider grab drops both racks together — no second module-scope slot, no parallel-tween bookkeeping. Edge case `secondaryActive` rolls into the existing "nothing changes" early-return.

## Implementation note

The two options the issue listed were:
1. Single tween, both racks (extend `PresetTween`).
2. Parallel `PresetTween` instances.

Went with #1 — tightest diff, single cancel path, identical timing across racks (the linear-zero animation reads as part of the same gesture, not a sibling).

## Test plan

- [x] `npm run build` (tsc + vite) — clean
- [x] `npm test` — 27 passed
- [x] `npm run lint` — clean
- [x] Cloudflare PR preview on Quest 3S:
  - Switch to Linear-terms tab, drag `(u, v, w)` to a non-zero pose, e.g. `(1, -0.5, 0.8)`.
  - Switch back to Coefficients, tap **Sphere**: surface returns to centered sphere; flip back to Linear-terms tab and confirm sliders animated to 0.
  - Repeat for **Reset** preset: linear sliders also zero.
  - Press a preset, then grab a coefficient slider mid-tween: both rack animations stop cleanly; user-grabbed slider is in control.
  - Press a preset with `(u, v, w) = 0` already: behaves identically to today (no jitter, no tween for an empty delta path).
  - 72 Hz holds across simultaneous tween (coefficient phase + linear-rack lerp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
