### PR TITLE
perf(quadrics): raymarcher STEPS 96 → 64 (#102 knob B)

### DIFF
--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -199,8 +199,10 @@ const CANONICAL_FORMS_LABEL_EXPANDED = 'Canonical forms ▾';
 // 2.5 to 3.5 (#87) to give linear-term sliders u/v/w (#85, ±2 each) room to
 // translate the implicit surface without pushing its visible region outside
 // the cube. The cost is per-step thickness in the raymarch (cube grows ~1.4×
-// per axis), which the STEPS = 96 loop absorbs without visibly slowing on
-// Quest 3S — re-evaluate if 72 Hz starts dropping in headset.
+// per axis); per #102 the per-fragment STEPS loop turned out to be the
+// dominant steady-state cost, so the four-knob ladder there compensates
+// (FBO scale 0.85 in #114, then STEPS 96 → 64 here, with BOUND tighten
+// queued as knob 3 if more headroom is needed).
 const BOUND = 3.5;
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
 
@@ -537,7 +539,21 @@ const FRAGMENT_SHADER = /* glsl */ `
     }
     float tStart = max(tNear, 0.0);
 
-    const int STEPS = 96;
+    // STEPS = the per-fragment uniform-march sample count across the AABB
+    // span, before the 8-iter bisection refines a sign change to a hit.
+    // Was 96 originally; lowered to 64 in #102 (knob B) — the per-fragment
+    // STEPS loop runs for every rasterized fragment in the bounding cube
+    // even when no surface is hit, so STEPS is a near-linear knob on
+    // steady-state fragment cost. Tradeoff: the AABB span at BOUND = 3.5
+    // is up to ~12 m diagonal; at 64 steps that's ~19 cm of march
+    // per-step worst case, which the bisection follow-up still resolves
+    // to sub-mm precision once a sign change is detected. Visible cost is
+    // missed-feature aliasing on geometry thinner than dt — relevant only
+    // at extreme (u, v, w) poses where the surface degenerates to a
+    // narrow sliver crossing the AABB; non-degenerate quadrics are
+    // contiguous and easily caught by 64 samples. If 48 is needed (knob B
+    // step 2), revisit.
+    const int STEPS = 64;
     float dt = (tFar - tStart) / float(STEPS);
     float t = tStart;
     float fPrev = fImplicit(ro + rd * t);


### PR DESCRIPTION
## Summary

Second profile-guided knob from #102's investigation plan, stacking
on the framebuffer scale 0.85 from #114 (which moved steady-state
from ~40 → ~50–55 FPS in headset). STEPS is the per-fragment
uniform-march sample count across the AABB before the 8-iter
bisection refines a sign change to a hit; the loop runs for every
rasterized fragment in the bounding cube even on no-hit, so STEPS
is a near-linear knob on steady-state fragment cost. Expect ~33 %
fragment-cost reduction at the same FBO scale.

Tradeoff: dt grows from ~12 m / 96 ≈ 12.5 cm to ~12 m / 64 ≈ 19 cm
worst case at BOUND = 3.5; bisection still resolves to sub-mm
precision once a sign change is detected, so visible cost is missed-
feature aliasing on geometry thinner than dt. Non-degenerate quadrics
are contiguous and easily caught by 64 samples — the failure mode
shows only at extreme (u, v, w) poses degenerating to narrow slivers.

The BOUND comment was also refreshed: it previously claimed "STEPS =
96 absorbs the cost without slowing on Quest 3S," which #102's data
invalidated (STEPS turned out to be the dominant cost). New comment
threads the four-knob ladder.

## Test plan

- [x] Open the auto-posted preview URL with `?fps=1` in the Quest 3S
  browser. Capture steady-state FPS readout after ~30 s of typical
  interaction; the cumulative state being tested is FBO 0.85 + STEPS
  64 (#114 already on main, this PR adds the second knob).
- [x] Stress-test the silhouette-aliasing tradeoff: drag sliders to
  near-degenerate poses (e.g. one of a/b/c near 0 with d ≠ 0; large
  linear-term values pushing the surface near the AABB edge).
  Confirm whether aliasing reads as objectionable or as imperceptible
  at typical viewing distance.
- [x] If FPS reaches / passes 72 Hz with no objectionable aliasing:
  keep, advance #102 toward closure (knobs 3 + 4 not needed). If FPS
  is closer but still short: keep, move to knob C (BOUND tighten 3.5
  → 2.5) or knob D (foveation 0.3 → 0.5). If aliasing reads bad:
  revert to STEPS 80 as a halfway point and re-test, or skip to FBO/
  foveation as alternative knobs that don't have this tradeoff.
  → **~70–80 FPS sustained (bar met); knobs 3 + 4 not needed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)