### PR TITLE
docs(readme): swap demo video for v0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ sibling sections (level-set slicing, linear terms) in future versions.
 
 ## Demo
 
-<video src="https://github.com/user-attachments/assets/bdaa5f33-0cef-4eda-ab95-ed6e83a50165" autoplay loop muted playsinline width="720" aria-label="Quest 3S view of the quadrics exhibit: dragging sliders and tapping canonical-pose preset buttons morph the surface through ellipsoid, cone, and hyperboloid families, with the live family classification label updating across each transition">
+<video src="REPLACE_ME_PENDING_USER_ATTACHMENTS_URL" autoplay loop muted playsinline width="720" aria-label="Quest 3S view of the quadrics exhibit: dragging sliders and tapping canonical-pose preset buttons morph the surface through ellipsoid, cone, and hyperboloid families, with the live family classification label updating across each transition">
   Your browser does not support inline video.
 </video>
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ sibling sections (level-set slicing, linear terms) in future versions.
 
 ## Demo
 
-<video src="REPLACE_ME_PENDING_USER_ATTACHMENTS_URL" autoplay loop muted playsinline width="720" aria-label="Quest 3S view of the quadrics exhibit: dragging sliders and tapping canonical-pose preset buttons morph the surface through ellipsoid, cone, and hyperboloid families, with the live family classification label updating across each transition">
+<video src="https://github.com/user-attachments/assets/1b445e07-f5fd-4c77-a23d-d0cc45765b55" autoplay loop muted playsinline width="720" aria-label="Quest 3S view of the quadrics exhibit: dragging sliders and tapping canonical-pose preset buttons morph the surface through ellipsoid, cone, and hyperboloid families, with the live family classification label updating across each transition">
   Your browser does not support inline video.
 </video>
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ sibling sections (level-set slicing, linear terms) in future versions.
 
 ## Demo
 
-<video src="https://github.com/user-attachments/assets/1b445e07-f5fd-4c77-a23d-d0cc45765b55" autoplay loop muted playsinline width="720" aria-label="Quest 3S view of the quadrics exhibit: dragging sliders and tapping canonical-pose preset buttons morph the surface through ellipsoid, cone, and hyperboloid families, with the live family classification label updating across each transition">
+<video src="https://github.com/user-attachments/assets/1b445e07-f5fd-4c77-a23d-d0cc45765b55" autoplay loop muted playsinline width="720" aria-label="Quest 3S view of the quadrics exhibit: dragging coefficient sliders to morph the implicit surface, sweeping a horizontal slicing plane through it to trace a glowing intersection ring, and tapping canonical-pose preset buttons, with the live family classifier updating in step">
   Your browser does not support inline video.
 </video>
 


### PR DESCRIPTION
## Summary

Refresh the README's demo `<video>` for v0.4. Source clip:
`~/Downloads/v0.4.mp4` — 16 s (seconds 10–26 of the v0.4 raw
capture), 720p / 24 fps / H.264 / no audio / +faststart, 384 KB.

The current commit puts a literal placeholder
(`REPLACE_ME_PENDING_USER_ATTACHMENTS_URL`) in the `src` attribute.
**Workflow:**

1. Brad drags `~/Downloads/v0.4.mp4` into a comment on this PR.
2. GitHub mints a `github.com/user-attachments/assets/<uuid>` URL
   in the comment body — the only URL form that inline-plays per
   the workspace `reference_github_readme_video` memory.
3. Claude swaps the placeholder for the real URL on this branch.
4. Smoke the preview deploy: confirm the video autoplays inline on
   GitHub's PR preview render of the README.
5. Merge.

The aria-label was left untouched. If the new clip foregrounds
v0.4-specific moments (cross-sections lens, linear-term sliders),
the aria-label can be sharpened in the same swap commit — flag
when dropping the video.

## Test plan

- [x] Drag-drop video into a PR comment; copy resulting URL.
- [x] Confirm Claude has updated `src=` to the real URL on the
  branch.
- [x] On the PR's "Files changed" tab, confirm the README diff
  shows the real URL (not the placeholder) and renders the
  embedded video at the top of the rendered README preview.
- [x] (Optional) sharpen the aria-label if the clip's content has
  shifted from v0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)