### PR TITLE
chore(shell): migrate THREE.Clock → THREE.Timer (#104)

### DIFF
--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -51,9 +51,13 @@ export function bootShell(): void {
   const ctx: ExhibitContext = { scene, renderer, camera };
   exhibit.mount(ctx);
 
-  const clock = new THREE.Clock();
+  const timer = new THREE.Timer();
+  // Page Visibility integration: prevents huge delta spikes after the tab
+  // (or Quest headset) is backgrounded and re-focused mid-session.
+  timer.connect(document);
   renderer.setAnimationLoop(() => {
-    const delta = clock.getDelta();
+    timer.update();
+    const delta = timer.getDelta();
     exhibit.update({ delta });
     renderer.render(scene, camera);
   });


### PR DESCRIPTION
## Summary

- Replace `THREE.Clock` (deprecated since r183) with `THREE.Timer` at the single call site in `src/shell/shell.ts`.
- Wire `timer.connect(document)` so the Page Visibility API absorbs delta spikes when the Quest headset is briefly removed mid-session.
- Console clean of the `THREE.Clock: This module has been deprecated...` warning at page load.

Closes #104.

## Test plan

Cloudflare PR preview (per #71) auto-deploys to a Quest-browser-reachable URL — smoke there before merge.

- [ ] Open preview in desktop Chrome → DevTools console clean of the `THREE.Clock` deprecation warning.
- [ ] FPS overlay (#101) ticks normally — no zeros, no NaN.
- [ ] Quadrics animation looks smooth (deltas plumbed correctly through `exhibit.update`).
- [ ] Open preview in Quest browser → enter VR → cross-section animation (#84) advances at the expected cadence.
- [ ] Bonus: doff/don the headset mid-session; first post-resume frame doesn't show a visible animation jump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)