### PR TITLE
chore(html): add SVG favicon (#123)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>geometer — geometric reasoning in VR</title>
     <style>
       body { margin: 0; font-family: system-ui, sans-serif; background: #111122; color: #ddd; }

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <circle cx="16" cy="16" r="11" fill="#3aa6e8" />
+  <line x1="3" y1="16" x2="29" y2="16" stroke="#9fd8f3" stroke-width="2" stroke-linecap="round" />
+</svg>


### PR DESCRIPTION
## Summary

- Adds `public/favicon.svg` — a sky-blue disk crossed by a lighter slicing line, a small nod to the just-shipped cross-sections lens (#84). Scales cleanly to 16×16.
- Links it from `index.html` via `<link rel="icon" type="image/svg+xml" href="/favicon.svg" />`.
- Vite copies `public/` verbatim into `dist/`, so Pages picks it up with no further wiring (verified locally — `dist/favicon.svg` and the `<link>` survive the build).

Closes #123.

## Test plan

Cloudflare PR preview is the smoke surface.

- [x] Open preview in desktop Chrome → DevTools console clean of the `/favicon.ico` 404.
- [x] Tab icon shows the sky-blue mark (not the default globe).
- [x] Mark is recognizable at 16×16 (browser tab) — not just a colored blob.
- [ ] Open in Quest browser → page loads cleanly, no console 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)