### PR TITLE
refactor(scaffold): extract implicit-surface raymarcher

### DIFF
--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -14,6 +14,7 @@ import { FpsOverlay } from '@/scaffold/perf/FpsOverlay';
 import { Label } from '@/scaffold/ui/Label';
 import { Preset, type LinearPresetValues, type PresetValues } from '@/scaffold/ui/Preset';
 import { PresetTween } from '@/scaffold/anim/PresetTween';
+import { createImplicitSurface } from '@/scaffold/render/ImplicitSurface';
 import { RendererInfoProbe } from '@/scaffold/perf/RendererInfoProbe';
 import { Section } from '@/scaffold/ui/Section';
 import { SectionTab } from '@/scaffold/ui/SectionTab';
@@ -349,26 +350,15 @@ const EQUATION_COEFFICIENT_COLORS: readonly [
 const DEBUG_SWEEP = false;
 const SWEEP_PERIOD = 8;
 
-const VERTEX_SHADER = /* glsl */ `
-  varying vec3 vWorldPos;
+// Quadrics-side GLSL feeding `createImplicitSurface` from
+// scaffold/render/ImplicitSurface (#129). The harness owns the vertex
+// shader, ray–AABB clip, fixed-step march + bisection, surface-local
+// frame, and depth write; everything below is the surface-specific
+// remainder — uniform decls, helper functions, the implicit form
+// `f(p) = ax² + by² + cz² + ux + vy + wz − d`, and the `shadeHit` body
+// (lambert + parametric/world-axis grid switch + cross-section glow).
 
-  void main() {
-    vec4 wp = modelMatrix * vec4(position, 1.0);
-    vWorldPos = wp.xyz;
-    gl_Position = projectionMatrix * viewMatrix * wp;
-  }
-`;
-
-const FRAGMENT_SHADER = /* glsl */ `
-  precision highp float;
-
-  // Three.js auto-populates projectionMatrix on every program, but only
-  // declares it in vertex-shader prefixes — fragment shaders have to
-  // declare it explicitly to use it. (viewMatrix and cameraPosition are
-  // declared automatically.)
-  uniform mat4 projectionMatrix;
-
-  uniform vec3  uSurfaceCenter;
+const QUADRICS_UNIFORM_DECLS = /* glsl */ `
   uniform float uA;
   uniform float uB;
   uniform float uC;
@@ -376,7 +366,6 @@ const FRAGMENT_SHADER = /* glsl */ `
   uniform float uU;
   uniform float uV;
   uniform float uW;
-  uniform float uBound;
   // Cross-sections section (#84): math-Z slicing plane in surface-local
   // coords. uPlaneActive is 0 when any other section is focused — the
   // glow band only renders when the user is actively viewing the slicing
@@ -389,7 +378,9 @@ const FRAGMENT_SHADER = /* glsl */ `
   uniform float uPlaneActive;
   uniform vec3  uLightDir;
   uniform vec3  uBaseColor;
+`;
 
+const QUADRICS_HELPERS = /* glsl */ `
   // Sky-blue glow color for the slicing-plane intersection ring, matching
   // the slider 'c' / math-Z palette (the slicing axis). Reads as
   // continuous with the existing axis-color story.
@@ -424,26 +415,6 @@ const FRAGMENT_SHADER = /* glsl */ `
   // never appears in practice. Keeps the shader dispatch stable through
   // floating-point noise.
   const float PARAM_SIGN_EPSILON   = 1e-4;
-
-  varying vec3 vWorldPos;
-
-  float fImplicit(vec3 p) {
-    return uA * p.x * p.x + uB * p.y * p.y + uC * p.z * p.z
-         + uU * p.x + uV * p.y + uW * p.z
-         - uD;
-  }
-
-  vec3 gradF(vec3 p) {
-    float h = 0.001;
-    vec3 dx = vec3(h, 0.0, 0.0);
-    vec3 dy = vec3(0.0, h, 0.0);
-    vec3 dz = vec3(0.0, 0.0, h);
-    return vec3(
-      fImplicit(p + dx) - fImplicit(p - dx),
-      fImplicit(p + dy) - fImplicit(p - dy),
-      fImplicit(p + dz) - fImplicit(p - dz)
-    ) / (2.0 * h);
-  }
 
   // Anti-aliased fract-based line mask. Used independently for each grid
   // direction so each gets its own fwidth — avoids the near-pole smear
@@ -544,108 +515,41 @@ const FRAGMENT_SHADER = /* glsl */ `
     float mV = lineMaskAA((v + PI) / TWO_PI * float(PARAM_LON_LINES));
     return vec2(max(mU, mV), 1.0);
   }
+`;
 
-  bool rayAABB(vec3 ro, vec3 rd, float r, out float tNear, out float tFar) {
-    vec3 invD = 1.0 / rd;
-    vec3 t0 = (vec3(-r) - ro) * invD;
-    vec3 t1 = (vec3( r) - ro) * invD;
-    vec3 tMin = min(t0, t1);
-    vec3 tMax = max(t0, t1);
-    tNear = max(max(tMin.x, tMin.y), tMin.z);
-    tFar  = min(min(tMax.x, tMax.y), tMax.z);
-    return tFar >= max(tNear, 0.0);
+const QUADRICS_F_IMPLICIT = /* glsl */ `
+  float fImplicit(vec3 p) {
+    return uA * p.x * p.x + uB * p.y * p.y + uC * p.z * p.z
+         + uU * p.x + uV * p.y + uW * p.z
+         - uD;
   }
+`;
 
-  void main() {
-    vec3 ro = cameraPosition - uSurfaceCenter;
-    vec3 rd = normalize(vWorldPos - cameraPosition);
-
-    float tNear, tFar;
-    if (!rayAABB(ro, rd, uBound, tNear, tFar)) {
-      discard;
-    }
-    float tStart = max(tNear, 0.0);
-
-    // STEPS = the per-fragment uniform-march sample count across the AABB
-    // span, before the 8-iter bisection refines a sign change to a hit.
-    // Was 96 originally; lowered to 64 in #102 (knob B) — the per-fragment
-    // STEPS loop runs for every rasterized fragment in the bounding cube
-    // even when no surface is hit, so STEPS is a near-linear knob on
-    // steady-state fragment cost. Tradeoff: the AABB span at BOUND = 3.5
-    // is up to ~12 m diagonal; at 64 steps that's ~19 cm of march
-    // per-step worst case, which the bisection follow-up still resolves
-    // to sub-mm precision once a sign change is detected. Visible cost is
-    // missed-feature aliasing on geometry thinner than dt — relevant only
-    // at extreme (u, v, w) poses where the surface degenerates to a
-    // narrow sliver crossing the AABB; non-degenerate quadrics are
-    // contiguous and easily caught by 64 samples. If 48 is needed (knob B
-    // step 2), revisit.
-    const int STEPS = 64;
-    float dt = (tFar - tStart) / float(STEPS);
-    float t = tStart;
-    float fPrev = fImplicit(ro + rd * t);
-    bool hit = false;
-    float tHit = 0.0;
-
-    for (int i = 1; i <= STEPS; i++) {
-      float tNext = tStart + float(i) * dt;
-      float fNext = fImplicit(ro + rd * tNext);
-      if (fPrev * fNext < 0.0) {
-        float lo = t;
-        float hi = tNext;
-        float fLo = fPrev;
-        for (int b = 0; b < 8; b++) {
-          float mid = 0.5 * (lo + hi);
-          float fMid = fImplicit(ro + rd * mid);
-          if (fLo * fMid < 0.0) {
-            hi = mid;
-          } else {
-            lo = mid;
-            fLo = fMid;
-          }
-        }
-        tHit = 0.5 * (lo + hi);
-        hit = true;
-        break;
-      }
-      t = tNext;
-      fPrev = fNext;
-    }
-
-    if (!hit) {
-      discard;
-    }
-
-    vec3 pHit = ro + rd * tHit;
-    vec3 n = normalize(gradF(pHit));
-    if (dot(n, rd) > 0.0) {
-      n = -n;
-    }
-
+const QUADRICS_SHADE = /* glsl */ `
+  // Gridlines as a depth cue. Two systems, never co-rendered (#45
+  // headset feedback: simultaneous display read as cluttered):
+  //
+  //   * Parametric (#45) — lines of constant θ/φ (ellipsoid) or u/v
+  //     (hyperboloids) in a family-aware natural parameterization.
+  //     Lines flow with the surface as parameters morph.
+  //   * World-axis (#34) — distance to the nearest integer multiple of
+  //     (1 / GRID_FREQ) on each world axis. Anchored to world (0,0,0),
+  //     so the surface reads as carved out of a fixed 3D coordinate
+  //     frame. Used as the fallback when the family doesn't admit a
+  //     natural parametric form (cylinders / cones / planes / degenerates).
+  //
+  // Both systems share GRID_COLOR / GRID_INTENSITY so the line character
+  // stays consistent across family transitions — only the *frame* the
+  // lines align to changes, reinforcing the family-classification flip
+  // already shown in the rack readout above.
+  //
+  // fwidth-based AA keeps lines one-pixel-wide regardless of viewing
+  // angle or distance; walking around the surface gives parallax through
+  // whichever grid is currently active.
+  vec3 shadeHit(vec3 pHit, vec3 n, vec3 hitWorld, vec3 rd) {
     float lambert = max(dot(n, normalize(uLightDir)), 0.0);
     vec3 baseColor = uBaseColor * (0.2 + 0.8 * lambert);
 
-    // Gridlines as a depth cue. Two systems, never co-rendered (#45
-    // headset feedback: simultaneous display read as cluttered):
-    //
-    //   * Parametric (#45) — lines of constant θ/φ (ellipsoid) or u/v
-    //     (hyperboloids) in a family-aware natural parameterization.
-    //     Lines flow with the surface as parameters morph.
-    //   * World-axis (#34) — distance to the nearest integer multiple of
-    //     (1 / GRID_FREQ) on each world axis. Anchored to world (0,0,0),
-    //     so the surface reads as carved out of a fixed 3D coordinate
-    //     frame. Used as the fallback when the family doesn't admit a
-    //     natural parametric form (cylinders / cones / planes / degenerates).
-    //
-    // Both systems share GRID_COLOR / GRID_INTENSITY so the line character
-    // stays consistent across family transitions — only the *frame* the
-    // lines align to changes, reinforcing the family-classification flip
-    // already shown in the rack readout above.
-    //
-    // fwidth-based AA keeps lines one-pixel-wide regardless of viewing
-    // angle or distance; walking around the surface gives parallax through
-    // whichever grid is currently active.
-    vec3 hitWorld = pHit + uSurfaceCenter;
     vec2 paramGrid = parametricGrid(pHit);
     float gridMask;
     if (paramGrid.y > 0.5) {
@@ -671,15 +575,7 @@ const FRAGMENT_SHADER = /* glsl */ `
         1.0 - smoothstep(0.0, PLANE_GLOW_HALF_WIDTH, planeDist);
       color += PLANE_GLOW_COLOR * (PLANE_GLOW_INTENSITY * planeMask);
     }
-
-    gl_FragColor = vec4(color, 1.0);
-
-    // Write the implicit-surface depth, not the bounding cube's. Quest's
-    // asynchronous spacewarp reprojects per-pixel from the depth buffer; with
-    // the cube's depth (meters off from the visible surface), reprojection
-    // smears the surface into a translucent / negative-space ghost.
-    vec4 clip = projectionMatrix * viewMatrix * vec4(hitWorld, 1.0);
-    gl_FragDepth = (clip.z / clip.w) * 0.5 + 0.5;
+    return color;
   }
 `;
 
@@ -771,12 +667,14 @@ const quadricsExhibit: Exhibit = {
     directional.position.copy(LIGHT_DIR).multiplyScalar(5);
     scene.add(directional);
 
-    material = new THREE.ShaderMaterial({
-      vertexShader: VERTEX_SHADER,
-      fragmentShader: FRAGMENT_SHADER,
-      side: THREE.DoubleSide,
-      uniforms: {
-        uSurfaceCenter: { value: SURFACE_CENTER.clone() },
+    const surfaceHandles = createImplicitSurface({
+      surfaceCenter: SURFACE_CENTER,
+      bound: BOUND,
+      uniforms: QUADRICS_UNIFORM_DECLS,
+      helpers: QUADRICS_HELPERS,
+      fImplicit: QUADRICS_F_IMPLICIT,
+      shade: QUADRICS_SHADE,
+      extraUniforms: {
         uA: { value: 1.0 },
         uB: { value: 1.0 },
         uC: { value: 1.0 },
@@ -786,18 +684,12 @@ const quadricsExhibit: Exhibit = {
         uW: { value: 0.0 },
         uPlaneY: { value: 0.0 },
         uPlaneActive: { value: 0.0 },
-        uBound: { value: BOUND },
         uLightDir: { value: LIGHT_DIR.clone() },
         uBaseColor: { value: new THREE.Color(0.4, 0.7, 0.95) },
       },
     });
-
-    const surface = new THREE.Mesh(
-      new THREE.BoxGeometry(BOUND * 2, BOUND * 2, BOUND * 2),
-      material,
-    );
-    surface.position.copy(SURFACE_CENTER);
-    scene.add(surface);
+    material = surfaceHandles.material;
+    scene.add(surfaceHandles.mesh);
 
     // Top → bottom: a, b, c, d. Span centered on SLIDER_RACK_CENTER.
     // Per-slider color + shape pull from SLIDER_CONFIG (#58); the

--- a/src/scaffold/render/ImplicitSurface.ts
+++ b/src/scaffold/render/ImplicitSurface.ts
@@ -68,7 +68,13 @@ export interface ImplicitSurfaceOptions {
   /** GLSL `uniform` declarations the consumer's shader chunks reference. */
   uniforms: string;
 
-  /** Optional GLSL helper functions used inside `fImplicit` / `shade`. */
+  /**
+   * Optional GLSL helper functions used by `shade` and (since helpers are
+   * injected *after* `fImplicit`) optionally by a custom `gradF` too.
+   * Helpers may call `fImplicit` themselves — useful for shader-side
+   * constraint solvers or any surface-aware helper that iterates on the
+   * implicit form.
+   */
   helpers?: string;
 
   /** GLSL: must define `float fImplicit(vec3 p)`. Surface is `f = 0`. */
@@ -110,12 +116,21 @@ export interface ImplicitSurfaceOptions {
   bisect?: number;
 
   /**
-   * Consumer-supplied uniforms, merged on top of the harness's built-ins
+   * Consumer-supplied uniforms, alongside the harness's built-ins
    * (`uSurfaceCenter`, `uBound`). Names declared in `uniforms` must match
    * keys here. Object identity is preserved so the consumer can mutate
    * `material.uniforms.uFoo.value` directly.
+   *
+   * The `?: never` slots make `uSurfaceCenter` / `uBound` a compile-time
+   * error if the consumer tries to redeclare them — silent override of
+   * the harness-seeded values would otherwise drive the ray origin or
+   * AABB clip from the wrong source. Mutate `material.uniforms.uSurfaceCenter`
+   * post-construction instead.
    */
-  extraUniforms: Record<string, THREE.IUniform>;
+  extraUniforms: Record<string, THREE.IUniform> & {
+    uSurfaceCenter?: never;
+    uBound?: never;
+  };
 }
 
 export interface ImplicitSurfaceHandles {
@@ -207,9 +222,9 @@ function buildFragmentShader(t: FragmentShaderTemplate): string {
 
     varying vec3 vWorldPos;
 
-    ${t.helpers}
-
     ${t.fImplicit}
+
+    ${t.helpers}
 
     ${t.gradF}
 

--- a/src/scaffold/render/ImplicitSurface.ts
+++ b/src/scaffold/render/ImplicitSurface.ts
@@ -1,0 +1,298 @@
+import * as THREE from 'three';
+
+// Generic raymarch harness for an axis-aligned bounded implicit surface
+// f(p) = 0, in surface-local coords. Owns the parts that are stable across
+// every quadric-style scene — vertex shader, ray–AABB clip, fixed-step
+// march + sign-change bisection, the surface-local frame, and the per-
+// fragment depth write that keeps Quest's asynchronous spacewarp from
+// reprojecting the bounding cube instead of the visible surface (#67).
+//
+// Each consumer supplies the surface-specific GLSL: at minimum `fImplicit`
+// and a `shadeHit(...)` that turns a hit point + normal into a color.
+// Optional slots cover analytic gradients (skipping the central-difference
+// default), shared helper functions, and extra uniform decls. Lighting,
+// gridlines, glow bands, family-aware decoration, etc. all live in the
+// consumer's `shade` slot — this module deliberately stays out of color.
+//
+// Lifted from src/exhibits/quadrics/index.ts in #129 so the tangent-planes
+// scene (#121) can render the same implicit surface without duplicating
+// the harness.
+
+const VERTEX_SHADER = /* glsl */ `
+  varying vec3 vWorldPos;
+
+  void main() {
+    vec4 wp = modelMatrix * vec4(position, 1.0);
+    vWorldPos = wp.xyz;
+    gl_Position = projectionMatrix * viewMatrix * wp;
+  }
+`;
+
+// Default gradient: central difference with h = 0.001. Cheap and surface-
+// formula-agnostic, so the harness ships with one even when the consumer
+// has no analytic form. Consumers that *do* have an analytic gradient
+// should pass it via `gradF` — central differences amplify floating-point
+// noise on flat regions (cf. #116 on the math-Y = 0 plane), and analytic
+// is also faster (1 evaluation vs. 6).
+const CENTRAL_DIFFERENCE_GRAD = /* glsl */ `
+  vec3 gradF(vec3 p) {
+    float h = 0.001;
+    vec3 dx = vec3(h, 0.0, 0.0);
+    vec3 dy = vec3(0.0, h, 0.0);
+    vec3 dz = vec3(0.0, 0.0, h);
+    return vec3(
+      fImplicit(p + dx) - fImplicit(p - dx),
+      fImplicit(p + dy) - fImplicit(p - dy),
+      fImplicit(p + dz) - fImplicit(p - dz)
+    ) / (2.0 * h);
+  }
+`;
+
+export interface ImplicitSurfaceOptions {
+  /**
+   * World-space center of the bounding cube. The mesh is positioned here,
+   * and `uSurfaceCenter` is initialized to this value. Surface-local
+   * fragment coords are world coords minus this center, so the consumer's
+   * `fImplicit` sees a surface centered on the origin.
+   */
+  surfaceCenter: THREE.Vector3;
+
+  /**
+   * Half-extent of the AABB around the surface center, in surface-local
+   * meters. The bounding mesh is a BoxGeometry of side `2 * bound`. Rays
+   * are clipped to this cube before marching; anything `fImplicit` defines
+   * outside the cube is invisible.
+   */
+  bound: number;
+
+  /** GLSL `uniform` declarations the consumer's shader chunks reference. */
+  uniforms: string;
+
+  /** Optional GLSL helper functions used inside `fImplicit` / `shade`. */
+  helpers?: string;
+
+  /** GLSL: must define `float fImplicit(vec3 p)`. Surface is `f = 0`. */
+  fImplicit: string;
+
+  /**
+   * GLSL: must define `vec3 gradF(vec3 p)`. Defaults to central-difference
+   * around `fImplicit` with h = 0.001. Pass an analytic form to avoid
+   * gradient noise on flat regions and save the 6 extra `fImplicit` calls
+   * per fragment.
+   */
+  gradF?: string;
+
+  /**
+   * GLSL: must define
+   *   `vec3 shadeHit(vec3 pHit, vec3 n, vec3 hitWorld, vec3 rd)`
+   * `pHit` is the hit point in surface-local coords; `n` is the
+   * front-facing unit normal; `hitWorld = pHit + uSurfaceCenter`; `rd` is
+   * the view ray direction. Returns linear RGB. Owns all lighting and
+   * decoration — the harness writes the result straight to gl_FragColor.
+   */
+  shade: string;
+
+  /**
+   * Per-fragment uniform-march sample count across the AABB span, before
+   * the bisection refines a sign change to a hit. Near-linear knob on
+   * steady-state fragment cost — quadrics tuned this to 64 in #102 (was
+   * 96) after the 12 m worst-case AABB diagonal showed sub-mm bisection
+   * still resolved features. Lower is cheaper and more aliasing-prone.
+   */
+  steps?: number;
+
+  /**
+   * Bisection iteration count after a sign change is detected. 8 ⇒ ~2.7 mm
+   * worst-case precision over a 12 m span (= 12 / 2^8), well below visible
+   * pixel size at typical viewing distance. Each step is one extra
+   * `fImplicit` evaluation.
+   */
+  bisect?: number;
+
+  /**
+   * Consumer-supplied uniforms, merged on top of the harness's built-ins
+   * (`uSurfaceCenter`, `uBound`). Names declared in `uniforms` must match
+   * keys here. Object identity is preserved so the consumer can mutate
+   * `material.uniforms.uFoo.value` directly.
+   */
+  extraUniforms: Record<string, THREE.IUniform>;
+}
+
+export interface ImplicitSurfaceHandles {
+  /**
+   * The compiled ShaderMaterial. Mutate `material.uniforms.<name>.value`
+   * to drive the surface from per-frame logic.
+   */
+  material: THREE.ShaderMaterial;
+
+  /**
+   * BoxGeometry mesh sized `2 × bound` per axis, positioned at
+   * `surfaceCenter`. Caller is responsible for `scene.add(mesh)`.
+   */
+  mesh: THREE.Mesh;
+}
+
+/**
+ * Build a raymarched implicit-surface mesh + material pair.
+ *
+ * The returned mesh is pre-positioned at `surfaceCenter` and ready to add
+ * to a scene; the material exposes both the harness's `uSurfaceCenter` /
+ * `uBound` uniforms and any `extraUniforms` passed in.
+ */
+export function createImplicitSurface(
+  opts: ImplicitSurfaceOptions,
+): ImplicitSurfaceHandles {
+  const steps = opts.steps ?? 64;
+  const bisect = opts.bisect ?? 8;
+
+  const fragmentShader = buildFragmentShader({
+    uniforms: opts.uniforms,
+    helpers: opts.helpers ?? '',
+    fImplicit: opts.fImplicit,
+    gradF: opts.gradF ?? CENTRAL_DIFFERENCE_GRAD,
+    shade: opts.shade,
+    steps,
+    bisect,
+  });
+
+  const uniforms: Record<string, THREE.IUniform> = {
+    uSurfaceCenter: { value: opts.surfaceCenter.clone() },
+    uBound: { value: opts.bound },
+    ...opts.extraUniforms,
+  };
+
+  const material = new THREE.ShaderMaterial({
+    vertexShader: VERTEX_SHADER,
+    fragmentShader,
+    // Camera can sit inside the bounding cube on extreme parameter poses
+    // (or simply close to the surface center), so the mesh's back faces
+    // must rasterize too — otherwise the surface vanishes whenever the
+    // user steps inside the AABB.
+    side: THREE.DoubleSide,
+    uniforms,
+  });
+
+  const mesh = new THREE.Mesh(
+    new THREE.BoxGeometry(opts.bound * 2, opts.bound * 2, opts.bound * 2),
+    material,
+  );
+  mesh.position.copy(opts.surfaceCenter);
+
+  return { material, mesh };
+}
+
+interface FragmentShaderTemplate {
+  uniforms: string;
+  helpers: string;
+  fImplicit: string;
+  gradF: string;
+  shade: string;
+  steps: number;
+  bisect: number;
+}
+
+function buildFragmentShader(t: FragmentShaderTemplate): string {
+  return /* glsl */ `
+    precision highp float;
+
+    // Three.js auto-populates projectionMatrix on every program but only
+    // declares it in the vertex prefix; fragment shaders must declare it
+    // explicitly. (viewMatrix and cameraPosition are auto-declared.)
+    uniform mat4 projectionMatrix;
+
+    uniform vec3  uSurfaceCenter;
+    uniform float uBound;
+
+    ${t.uniforms}
+
+    varying vec3 vWorldPos;
+
+    ${t.helpers}
+
+    ${t.fImplicit}
+
+    ${t.gradF}
+
+    ${t.shade}
+
+    bool rayAABB(vec3 ro, vec3 rd, float r, out float tNear, out float tFar) {
+      vec3 invD = 1.0 / rd;
+      vec3 t0 = (vec3(-r) - ro) * invD;
+      vec3 t1 = (vec3( r) - ro) * invD;
+      vec3 tMin = min(t0, t1);
+      vec3 tMax = max(t0, t1);
+      tNear = max(max(tMin.x, tMin.y), tMin.z);
+      tFar  = min(min(tMax.x, tMax.y), tMax.z);
+      return tFar >= max(tNear, 0.0);
+    }
+
+    void main() {
+      vec3 ro = cameraPosition - uSurfaceCenter;
+      vec3 rd = normalize(vWorldPos - cameraPosition);
+
+      float tNear, tFar;
+      if (!rayAABB(ro, rd, uBound, tNear, tFar)) {
+        discard;
+      }
+      float tStart = max(tNear, 0.0);
+
+      const int STEPS = ${t.steps};
+      float dt = (tFar - tStart) / float(STEPS);
+      float t = tStart;
+      float fPrev = fImplicit(ro + rd * t);
+      bool hit = false;
+      float tHit = 0.0;
+
+      for (int i = 1; i <= STEPS; i++) {
+        float tNext = tStart + float(i) * dt;
+        float fNext = fImplicit(ro + rd * tNext);
+        if (fPrev * fNext < 0.0) {
+          float lo = t;
+          float hi = tNext;
+          float fLo = fPrev;
+          const int BISECT = ${t.bisect};
+          for (int b = 0; b < BISECT; b++) {
+            float mid = 0.5 * (lo + hi);
+            float fMid = fImplicit(ro + rd * mid);
+            if (fLo * fMid < 0.0) {
+              hi = mid;
+            } else {
+              lo = mid;
+              fLo = fMid;
+            }
+          }
+          tHit = 0.5 * (lo + hi);
+          hit = true;
+          break;
+        }
+        t = tNext;
+        fPrev = fNext;
+      }
+
+      if (!hit) {
+        discard;
+      }
+
+      vec3 pHit = ro + rd * tHit;
+      vec3 n = normalize(gradF(pHit));
+      // Front-face the normal against the view ray. The implicit surface is
+      // two-sided (we render with DoubleSide so the camera can sit inside
+      // the cube), so gradF can point either way relative to rd; lighting
+      // wants whichever side is currently visible.
+      if (dot(n, rd) > 0.0) {
+        n = -n;
+      }
+      vec3 hitWorld = pHit + uSurfaceCenter;
+
+      gl_FragColor = vec4(shadeHit(pHit, n, hitWorld, rd), 1.0);
+
+      // Write the implicit-surface depth, not the bounding cube's. Quest's
+      // asynchronous spacewarp reprojects per-pixel from the depth buffer;
+      // with the cube's depth (meters off from the visible surface), the
+      // reprojection smears the surface into a translucent / negative-space
+      // ghost.
+      vec4 clip = projectionMatrix * viewMatrix * vec4(hitWorld, 1.0);
+      gl_FragDepth = (clip.z / clip.w) * 0.5 + 0.5;
+    }
+  `;
+}


### PR DESCRIPTION
## Summary

Lifts the vertex shader, ray–AABB clip, fixed-step march + sign-change bisection, surface-local frame, and depth-write-to-projection out of `src/exhibits/quadrics/index.ts` into a new scaffold module `src/scaffold/render/ImplicitSurface.ts`.

The harness exposes a `createImplicitSurface(opts)` builder with GLSL injection slots — `uniforms`, `helpers`, `fImplicit`, optional `gradF`, `shade` — plus numeric knobs (`bound`, `steps`, `bisect`). Consumers own all lighting and decoration in `shade`; the scaffold deliberately stays out of color so each scene can ship its own visual language.

Closes #129.

## Why now

The v0.6 milestone's first scaffold pass (#120 / PR #128) lifted the UI/animation/perf primitives but left the implicit-surface raymarcher inline in quadrics. The tangent-planes scene (#121) needs the same surface, and v0.7's gradient/level-surfaces scene is the third consumer waiting. Lifting now avoids 400+ lines of duplicated GLSL across the 0.x cluster.

## What's preserved (no behavior change)

- `SURFACE_CENTER`, `BOUND = 3.5`, `STEPS = 64`, `BISECT = 8`.
- Vertex shader producing `vWorldPos` for the surface-local ray setup.
- `gl_FragDepth` write to projection — Quest async-spacewarp depth correctness from #67.
- `THREE.DoubleSide` so the camera can sit inside the AABB without the surface vanishing.
- Quadric-specific decoration (`asinhSafe`, `lineMaskAA`, `parametricGrid`, lambert + parametric/world grid switch + cross-section glow band) lives unchanged inside the new `QUADRICS_HELPERS` / `QUADRICS_SHADE` constants in `src/exhibits/quadrics/index.ts`.
- AABB hole-punch (#125) is upstream of the lift and untouched.

## Diff shape

| | before | after |
|---|---|---|
| `src/exhibits/quadrics/index.ts` | 1269 lines | 1161 lines |
| `src/scaffold/render/ImplicitSurface.ts` | — | 298 lines |

Net +190 lines, but the harness is now ready to be reused twice.

## Smoke checklist — confirmed by maintainer

Type-check (`tsc --noEmit`), Vite build, Vitest (39 passed), and ESLint all pass locally. Browser smoke confirmed by maintainer 2026-05-07: no observed behavior change.

- [x] Surface renders. No GLSL compile errors in the console.
- [x] All 8 presets (Reset, Ellipsoid, Cone, H 1-sheet, H 2-sheets, Cylinder, Paraboloid, Saddle) snap correctly with the family-morph tween.
- [x] Coefficient sliders (`a`/`b`/`c`/`d`) drive the surface.
- [x] Linear-terms section sliders (`u`/`v`/`w`) translate the surface.
- [x] Cross-sections section glow band fires only when that section is active.
- [x] Parametric grid (lat/lon on ellipsoid; u/v on hyperboloids) switches to world-axis grid on cylinders/cones/planes.
- [x] Gridline AA holds at oblique viewing angles.
- [x] AABB hole-punch (#125) still leaves the cube footprint clear.
- [x] Quest depth-write-for-spacewarp correctness — surface does not ghost / smear on head movement.

## Out of scope

- Tangent-planes scene itself — covered by #121 (lands on top of this).
- `EquationReadout` lift (quadric-specific math layout; second consumer would have a different equation form).
- Controller-dispatch lift (separate, smaller refactor; will visit if #121 needs it).
- Switching quadrics' default central-difference `gradF` to an analytic form (would address the math-Y = 0 plane fuzzy artifact in #116, but that's a behavior change and belongs in its own PR).

## References

- v0.6 milestone (#7).
- #120 / PR #128 — first scaffold extraction pass.
- #121 — tangent-planes scene (the consumer that prompted this).
- #125 / PR #126 — AABB hole-punch this PR preserves.
- #67 — original depth-write-for-spacewarp work.
- #102 — STEPS = 64 perf tune.