### PR TITLE
chore(github): add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+<!-- Thanks for the PR! Fill in the sections below, then delete these
+     comments. Repo conventions (branch naming, Conventional Commits,
+     pre-commit, headset preview) are in CONTRIBUTING.md. -->
+
+Closes #<!-- issue number; or "Refs #N" / delete this line if no linked issue -->
+
+## Summary
+
+<!-- 1–3 sentences: what changed and why. The diff shows the *what*, so
+     prioritize the *why*. -->
+
+## Test plan
+
+<!-- How a reviewer should verify this. For UI changes, the Cloudflare PR
+     preview URL (posted as a PR comment by the pr-preview workflow ~1
+     minute after push) is the primary surface — list the things to click
+     / drag / look for. For non-UI changes, list the manual or automated
+     checks that demonstrate correctness. -->
+
+- [ ]


### PR DESCRIPTION
## Summary

Three-section template (`Closes #N`, **Summary**, **Test plan**) so PR shape doesn't get re-litigated every time. Light enough not to friction a typo fix; structured enough to standardize the Cloudflare-preview smoke-test ritual `CONTRIBUTING.md` already asks for. Defers heavy conventions (branch naming, Conventional Commits, pre-commit, preview URL shape) to `CONTRIBUTING.md` rather than duplicating them.

Skipped intentionally: a "Screenshots" section (rare PRs that need them can paste into Summary or Test plan), a "Breaking changes" section (rare here; call out in Summary when it happens), and an "I ran tests / lint" checklist (CI enforces those regardless).

## Test plan

- [ ] After merge, opening a new PR auto-populates the body with the template.
- [ ] Comments render invisibly in GitHub's PR-body preview, leaving a clean three-section skeleton.