### PR TITLE
perf(quadrics): analytic gradF, drop central-difference (#131)

### DIFF
--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -579,6 +579,21 @@ const QUADRICS_F_IMPLICIT = /* glsl */ `
   }
 `;
 
+// Analytic gradient of QUADRICS_F_IMPLICIT, opting out of the harness's
+// central-difference default (#131). Closed-form for a quadratic polynomial,
+// so no extra `fImplicit` calls per fragment, and — more important —
+// constant on flat poses where central differences amplify floating-point
+// noise into the math-Y = 0 fuzzy artifact tracked in #116.
+const QUADRICS_GRAD_F = /* glsl */ `
+  vec3 gradF(vec3 p) {
+    return vec3(
+      2.0 * uA * p.x + uU,
+      2.0 * uB * p.y + uV,
+      2.0 * uC * p.z + uW
+    );
+  }
+`;
+
 const QUADRICS_SHADE = /* glsl */ `
   // Gridlines as a depth cue. Two systems, never co-rendered (#45
   // headset feedback: simultaneous display read as cluttered):
@@ -750,6 +765,7 @@ const quadricsExhibit: Exhibit = {
       uniforms: QUADRICS_UNIFORM_DECLS,
       helpers: QUADRICS_HELPERS,
       fImplicit: QUADRICS_F_IMPLICIT,
+      gradF: QUADRICS_GRAD_F,
       shade: QUADRICS_SHADE,
       extraUniforms: {
         uA: { value: 1.0 },


### PR DESCRIPTION
Closes #131
Refs #116

## Summary

Wires an analytic gradient for the quadrics implicit form into the
scaffold's optional `gradF` slot — the slot that was added in #130
specifically so consumers with a known-analytic gradient can skip the
central-difference default. Closed-form for a quadratic polynomial:

```glsl
vec3 gradF(vec3 p) {
  return vec3(
    2.0 * uA * p.x + uU,
    2.0 * uB * p.y + uV,
    2.0 * uC * p.z + uW
  );
}
```

Two wins compose. (1) Per-fragment cost: six muls + three adds vs. six
extra `fImplicit` evaluations from the default central difference.
(2) Gradient is noise-free on flat regions, which was #116's hypothesis 1.

Scaffold default behavior is unchanged — `CENTRAL_DIFFERENCE_GRAD` is
still the fallback for future implicit consumers without a clean closed
form.

## Smoke test outcome (Quest 3S)

- ✅ All 8 canonical-form presets shade correctly.
- ✅ Slider sweep through ±2 — no gradient/lighting artifacts during morph.
- ✅ No frame-rate regression; subjectively a small improvement.
- ❌ **#116 NOT resolved.** The fuzzy artifact on the math-Y = 0 edge-on
      plane persists, which **rules out hypothesis 1** (gradient noise
      from central differences). Diagnosis re-framed on #116: the root
      cause is a *tangent zero* of `f` (the function touches zero on
      the plane but never crosses), which the sign-change marcher
      fundamentally cannot detect. The visible "fuzzy plane" is
      stochastic floating-point noise in the per-fragment evaluation
      chain occasionally flipping signs on grazing rays — a real bug,
      but a separate one from the gradient. Tracked in a follow-up
      issue with three candidate fixes.

This PR ships as a perf + correctness improvement on its own merits;
tangent-zero handling is a separate, more involved change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)