### PR TITLE
feat(quadrics): add ±1.0 slider snap detents (#139)

### DIFF
--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -103,11 +103,21 @@ drags through a degeneracy.
   sphere, an ellipsoid.
 - **Continuity:** continuous (no integer snapping). Slider value is a real
   in `[−2, 2]`.
-- **Snap-to-zero detent:** when a slider's continuous position satisfies
-  `|v| < 0.05`, its reported value clamps to exactly `0`. This makes the
-  degeneracy boundary cases (cone, intersecting planes, single plane)
-  reachable precisely instead of by approximation. The detent applies only
-  at zero — no other snapping in v0.1.
+- **Snap detents:** when a slider's continuous position satisfies
+  `|v − p| < 0.05` for any detent target `p`, its reported value clamps
+  to exactly `p`. The detent set is per-slider:
+  - **Squared coefficients (`a` / `b` / `c` / `d`)** and **linear-term
+    sliders (`u` / `v` / `w`)**: `{−1, 0, +1}`. Zero makes the
+    degeneracy boundary cases (cone, intersecting planes, single
+    plane) reachable precisely; ±1 (#139) makes the textbook unit
+    poses (unit sphere, unit cone, unit hyperboloids) park on integer
+    coefficients exactly instead of approximating.
+  - **Cross-section sliders (`x₀` / `y₀` / `z₀`)**: `{0}` only. Their
+    range is wider (±2.5) and there's no canonical pose at ±1; ±1 is
+    deferred pending headset feel (#139).
+  Detents apply at rest (drag/release and constructor); programmatic
+  preset tweens use `setValueRaw` to bypass them so the thumb sweeps
+  through cleanly mid-morph.
 - **Per-slider visual:** horizontal track with a draggable thumb. Each
   slider in the rack is identified by **color** (Wong / Okabe-Ito
   colorblind-safe palette: vermillion / bluish-green / sky-blue / yellow

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -217,11 +217,30 @@ const CANONICAL_FORMS_LABEL_EXPANDED = 'Canonical forms ▾';
 const BOUND = 3.5;
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
 
-// Slider snap-to-zero detent half-width, per SPEC.md "Slider model".
-// Lets the user park exactly on a degeneracy boundary (cone, single
-// plane, etc.) instead of approximating. Passed into every
+// Slider detent half-width, per SPEC.md "Slider model". Lets the user
+// park exactly on a snap point (degeneracy boundary or canonical-form
+// coordinate) instead of approximating. Passed into every
 // scaffold/ui/Slider construction in this exhibit.
 const SLIDER_SNAP_DETENT = 0.05;
+
+// Detent positions for the squared coefficients (a/b/c/d) and the
+// linear-term sliders (u/v/w). 0 keeps every degeneracy boundary
+// reachable (cone at c = 0, cylinder at one squared coef = 0, double
+// plane at two squared coefs = 0, etc.). ±1 (#139) lets the textbook
+// unit poses — unit sphere x² + y² + z² = 1, unit cone, unit
+// hyperboloids — park on integer coefficients exactly, where without
+// the detent dragging "to roughly 1" actually parks at 0.97 / 1.04
+// and the equation readout reads as near-canonical-but-not. Spaced
+// 1.0 apart, well past 2 × SLIDER_SNAP_DETENT, so the windows don't
+// overlap.
+const SLIDER_SNAP_POINTS_CANONICAL: readonly number[] = [-1, 0, 1];
+
+// Cross-section sliders (x₀/y₀/z₀) span ±CROSS_SECTION_SLIDER_RANGE
+// (currently ±2.5) and don't hit canonical poses at ±1, so they keep
+// the single zero detent only — there's nothing pedagogically special
+// about parking the slicing plane at x₀ = 1. Pending headset feel
+// (#139), revisit if a wider integer-grid detent set earns its weight.
+const SLIDER_SNAP_POINTS_ZERO_ONLY: readonly number[] = [0];
 
 // Preset → preset family-morph tween parameters (#56). 0.9 s after a
 // headset trial of the original 0.3 s — three-times slower reads as
@@ -841,6 +860,7 @@ const quadricsExhibit: Exhibit = {
         max: 2,
         initial: 1,
         snapDetent: SLIDER_SNAP_DETENT,
+        snapPoints: SLIDER_SNAP_POINTS_CANONICAL,
         grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER,
         baseColor: cfg.color,
         thumbShape: cfg.shape,
@@ -904,6 +924,7 @@ const quadricsExhibit: Exhibit = {
         max: 2,
         initial: 0,
         snapDetent: SLIDER_SNAP_DETENT,
+        snapPoints: SLIDER_SNAP_POINTS_CANONICAL,
         grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER,
         baseColor: cfg.color,
         thumbShape: cfg.shape,
@@ -935,6 +956,7 @@ const quadricsExhibit: Exhibit = {
           max: CROSS_SECTION_SLIDER_RANGE,
           initial: 0,
           snapDetent: SLIDER_SNAP_DETENT,
+          snapPoints: SLIDER_SNAP_POINTS_ZERO_ONLY,
           grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER,
           baseColor: cfg.color,
           thumbShape: cfg.shape,

--- a/src/scaffold/ui/Slider.ts
+++ b/src/scaffold/ui/Slider.ts
@@ -16,13 +16,25 @@ export interface SliderOptions {
   min: number;
   max: number;
   initial: number;
-  // Snap-to-zero detent half-width. When the slider's continuous
-  // position satisfies |v| < snapDetent, the emitted value clamps to
-  // exactly 0. 0 disables the detent. The quadrics exhibit passes
-  // 0.05 (per its SPEC.md "Slider model") so the user can park
-  // precisely on degeneracy boundaries. Required so each scene
-  // declares the design choice rather than inheriting it implicitly.
+  // Snap-detent half-width. When the slider's continuous position
+  // satisfies `|v - p| < snapDetent` for any `p` in `snapPoints`, the
+  // emitted value clamps to exactly `p`. 0 disables snapping (or pass
+  // an empty `snapPoints`). The quadrics exhibit passes 0.05 (per its
+  // SPEC.md "Slider model") so the user can park precisely on
+  // degeneracy boundaries and canonical-form coordinates. Required so
+  // each scene declares the design choice rather than inheriting it
+  // implicitly.
   snapDetent: number;
+  // Detent target positions, paired with `snapDetent`. Common values:
+  // `[0]` for a single zero detent (degeneracy boundary parking);
+  // `[-1, 0, 1]` adds the canonical unit-form coefficients (#139) so
+  // textbook poses like the unit sphere park exactly at integer 1.
+  // Adjacent points must be at least `2 * snapDetent` apart or their
+  // capture windows will overlap. Required for the same reason as
+  // `snapDetent`: detent placement is a design-feel choice that varies
+  // by scene and slider role (e.g., cross-section sliders span ±2.5
+  // and don't hit canonical poses at ±1, so they pass `[0]` only).
+  snapPoints: readonly number[];
   // Ray–thumb hit-test sphere radius is `thumbRadius *
   // grabRadiusMultiplier`. Wider than the visual thumb makes re-grab
   // forgiving when the hand drifts off-aim during release; especially
@@ -78,11 +90,12 @@ export class Slider {
   private readonly hoverEmissive: THREE.Color;
   private readonly grabEmissive: THREE.Color;
 
-  // `rawValue` integrates hand motion every frame, untouched by the detent.
-  // `currentValue` is the emitted value — snapped to exactly 0 inside the
-  // detent — and is what `get value()` returns to the shader. Splitting the
-  // two lets slow drags accumulate underneath the detent instead of being
-  // re-pinned to 0 each frame (#24).
+  // `rawValue` integrates hand motion every frame, untouched by detents.
+  // `currentValue` is the emitted value — snapped to the nearest
+  // `snapPoints` entry inside its detent half-width — and is what
+  // `get value()` returns to the shader. Splitting the two lets slow
+  // drags accumulate underneath the detent instead of being re-pinned
+  // each frame (#24).
   private rawValue: number;
   private currentValue: number;
   private grabbedBy: THREE.Object3D | null = null;
@@ -99,8 +112,11 @@ export class Slider {
       ...options,
     };
     this.rawValue = clamp(options.initial, options.min, options.max);
-    this.currentValue =
-      Math.abs(this.rawValue) < this.opts.snapDetent ? 0 : this.rawValue;
+    this.currentValue = applySnap(
+      this.rawValue,
+      this.opts.snapPoints,
+      this.opts.snapDetent,
+    );
 
     this.group = new THREE.Group();
     this.group.name = `slider:${options.label}`;
@@ -157,8 +173,11 @@ export class Slider {
    */
   setValue(v: number): void {
     this.rawValue = clamp(v, this.opts.min, this.opts.max);
-    this.currentValue =
-      Math.abs(this.rawValue) < this.opts.snapDetent ? 0 : this.rawValue;
+    this.currentValue = applySnap(
+      this.rawValue,
+      this.opts.snapPoints,
+      this.opts.snapDetent,
+    );
     if (this.grabbedBy) {
       this.lastControllerLocalX = this.controllerLocalX(this.grabbedBy);
     }
@@ -167,11 +186,12 @@ export class Slider {
 
   /**
    * Detent-bypassing variant of `setValue`, used by programmatic tweens
-   * (#56). The detent's purpose is to let the user park *deliberately* on a
-   * degeneracy boundary; during a multi-frame morph it just creates a dead
-   * window across ±snapDetent where the thumb visibly sticks at zero. The
-   * tween caller is expected to finish with a normal `setValue` so the
-   * detent re-engages at rest.
+   * (#56). The detents' purpose is to let the user park *deliberately* on a
+   * canonical pose (degeneracy boundary, unit-form coefficient); during a
+   * multi-frame morph each detent just creates a dead window across
+   * ±snapDetent where the thumb visibly sticks. The tween caller is
+   * expected to finish with a normal `setValue` so the detents re-engage
+   * at rest.
    */
   setValueRaw(v: number): void {
     this.rawValue = clamp(v, this.opts.min, this.opts.max);
@@ -272,8 +292,11 @@ export class Slider {
       this.opts.min,
       this.opts.max,
     );
-    this.currentValue =
-      Math.abs(this.rawValue) < this.opts.snapDetent ? 0 : this.rawValue;
+    this.currentValue = applySnap(
+      this.rawValue,
+      this.opts.snapPoints,
+      this.opts.snapDetent,
+    );
     this.syncThumbPosition();
   }
 
@@ -283,15 +306,16 @@ export class Slider {
     return this.localPoint.x;
   }
 
-  // Thumb tracks `currentValue` — the emitted/shader value with the detent
-  // already applied (or bypassed, for setValueRaw). Inside the detent during
-  // a drag the thumb parks at zero so it stays aligned with what the equation
-  // readout will display (per SPEC.md "Slider model"). The slow-drag-escape
-  // behavior of #24 is preserved by `rawValue` accumulating in `update()`
-  // underneath — once raw clears ±snapDetent, currentValue tracks it again.
-  // Tween-time setValueRaw bypasses the detent so the thumb sweeps through
-  // zero rather than visibly sticking across the ±snapDetent window mid-
-  // morph (#56).
+  // Thumb tracks `currentValue` — the emitted/shader value with detents
+  // already applied (or bypassed, for setValueRaw). Inside any detent
+  // during a drag the thumb parks at that detent's snap point so it stays
+  // aligned with what the equation readout will display (per SPEC.md
+  // "Slider model"). The slow-drag-escape behavior of #24 is preserved
+  // by `rawValue` accumulating in `update()` underneath — once raw clears
+  // the ±snapDetent window around a snap point, currentValue tracks it
+  // again. Tween-time setValueRaw bypasses the detents so the thumb
+  // sweeps through them rather than visibly sticking at each one across
+  // their ±snapDetent windows mid-morph (#56).
   private syncThumbPosition(): void {
     const halfLen = this.opts.trackLength / 2;
     const t =
@@ -382,6 +406,23 @@ function buildArrowGeometry(
 
 function clamp(v: number, lo: number, hi: number): number {
   return Math.min(Math.max(v, lo), hi);
+}
+
+// Snap `v` to the first `snapPoints` entry whose distance to `v` is
+// strictly less than `halfWidth`; otherwise pass `v` through. Strict `<`
+// matches the pre-#139 single-zero detent contract. Detent windows must
+// not overlap (callers space points by at least `2 * halfWidth`); if
+// they did, the *first* matching point wins, which keeps behavior
+// deterministic but rewards keeping snap points well-separated.
+function applySnap(
+  v: number,
+  snapPoints: readonly number[],
+  halfWidth: number,
+): number {
+  for (const p of snapPoints) {
+    if (Math.abs(v - p) < halfWidth) return p;
+  }
+  return v;
 }
 
 function pulse(controller: THREE.Object3D): void {


### PR DESCRIPTION
Closes #139

## Summary

Adds ±1 detents alongside the existing 0 detent on the squared-coefficient (`a`/`b`/`c`/`d`) and linear-term (`u`/`v`/`w`) sliders so textbook unit poses — unit sphere `x² + y² + z² = 1`, unit cone, unit hyperboloids — park on integer coefficients exactly instead of approximating to 0.97 / 1.04. Implements approach (1) from the issue: extends `scaffold/ui/Slider` with a required `snapPoints: readonly number[]` option, so every scene declares its detent set explicitly per the scaffold-required-opts convention in `CLAUDE.md`.

Cross-section sliders (`x₀`/`y₀`/`z₀`) keep `[0]` only — their range is wider (±2.5) and ±1 isn't a canonical pose there. Per the issue's open question, deferred pending headset feel.

## Test plan

- [x] **Cloudflare PR preview, headset:** drag any of `a`/`b`/`c`/`d` and `u`/`v`/`w` through ±1; releasing within ±0.05 of −1, 0, or +1 parks at exactly that value (equation readout shows `1.00` not `0.97`).
- [x] Cross-section sliders (`x₀`/`y₀`/`z₀`): verify they still snap to 0 only — no detent at ±1.
- [x] Slow drag from inside ±0.05 of a snap point still escapes the detent (the #24 slow-drag-escape behavior is preserved across all snap points, not just zero).
- [ ] Preset tween morphs (`setValueRaw`) sweep cleanly through 0 and ±1 mid-morph without sticking — pick a preset that crosses an integer (e.g. ellipsoid → cone, unit poses among the 8 presets).
- [x] `npm run build` (tsc + vite) passes.
- [x] `npm test` (96 tests) passes.
- [x] `npm run lint` clean.