### PR TITLE
docs(claude): note Cloudflare PR preview as the headset smoke surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,19 @@ deployment from `main` via `.github/workflows/pages.yml`.
 When adding a new scene, see `CONTRIBUTING.md` → "Adding a new exhibit"
 and lean on `src/scaffold/` rather than copying from quadrics.
 
+## Headset smoke-testing
+
+Every PR gets an auto-deployed Cloudflare Worker preview URL
+(commented on the PR ~1 min after push). **Headset smoke-testing
+happens there, not against `npm run dev` / localhost** — a Quest
+on the network can't reach a laptop's dev server without extra
+tunneling setup. So when a change needs in-headset eyes, the
+Cloudflare PR preview is the surface; don't suggest "open
+localhost in the Quest browser." Full details — fork-PR caveat,
+production URL, network setup pointer — in
+[`CONTRIBUTING.md`](CONTRIBUTING.md) → "Previewing changes in a
+headset."
+
 ## Repo conventions
 
 - **Public OSS repo, MIT-licensed, copyright Skyline Trail Computing


### PR DESCRIPTION
## Summary

Short blurb in `CLAUDE.md` so future Claude Code sessions don't relitigate "open localhost in the Quest browser" — a Quest on the LAN can't reach a laptop's dev server without extra tunneling setup. `CONTRIBUTING.md` already has the full section; this is the auto-loaded pointer to it.

## Test plan

- [x] `gitleaks` / pre-commit clean.
- [ ] Reviewer eyes — confirm the framing matches your intent ("Cloudflare PR preview is the surface, not localhost"), and that referring out to `CONTRIBUTING.md` for detail is the right shape.