### PR TITLE
refactor: add dispose() to five quadrics primitives (#150 step 1)

### DIFF
--- a/src/exhibits/quadrics/AxisToggle.ts
+++ b/src/exhibits/quadrics/AxisToggle.ts
@@ -102,6 +102,11 @@ export class AxisToggle {
     return this.enabled;
   }
 
+  dispose(): void {
+    this.mesh.geometry.dispose();
+    (this.mesh.material as THREE.Material).dispose();
+  }
+
   /**
    * Test whether `controller`'s forward ray hits the toggle. On hit, flip
    * enabled, fire haptics + press flash, and return true. The caller

--- a/src/exhibits/quadrics/DoublePlane.ts
+++ b/src/exhibits/quadrics/DoublePlane.ts
@@ -155,6 +155,13 @@ export interface DoublePlaneHandles {
    * the caller passes the predicate's result through unchanged.
    */
   setPose(pose: PlanePose | null): void;
+
+  /**
+   * Dispose the shared plane geometry + shader material. Call once
+   * when the owning exhibit is unmounted; the two sibling meshes share
+   * a single geometry/material pair, so each is disposed exactly once.
+   */
+  dispose(): void;
 }
 
 /**
@@ -236,6 +243,10 @@ export function createDoublePlane(opts: DoublePlaneOptions): DoublePlaneHandles 
           meshes[i].visible = false;
         }
       }
+    },
+    dispose(): void {
+      geometry.dispose();
+      material.dispose();
     },
   };
 }

--- a/src/exhibits/quadrics/SlicingPlane.ts
+++ b/src/exhibits/quadrics/SlicingPlane.ts
@@ -144,6 +144,13 @@ export interface SlicingPlanesHandles {
    * per-axis state.
    */
   setVisibility(x: boolean, y: boolean, z: boolean): void;
+
+  /**
+   * Dispose each per-axis plane's PlaneGeometry + ShaderMaterial.
+   * Geometries and materials are not shared across axes (each plane is
+   * built by its own `buildPlaneMesh` call), so iterate all three.
+   */
+  dispose(): void;
 }
 
 /**
@@ -201,6 +208,12 @@ export function createSlicingPlanes(
       xPlane.visible = x;
       yPlane.visible = y;
       zPlane.visible = z;
+    },
+    dispose(): void {
+      for (const mesh of [xPlane, yPlane, zPlane]) {
+        mesh.geometry.dispose();
+        (mesh.material as THREE.Material).dispose();
+      }
     },
   };
 }

--- a/src/scaffold/ui/Section.ts
+++ b/src/scaffold/ui/Section.ts
@@ -47,4 +47,12 @@ export class Section {
     this.active = active;
     for (const s of this.sliders) s.group.visible = active;
   }
+
+  // Section is a pure container — the exhibit owns the underlying
+  // Slider instances and disposes them directly. Implemented for
+  // contract parity with the rest of `scaffold/ui/` so callers can
+  // treat any owned primitive uniformly during exhibit unmount.
+  dispose(): void {
+    // intentionally empty
+  }
 }

--- a/src/scaffold/ui/Slider.ts
+++ b/src/scaffold/ui/Slider.ts
@@ -164,6 +164,13 @@ export class Slider {
     return this.grabbedBy !== null;
   }
 
+  dispose(): void {
+    this.track.geometry.dispose();
+    (this.track.material as THREE.Material).dispose();
+    this.thumb.geometry.dispose();
+    (this.thumb.material as THREE.Material).dispose();
+  }
+
   /**
    * Programmatically set the value (e.g. from a preset, #46). Snaps the raw
    * accumulator and applies the zero detent identically to a drag tick, then


### PR DESCRIPTION
Refs #150.

## Summary

Adds `dispose()` to the five `scaffold/ui` and `exhibits/quadrics`
primitives that lacked one, as identified by the v3 plan's §3.4 audit:
`Slider`, `Section`, `AxisToggle`, `DoublePlaneHandles`,
`SlicingPlanesHandles`. Each landed as its own commit per the plan's
"five small commits" sequencing. Pure additions with no consumers
yet — needed before #150 step 4's quadrics rename can implement
`unmount()` per the §3.5 audit checklist without leaking GPU
resources on exhibit switch.

`Section.dispose()` is intentionally empty (Section is a pure
container; the exhibit owns the underlying Slider instances and
disposes them directly). The other four release the geometries +
materials they own, with `DoublePlane`'s shared geometry+material
disposed once across both sibling meshes and `SlicingPlane`'s three
per-axis pairs each disposed independently.

## Test plan

- [x] `npm test` (vitest, 96 passing) clean after each commit.
- [x] `npm run build` (`tsc --noEmit && vite build`) clean after each commit.
- [x] `npm run lint` clean.
- [x] Cloudflare PR preview boots and the quadrics exhibit looks
      identical to `main` — no behavioral change expected since
      nothing calls these new methods yet.