### PR TITLE
refactor(shell): widen Exhibit contract for shell-owned dispatch (#150 step 4)

### DIFF
--- a/src/exhibits/hello/index.ts
+++ b/src/exhibits/hello/index.ts
@@ -3,30 +3,35 @@ import type { Exhibit, ExhibitContext } from '../../shell/Exhibit';
 import { registerExhibit } from '../../shell/registry';
 
 let cube: THREE.Mesh | undefined;
+let floor: THREE.Mesh | undefined;
 
 const helloExhibit: Exhibit = {
   id: 'hello',
   title: 'Hello — toolchain smoke test',
 
-  mount({ scene }: ExhibitContext) {
-    const floor = new THREE.Mesh(
+  // Hello is intentionally cluster-less (#150): it's a toolchain smoke
+  // test, not a cluster member. The SceneRack filters it out; it remains
+  // reachable via direct `import` in dev branches.
+
+  mount({ group }: ExhibitContext) {
+    floor = new THREE.Mesh(
       new THREE.PlaneGeometry(10, 10),
       new THREE.MeshStandardMaterial({ color: 0x222244 }),
     );
     floor.rotation.x = -Math.PI / 2;
-    scene.add(floor);
+    group.add(floor);
 
     cube = new THREE.Mesh(
       new THREE.BoxGeometry(0.3, 0.3, 0.3),
       new THREE.MeshStandardMaterial({ color: 0x66ccff }),
     );
     cube.position.set(0, 1.6, -1);
-    scene.add(cube);
+    group.add(cube);
 
-    scene.add(new THREE.AmbientLight(0xffffff, 0.4));
+    group.add(new THREE.AmbientLight(0xffffff, 0.4));
     const directional = new THREE.DirectionalLight(0xffffff, 0.8);
     directional.position.set(5, 5, 5);
-    scene.add(directional);
+    group.add(directional);
   },
 
   update() {
@@ -34,6 +39,30 @@ const helloExhibit: Exhibit = {
       cube.rotation.x += 0.005;
       cube.rotation.y += 0.005;
     }
+  },
+
+  unmount() {
+    // Lights have no GPU resources to dispose; they're removed when the
+    // shell drops the per-exhibit group. Cube + floor allocate geometry
+    // and material that need explicit dispose() to free the GPU buffers.
+    if (cube) {
+      cube.geometry.dispose();
+      (cube.material as THREE.Material).dispose();
+      cube = undefined;
+    }
+    if (floor) {
+      floor.geometry.dispose();
+      (floor.material as THREE.Material).dispose();
+      floor = undefined;
+    }
+  },
+
+  onSelectStart() {
+    // Hello has no interactive controls.
+  },
+
+  onSelectEnd() {
+    // Hello has no interactive controls.
   },
 };
 

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import type { Exhibit, ExhibitContext } from '../../shell/Exhibit';
+import { CLUSTER_CALCULUS3 } from '../../shell/clusters';
 import { registerExhibit } from '../../shell/registry';
 import {
   BLUISH_GREEN,
@@ -737,7 +738,11 @@ let activeSectionIndex = 0;
 // flips the flag and shows / hides the row.
 let canonicalFormsHeading: SectionTab | undefined;
 let presetsExpanded = false;
-let controllers: THREE.Object3D[] = [];
+// Cached reference to the shell-owned controllers (#150). Repopulated on
+// each `mount` from `ctx.controllers`; cleared on `unmount`. The shell
+// registers the controller event listeners; this exhibit only reads the
+// array for hover ticking and during `onSelectStart` / `onSelectEnd`.
+let controllers: readonly THREE.Object3D[] = [];
 let rackLabel: Label | undefined;
 let equationReadout: EquationReadout | undefined;
 let fpsOverlay: FpsOverlay | undefined;
@@ -750,12 +755,38 @@ let elapsed = 0;
 // the thumb. Module-scoped so update() can tick it.
 let presetTween: PresetTween | undefined;
 
+// Resource-tracking arrays + named handles for `unmount` (#150 step 4 per
+// `_private/plans/150-cluster-navigation.md` §3.5). The audit table in §3.5
+// names every let in this module and its disposal owner.
+//
+// Ownership rule: each resource has exactly one disposal owner. Named
+// handles (`material`, `surfaceMesh.geometry`, `doublePlane`, `slicingPlanes`,
+// `floorMaterial`) are NEVER pushed into the generic `ownedDisposables` /
+// `ownedGeometries` / `ownedMaterials` arrays — they're disposed via the
+// dedicated named-handle block in `unmount`. The generic arrays are
+// reserved for resources whose lifecycle is otherwise unmanaged: scaffold
+// primitives that expose `dispose()` (Sliders, Presets, Sections, etc.)
+// flow through `ownedDisposables`; anonymous geometries or materials
+// allocated inline flow through the corresponding `*Geometries` /
+// `*Materials` arrays. `floorMaterial` + `floorGeometries` have their own
+// dedicated handles (one shared material across all strips, one geometry
+// per strip) and are disposed by the named-handle block, not via
+// `ownedMaterials` / `ownedGeometries`.
+let ownedDisposables: Array<{ dispose(): void }> = [];
+let ownedGeometries: THREE.BufferGeometry[] = [];
+let ownedMaterials: THREE.Material[] = [];
+let cleanupCallbacks: Array<() => void> = [];
+let floorMaterial: THREE.MeshStandardMaterial | undefined;
+let floorGeometries: THREE.PlaneGeometry[] = [];
+
 const quadricsExhibit: Exhibit = {
   id: 'quadrics',
   title: 'Quadric surfaces',
+  cluster: CLUSTER_CALCULUS3,
 
-  mount({ scene, renderer, camera: cam }: ExhibitContext) {
+  mount({ group, renderer, camera: cam, controllers: shellControllers }: ExhibitContext) {
     camera = cam;
+    controllers = shellControllers;
 
     // #125: hole-punch the floor inside the AABB's world-XZ footprint so it
     // doesn't occlude the lower half of the cube. Math-Z routes to world-Y;
@@ -765,7 +796,7 @@ const quadricsExhibit: Exhibit = {
     // hyperboloids whose axis is math-Z). Strips outside the cube footprint
     // preserve the ground reference; the rectangle inside is left open.
     const FLOOR_HALF = 5;
-    const floorMaterial = new THREE.MeshStandardMaterial({ color: 0x222244 });
+    floorMaterial = new THREE.MeshStandardMaterial({ color: 0x222244 });
     const holeMinX = Math.max(SURFACE_CENTER.x - BOUND, -FLOOR_HALF);
     const holeMaxX = Math.min(SURFACE_CENTER.x + BOUND, FLOOR_HALF);
     const holeMinZ = Math.max(SURFACE_CENTER.z - BOUND, -FLOOR_HALF);
@@ -777,23 +808,25 @@ const quadricsExhibit: Exhibit = {
       zMax: number,
     ): void => {
       if (xMax <= xMin || zMax <= zMin) return;
-      const strip = new THREE.Mesh(
-        new THREE.PlaneGeometry(xMax - xMin, zMax - zMin),
-        floorMaterial,
-      );
+      const stripGeometry = new THREE.PlaneGeometry(xMax - xMin, zMax - zMin);
+      // Push to module-scoped `floorGeometries` so unmount can dispose
+      // each strip's geometry. The shared `floorMaterial` is the named
+      // handle — disposed once, regardless of strip count (#150 §3.5).
+      floorGeometries.push(stripGeometry);
+      const strip = new THREE.Mesh(stripGeometry, floorMaterial!);
       strip.rotation.x = -Math.PI / 2;
       strip.position.set((xMin + xMax) / 2, 0, (zMin + zMax) / 2);
-      scene.add(strip);
+      group.add(strip);
     };
     addFloorStrip(-FLOOR_HALF, FLOOR_HALF, holeMaxZ, FLOOR_HALF); // front of cube
     addFloorStrip(-FLOOR_HALF, FLOOR_HALF, -FLOOR_HALF, holeMinZ); // behind cube
     addFloorStrip(-FLOOR_HALF, holeMinX, holeMinZ, holeMaxZ); // left of cube
     addFloorStrip(holeMaxX, FLOOR_HALF, holeMinZ, holeMaxZ); // right of cube
 
-    scene.add(new THREE.AmbientLight(0xffffff, 0.4));
+    group.add(new THREE.AmbientLight(0xffffff, 0.4));
     const directional = new THREE.DirectionalLight(0xffffff, 0.8);
     directional.position.copy(LIGHT_DIR).multiplyScalar(5);
-    scene.add(directional);
+    group.add(directional);
 
     const surfaceHandles = createImplicitSurface({
       surfaceCenter: SURFACE_CENTER,
@@ -824,7 +857,7 @@ const quadricsExhibit: Exhibit = {
     });
     material = surfaceHandles.material;
     surfaceMesh = surfaceHandles.mesh;
-    scene.add(surfaceHandles.mesh);
+    group.add(surfaceHandles.mesh);
 
     // Double-plane stand-in mesh (#138). Hidden by default; update()
     // toggles visibility against the raymarched mesh based on the
@@ -838,7 +871,7 @@ const quadricsExhibit: Exhibit = {
       baseColor: new THREE.Color(0.4, 0.7, 0.95),
       lightDir: LIGHT_DIR,
     });
-    scene.add(doublePlane.group);
+    group.add(doublePlane.group);
 
     // Top → bottom: a, b, c, d. Span centered on SLIDER_RACK_CENTER.
     // Per-slider color + shape pull from SLIDER_CONFIG (#58); the
@@ -870,7 +903,7 @@ const quadricsExhibit: Exhibit = {
         topY - i * SLIDER_ROW_PITCH,
         SLIDER_RACK_CENTER.z,
       );
-      scene.add(slider.group);
+      group.add(slider.group);
       return slider;
     });
     // `sliders` is the math-routing array [a, b, c, d] and feeds the
@@ -896,7 +929,7 @@ const quadricsExhibit: Exhibit = {
         SLIDER_RACK_CENTER.z,
       );
       preset.group.visible = false;
-      scene.add(preset.group);
+      group.add(preset.group);
       return preset;
     });
 
@@ -934,7 +967,7 @@ const quadricsExhibit: Exhibit = {
         linearTopY - i * SLIDER_ROW_PITCH,
         SLIDER_RACK_CENTER.z,
       );
-      scene.add(slider.group);
+      group.add(slider.group);
       return slider;
     });
     linearSliders = linearTermSliders;
@@ -966,7 +999,7 @@ const quadricsExhibit: Exhibit = {
           crossSectionTopY - i * SLIDER_ROW_PITCH,
           SLIDER_RACK_CENTER.z,
         );
-        scene.add(slider.group);
+        group.add(slider.group);
         return slider;
       },
     );
@@ -1003,7 +1036,7 @@ const quadricsExhibit: Exhibit = {
       halfExtent: BOUND,
     });
     slicingPlanes.group.visible = false;
-    scene.add(slicingPlanes.group);
+    group.add(slicingPlanes.group);
 
     // Three sections (#88, #84). The dispatch loop below reads from
     // `sections[activeSectionIndex]` for grab dispatch and per-section
@@ -1054,7 +1087,7 @@ const quadricsExhibit: Exhibit = {
         SECTION_TAB_RACK_TOP_Y - (i + 1) * SECTION_TAB_RACK_PITCH,
         SLIDER_RACK_CENTER.z,
       );
-      scene.add(tab.group);
+      group.add(tab.group);
       return tab;
     });
     tabs[activeSectionIndex].setActive(true);
@@ -1075,9 +1108,7 @@ const quadricsExhibit: Exhibit = {
       SLIDER_RACK_CENTER.z,
     );
     canonicalFormsHeading.setActive(presetsExpanded);
-    scene.add(canonicalFormsHeading.group);
-
-    controllers = setupControllers(scene, renderer);
+    group.add(canonicalFormsHeading.group);
 
     // Family classifier readout sits at the top of the stack above the
     // rack. The live equation readout (#58) carries the four coefficient
@@ -1085,17 +1116,17 @@ const quadricsExhibit: Exhibit = {
     // used to live left of each track.
     rackLabel = new Label({ primaryFontSize: RACK_LABEL_PRIMARY_FONT_SIZE });
     rackLabel.group.position.copy(RACK_LABEL_POSITION);
-    scene.add(rackLabel.group);
+    group.add(rackLabel.group);
 
     equationReadout = new EquationReadout({
       coefficientColors: EQUATION_COEFFICIENT_COLORS,
     });
     equationReadout.group.position.copy(EQUATION_READOUT_POSITION);
-    scene.add(equationReadout.group);
+    group.add(equationReadout.group);
 
     worldAxes = new WorldAxes({ axisColors: AXIS_COLORS });
     worldAxes.group.position.copy(AXIS_INDICATOR_POSITION);
-    scene.add(worldAxes.group);
+    group.add(worldAxes.group);
 
     // Optional in-VR FPS readout (#99) + console renderer.info dump
     // (#102). Both off by default; opt-in via a `?fps=1` query string
@@ -1105,9 +1136,30 @@ const quadricsExhibit: Exhibit = {
     if (isFpsOverlayEnabled()) {
       fpsOverlay = new FpsOverlay();
       fpsOverlay.group.position.copy(FPS_OVERLAY_POSITION);
-      scene.add(fpsOverlay.group);
+      group.add(fpsOverlay.group);
       rendererInfoProbe = new RendererInfoProbe(renderer);
     }
+
+    // Register owned scaffold primitives for unmount disposal (#150 §3.5).
+    // Per the ownership rule: only primitives go into `ownedDisposables`;
+    // the named handles (material, surfaceMesh.geometry, doublePlane,
+    // slicingPlanes, floorMaterial, floorGeometries) are disposed by the
+    // dedicated named-handle block in `unmount`. dSlider aliases sliders[3],
+    // so it's already covered by `...sliders`.
+    ownedDisposables.push(
+      ...sliders,
+      ...linearSliders,
+      ...crossSectionSliders,
+      ...crossSectionToggles,
+      ...presets,
+      ...sections,
+      ...tabs,
+    );
+    if (canonicalFormsHeading) ownedDisposables.push(canonicalFormsHeading);
+    if (rackLabel) ownedDisposables.push(rackLabel);
+    if (equationReadout) ownedDisposables.push(equationReadout);
+    if (worldAxes) ownedDisposables.push(worldAxes);
+    if (fpsOverlay) ownedDisposables.push(fpsOverlay);
   },
 
   update({ delta }) {
@@ -1291,164 +1343,205 @@ const quadricsExhibit: Exhibit = {
     }
     if (rendererInfoProbe) rendererInfoProbe.update(performance.now());
   },
+
+  unmount({}: ExhibitContext): void {
+    // Resource teardown audit: see `_private/plans/150-cluster-navigation.md`
+    // §3.5. Each module-scoped `let` declared above appears here, either
+    // disposed via the generic-array drain or the named-handle block, then
+    // reset to its initial value so a future re-mount allocates fresh.
+
+    // 1. Run any deferred cleanup callbacks. None today; the array is
+    // populated by features that need to register listeners / timers /
+    // RAFs against external surfaces (none of which quadrics has after
+    // step 4 — the shell owns the controllers, the window resize listener
+    // is shell-lifetime).
+    for (const cb of cleanupCallbacks) cb();
+    cleanupCallbacks = [];
+
+    // 2. Generic disposable arrays (per §3.5 ownership rule: anonymous
+    // resources only — named handles are NOT in here).
+    for (const d of ownedDisposables) d.dispose();
+    ownedDisposables = [];
+    for (const g of ownedGeometries) g.dispose();
+    ownedGeometries = [];
+    for (const m of ownedMaterials) m.dispose();
+    ownedMaterials = [];
+
+    // 3. Named handles — disposed directly, each guarded so a double
+    // unmount is safe (DeepSeek #5 / v3-roundtable).
+    if (floorMaterial) {
+      floorMaterial.dispose();
+      floorMaterial = undefined;
+    }
+    for (const g of floorGeometries) g.dispose();
+    floorGeometries = [];
+    if (material) {
+      material.dispose();
+      material = undefined;
+    }
+    if (surfaceMesh?.geometry) surfaceMesh.geometry.dispose();
+    if (doublePlane) {
+      doublePlane.dispose();
+      doublePlane = undefined;
+    }
+    if (slicingPlanes) {
+      slicingPlanes.dispose();
+      slicingPlanes = undefined;
+    }
+
+    // 4. Reset every other module-scoped `let` so re-mount allocates
+    // fresh. Order mirrors the declaration order at the top of this file.
+    sliders = [];
+    dSlider = undefined;
+    linearSliders = [];
+    crossSectionSliders = [];
+    crossSectionToggles = [];
+    surfaceMesh = undefined;
+    presets = [];
+    sections = [];
+    tabs = [];
+    activeSectionIndex = 0;
+    canonicalFormsHeading = undefined;
+    presetsExpanded = false;
+    // The shell owns the actual controllers; we just clear the local
+    // cache. Re-mount populates from `ctx.controllers`.
+    controllers = [];
+    rackLabel = undefined;
+    equationReadout = undefined;
+    fpsOverlay = undefined;
+    // RendererInfoProbe holds a renderer reference for read-only stats —
+    // no GPU resources to dispose. Reset to undefined so re-mount's
+    // `if (isFpsOverlayEnabled())` conditional allocates fresh.
+    rendererInfoProbe = undefined;
+    worldAxes = undefined;
+    camera = undefined;
+    elapsed = 0;
+    presetTween = undefined;
+  },
+
+  onSelectStart(controller: THREE.Object3D): void {
+    // Dispatch in z-order from rack-local outward: active section's
+    // sliders first (the warm drag affordance), then the global preset
+    // row (only when expanded), then the section tabs and canonical-
+    // forms heading. These regions are spatially disjoint but the
+    // explicit ordering keeps the first-hit-wins contract well-defined
+    // regardless of layout.
+    const activeSection = sections[activeSectionIndex];
+    if (!activeSection) return;
+    // Per-axis toggles (#134) dispatch *before* the section's sliders
+    // so the toggle stays reachable at thumb-extreme. At default and
+    // near-default thumb values the toggle's grab sphere is disjoint
+    // from the slider's, so order doesn't change behavior. At the
+    // slider's leftmost extreme the two grab spheres overlap by 0.032 m
+    // — a ray aimed at the visible thumb still hits only the slider
+    // (the toggle's sphere doesn't extend that far), but a ray aimed
+    // at the visible toggle hits both. Toggle-first dispatch picks
+    // the toggle in that overlap, preserving both intents; slider-
+    // first would silently steal toggle taps when the slider is
+    // parked at its extreme. Only fires when Cross sections is
+    // focused — toggles belong to that section.
+    if (activeSection.name === CROSS_SECTION_SECTION_NAME) {
+      for (const t of crossSectionToggles) {
+        if (t.tryToggle(controller)) return;
+      }
+    }
+    for (const s of activeSection.sliders) {
+      if (s.tryGrab(controller)) {
+        // Cancel any in-flight preset tween — the user is taking the
+        // wheel, and a still-ticking tween would fight the drag (#56,
+        // "interrupt" interaction policy).
+        presetTween?.cancel();
+        presetTween = undefined;
+        return;
+      }
+    }
+    // Slider `d` is shared across Squared and Linear (#140) and lives
+    // outside the active section's sliders array, so it gets its own
+    // grab pass after the section's sliders. Skipped in Cross sections
+    // — `d` is hidden there and shouldn't be silently grabbable.
+    if (
+      dSlider !== undefined &&
+      activeSection.name !== CROSS_SECTION_SECTION_NAME &&
+      dSlider.tryGrab(controller)
+    ) {
+      presetTween?.cancel();
+      presetTween = undefined;
+      return;
+    }
+    if (presetsExpanded) for (const p of presets) {
+      if (p.tryActivate(controller)) {
+        // Preset values are coefficient-frame [a, b, c, d] regardless
+        // of the active section (#93): the preset row is global, so
+        // pressing a preset always drives the coefficient rack toward
+        // the named canonical pose. Animate from the rack's current
+        // values to the preset (#56) instead of snapping — makes the
+        // family transition itself visible. The previous tween, if
+        // any, is replaced; its ticked-state on the sliders is the
+        // new tween's start.
+        //
+        // Presets also drive the linear-terms rack (#92): for centered
+        // canonical poses (Sphere / Reset / Cone / cylinders / hyperb-
+        // oloids …) the target is (0, 0, 0) because the surface is
+        // only canonical if it's centered. Paraboloid / Saddle break
+        // that pattern: their canonical form *requires* a linear
+        // coefficient (z = x² + y² needs w = -1), so the preset
+        // declares a non-zero linearValues target which the tween
+        // honors verbatim. Either way, both racks tween together —
+        // a single cancel() on mid-drag interrupt drops both at once.
+        const currentValues: PresetValues = [
+          sliders[0].value,
+          sliders[1].value,
+          sliders[2].value,
+          sliders[3].value,
+        ];
+        const linearStart = linearSliders.map((s) => s.value);
+        const linearTarget: readonly number[] = p.linearValues;
+        presetTween?.cancel();
+        presetTween = new PresetTween({
+          start: currentValues,
+          target: p.values,
+          sliders,
+          nowMs: performance.now(),
+          durationMs: PRESET_TWEEN_DURATION_MS,
+          easing: easeInOutCubic,
+          secondary: {
+            start: linearStart,
+            target: linearTarget,
+            sliders: linearSliders,
+          },
+        });
+        return;
+      }
+    }
+    for (let i = 0; i < tabs.length; i++) {
+      if (tabs[i].tryActivate(controller)) {
+        switchToSection(i);
+        return;
+      }
+    }
+    if (canonicalFormsHeading?.tryActivate(controller)) {
+      togglePresetsExpanded();
+      return;
+    }
+  },
+
+  onSelectEnd(controller: THREE.Object3D): void {
+    // Release sliders across all sections — releasing a slider that
+    // isn't grabbed is a no-op, and an active grab can only ever live
+    // in the section that was active at grab time, so a switch
+    // mid-drag (which the dispatch above prevents anyway) wouldn't
+    // strand a held slider.
+    for (const section of sections) {
+      for (const s of section.sliders) s.releaseFromController(controller);
+    }
+    // `d` lives outside any section (#140); release it explicitly.
+    dSlider?.releaseFromController(controller);
+  },
 };
 
 function isFpsOverlayEnabled(): boolean {
   if (typeof window === 'undefined') return false;
   return new URLSearchParams(window.location.search).get('fps') === '1';
-}
-
-function setupControllers(
-  scene: THREE.Scene,
-  renderer: THREE.WebGLRenderer,
-): THREE.Object3D[] {
-  // Visible 1 m laser line along controller −Z, so the user can see where
-  // they're aiming before pressing the trigger.
-  const rayGeom = new THREE.BufferGeometry().setFromPoints([
-    new THREE.Vector3(0, 0, 0),
-    new THREE.Vector3(0, 0, -1),
-  ]);
-  const rayMat = new THREE.LineBasicMaterial({
-    color: 0xffffff,
-    transparent: true,
-    opacity: 0.6,
-  });
-
-  const out: THREE.Object3D[] = [];
-  for (const i of [0, 1] as const) {
-    const controller = renderer.xr.getController(i);
-    controller.add(new THREE.Line(rayGeom, rayMat));
-    scene.add(controller);
-    out.push(controller);
-
-    controller.addEventListener('connected', (event: { data: XRInputSource }) => {
-      const inputSource = event.data;
-      if (inputSource.gamepad) {
-        controller.userData.gamepad = inputSource.gamepad;
-      }
-    });
-    controller.addEventListener('disconnected', () => {
-      delete controller.userData.gamepad;
-    });
-
-    controller.addEventListener('selectstart', () => {
-      // Dispatch in z-order from rack-local outward: active section's
-      // sliders first (the warm drag affordance), then the global preset
-      // row (only when expanded), then the section tabs and canonical-
-      // forms heading. These regions are spatially disjoint but the
-      // explicit ordering keeps the first-hit-wins contract well-defined
-      // regardless of layout.
-      const activeSection = sections[activeSectionIndex];
-      // Per-axis toggles (#134) dispatch *before* the section's sliders
-      // so the toggle stays reachable at thumb-extreme. At default and
-      // near-default thumb values the toggle's grab sphere is disjoint
-      // from the slider's, so order doesn't change behavior. At the
-      // slider's leftmost extreme the two grab spheres overlap by 0.032 m
-      // — a ray aimed at the visible thumb still hits only the slider
-      // (the toggle's sphere doesn't extend that far), but a ray aimed
-      // at the visible toggle hits both. Toggle-first dispatch picks
-      // the toggle in that overlap, preserving both intents; slider-
-      // first would silently steal toggle taps when the slider is
-      // parked at its extreme. Only fires when Cross sections is
-      // focused — toggles belong to that section.
-      if (activeSection.name === CROSS_SECTION_SECTION_NAME) {
-        for (const t of crossSectionToggles) {
-          if (t.tryToggle(controller)) return;
-        }
-      }
-      for (const s of activeSection.sliders) {
-        if (s.tryGrab(controller)) {
-          // Cancel any in-flight preset tween — the user is taking the
-          // wheel, and a still-ticking tween would fight the drag (#56,
-          // "interrupt" interaction policy).
-          presetTween?.cancel();
-          presetTween = undefined;
-          return;
-        }
-      }
-      // Slider `d` is shared across Squared and Linear (#140) and lives
-      // outside the active section's sliders array, so it gets its own
-      // grab pass after the section's sliders. Skipped in Cross sections
-      // — `d` is hidden there and shouldn't be silently grabbable.
-      if (
-        dSlider !== undefined &&
-        activeSection.name !== CROSS_SECTION_SECTION_NAME &&
-        dSlider.tryGrab(controller)
-      ) {
-        presetTween?.cancel();
-        presetTween = undefined;
-        return;
-      }
-      if (presetsExpanded) for (const p of presets) {
-        if (p.tryActivate(controller)) {
-          // Preset values are coefficient-frame [a, b, c, d] regardless
-          // of the active section (#93): the preset row is global, so
-          // pressing a preset always drives the coefficient rack toward
-          // the named canonical pose. Animate from the rack's current
-          // values to the preset (#56) instead of snapping — makes the
-          // family transition itself visible. The previous tween, if
-          // any, is replaced; its ticked-state on the sliders is the
-          // new tween's start.
-          //
-          // Presets also drive the linear-terms rack (#92): for centered
-          // canonical poses (Sphere / Reset / Cone / cylinders / hyperb-
-          // oloids …) the target is (0, 0, 0) because the surface is
-          // only canonical if it's centered. Paraboloid / Saddle break
-          // that pattern: their canonical form *requires* a linear
-          // coefficient (z = x² + y² needs w = -1), so the preset
-          // declares a non-zero linearValues target which the tween
-          // honors verbatim. Either way, both racks tween together —
-          // a single cancel() on mid-drag interrupt drops both at once.
-          const currentValues: PresetValues = [
-            sliders[0].value,
-            sliders[1].value,
-            sliders[2].value,
-            sliders[3].value,
-          ];
-          const linearStart = linearSliders.map((s) => s.value);
-          const linearTarget: readonly number[] = p.linearValues;
-          presetTween?.cancel();
-          presetTween = new PresetTween({
-            start: currentValues,
-            target: p.values,
-            sliders,
-            nowMs: performance.now(),
-            durationMs: PRESET_TWEEN_DURATION_MS,
-            easing: easeInOutCubic,
-            secondary: {
-              start: linearStart,
-              target: linearTarget,
-              sliders: linearSliders,
-            },
-          });
-          return;
-        }
-      }
-      for (let i = 0; i < tabs.length; i++) {
-        if (tabs[i].tryActivate(controller)) {
-          switchToSection(i);
-          return;
-        }
-      }
-      if (canonicalFormsHeading?.tryActivate(controller)) {
-        togglePresetsExpanded();
-        return;
-      }
-    });
-    controller.addEventListener('selectend', () => {
-      // Release sliders across all sections — releasing a slider that
-      // isn't grabbed is a no-op, and an active grab can only ever live
-      // in the section that was active at grab time, so a switch
-      // mid-drag (which the dispatch above prevents anyway) wouldn't
-      // strand a held slider.
-      for (const section of sections) {
-        for (const s of section.sliders) s.releaseFromController(controller);
-      }
-      // `d` lives outside any section (#140); release it explicitly.
-      dSlider?.releaseFromController(controller);
-    });
-  }
-  return out;
 }
 
 function switchToSection(index: number): void {

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -1379,7 +1379,13 @@ const quadricsExhibit: Exhibit = {
       material.dispose();
       material = undefined;
     }
-    if (surfaceMesh?.geometry) surfaceMesh.geometry.dispose();
+    if (surfaceMesh) {
+      // Match the guard pattern of every other named handle (DeepSeek #5
+      // / v3-roundtable): dispose-then-null inline so a double-unmount
+      // can't dispose the geometry twice.
+      surfaceMesh.geometry.dispose();
+      surfaceMesh = undefined;
+    }
     if (doublePlane) {
       doublePlane.dispose();
       doublePlane = undefined;
@@ -1396,7 +1402,8 @@ const quadricsExhibit: Exhibit = {
     linearSliders = [];
     crossSectionSliders = [];
     crossSectionToggles = [];
-    surfaceMesh = undefined;
+    // surfaceMesh is reset inline in the named-handle block above so the
+    // dispose guard stays inside one branch.
     presets = [];
     sections = [];
     tabs = [];

--- a/src/shell/Exhibit.ts
+++ b/src/shell/Exhibit.ts
@@ -1,9 +1,18 @@
 import * as THREE from 'three';
+import type { ClusterId } from './clusters';
 
 export interface ExhibitContext {
-  scene: THREE.Scene;
+  // Per-exhibit root group (#150). The shell creates this on mount and
+  // removes it on unmount — exhibits add their content to `group`, not
+  // directly to a scene. Step 5 will add an in-session swap path that
+  // unmounts the prior exhibit's group before mounting the next one.
+  group: THREE.Group;
   renderer: THREE.WebGLRenderer;
   camera: THREE.PerspectiveCamera;
+  // Shell-owned XR controllers (#150). Listeners are registered once in
+  // `bootShell`; the shell dispatches `selectstart` / `selectend` to the
+  // currently-mounted exhibit via `onSelectStart` / `onSelectEnd`.
+  controllers: readonly THREE.Object3D[];
 }
 
 export interface ExhibitFrame {
@@ -13,7 +22,21 @@ export interface ExhibitFrame {
 export interface Exhibit {
   id: string;
   title: string;
+  // Cluster membership for the SceneRack visibility filter (#150). Step 4
+  // sets the field on `quadrics`; step 5 wires the rack to filter by it.
+  // `hello` leaves it unset — it's a toolchain smoke test, not a cluster
+  // member.
+  cluster?: ClusterId;
   mount(ctx: ExhibitContext): void;
   update(frame: ExhibitFrame): void;
-  unmount?(ctx: ExhibitContext): void;
+  // `unmount` is required as of #150 step 4: exhibits dispose owned GPU
+  // resources and unregister side-effects. The shell removes the
+  // per-exhibit `group` afterwards; exhibits don't need to clear the
+  // group's children manually.
+  unmount(ctx: ExhibitContext): void;
+  // Controller-event dispatch routes shell → exhibit (#150). Quadrics
+  // implements the full grab-tab-toggle dispatch in `onSelectStart`;
+  // `hello` is a no-op.
+  onSelectStart(controller: THREE.Object3D): void;
+  onSelectEnd(controller: THREE.Object3D): void;
 }

--- a/src/shell/clusters.ts
+++ b/src/shell/clusters.ts
@@ -1,0 +1,17 @@
+// Cluster identifiers — single source of truth for the SceneRack visibility
+// filter (#150) and any future per-cluster routing. Each "season" of geometer
+// (per the Decisions log in `_private/...`) maps to one CU course-aligned
+// cluster: APPM 2350 (Calculus 3) is the v1.0 cluster; APPM 2360 (Diff Eq +
+// Linear Algebra) is the planned next.
+//
+// `Exhibit.cluster?` is typed as `ClusterId` rather than raw `string` so a
+// typo of the literal (e.g. 'calc3' instead of 'calculus3') widens the type
+// to plain `string` and visibly fails the autocomplete — the same silent-
+// miss as a string admits, but the literal is much harder to mistype.
+// `(string & {})` is the standard "literal-narrows-but-string-still-allowed"
+// trick: future cluster names can be added as additional consts without the
+// type fighting back.
+
+export const CLUSTER_CALCULUS3 = 'calculus3' as const;
+
+export type ClusterId = typeof CLUSTER_CALCULUS3 | (string & {});

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -3,23 +3,15 @@ import { VRButton } from 'three/addons/webxr/VRButton.js';
 import type { Exhibit, ExhibitContext } from './Exhibit';
 import { listExhibits } from './registry';
 
-// Visible 1 m laser line along controller −Z, so the user can see where
-// they're aiming before pressing the trigger. Owned by the shell as of
-// #150 step 4 — was previously per-exhibit in `quadrics/setupControllers`.
-function buildAimRayLine(): THREE.Line {
-  const rayGeom = new THREE.BufferGeometry().setFromPoints([
-    new THREE.Vector3(0, 0, 0),
-    new THREE.Vector3(0, 0, -1),
-  ]);
-  const rayMat = new THREE.LineBasicMaterial({
-    color: 0xffffff,
-    transparent: true,
-    opacity: 0.6,
-  });
-  return new THREE.Line(rayGeom, rayMat);
-}
+// Vite HMR can re-execute module-level code in dev. `bootShell` is
+// idempotent against double-invocation: subsequent calls early-return
+// rather than registering a second set of controllers / listeners /
+// exhibit groups, which would leak GPU resources and double-fire events.
+let booted = false;
 
 export function bootShell(): void {
+  if (booted) return;
+  booted = true;
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0x111122);
 
@@ -74,8 +66,21 @@ export function bootShell(): void {
   const controller1 = renderer.xr.getController(1);
   scene.add(controller0);
   scene.add(controller1);
+  // Visible 1 m laser line along controller −Z. One geometry + material
+  // shared across both controllers (matches the pre-#150 quadrics setup,
+  // which also shared the rayGeom + rayMat instances rather than
+  // allocating per controller).
+  const aimRayGeom = new THREE.BufferGeometry().setFromPoints([
+    new THREE.Vector3(0, 0, 0),
+    new THREE.Vector3(0, 0, -1),
+  ]);
+  const aimRayMat = new THREE.LineBasicMaterial({
+    color: 0xffffff,
+    transparent: true,
+    opacity: 0.6,
+  });
   for (const c of [controller0, controller1] as const) {
-    c.add(buildAimRayLine());
+    c.add(new THREE.Line(aimRayGeom, aimRayMat));
     c.addEventListener('connected', (event: { data: XRInputSource }) => {
       const inputSource = event.data;
       if (inputSource.gamepad) c.userData.gamepad = inputSource.gamepad;
@@ -138,7 +143,12 @@ export function bootShell(): void {
   renderer.setAnimationLoop(() => {
     timer.update();
     const delta = timer.getDelta();
-    exhibit.update({ delta });
+    // Dispatch through `currentExhibit` (matching `selectstart` / `selectend`
+    // dispatch above) so step 5's swap path only needs to reassign
+    // `currentExhibit` — the animation loop picks up the new exhibit
+    // automatically. Equivalent to `exhibit.update` in step 4 (single
+    // exhibit, no swap), but stays correct when step 5 lands.
+    currentExhibit?.update({ delta });
     renderer.render(scene, camera);
   });
 }

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -1,7 +1,23 @@
 import * as THREE from 'three';
 import { VRButton } from 'three/addons/webxr/VRButton.js';
-import type { ExhibitContext } from './Exhibit';
+import type { Exhibit, ExhibitContext } from './Exhibit';
 import { listExhibits } from './registry';
+
+// Visible 1 m laser line along controller −Z, so the user can see where
+// they're aiming before pressing the trigger. Owned by the shell as of
+// #150 step 4 — was previously per-exhibit in `quadrics/setupControllers`.
+function buildAimRayLine(): THREE.Line {
+  const rayGeom = new THREE.BufferGeometry().setFromPoints([
+    new THREE.Vector3(0, 0, 0),
+    new THREE.Vector3(0, 0, -1),
+  ]);
+  const rayMat = new THREE.LineBasicMaterial({
+    color: 0xffffff,
+    transparent: true,
+    opacity: 0.6,
+  });
+  return new THREE.Line(rayGeom, rayMat);
+}
 
 export function bootShell(): void {
   const scene = new THREE.Scene();
@@ -42,10 +58,47 @@ export function bootShell(): void {
     renderer.setSize(window.innerWidth, window.innerHeight);
   });
 
+  // Shell-owned XR controllers (#150 step 4). Listeners are registered
+  // once at boot; controller events dispatch to the currently-mounted
+  // exhibit via `currentExhibit.onSelectStart` / `onSelectEnd`. Step 5
+  // will add rack-first-refusal arbitration before the dispatch line —
+  // the SceneRack instance is constructed in step 5, so step 4's
+  // selectstart body is a direct dispatch with no rack reference.
+  let currentExhibit: Exhibit | null = null;
+  // Iterate over the literal tuple so each `c` keeps its
+  // `renderer.xr.getController` return type — the XR event overload
+  // (`'connected'` / `'disconnected'` / `'selectstart'` / `'selectend'`)
+  // lives on that type, not on the wider `Object3D`. The widening to
+  // `readonly Object3D[]` for the ctx happens after listeners are set up.
+  const controller0 = renderer.xr.getController(0);
+  const controller1 = renderer.xr.getController(1);
+  scene.add(controller0);
+  scene.add(controller1);
+  for (const c of [controller0, controller1] as const) {
+    c.add(buildAimRayLine());
+    c.addEventListener('connected', (event: { data: XRInputSource }) => {
+      const inputSource = event.data;
+      if (inputSource.gamepad) c.userData.gamepad = inputSource.gamepad;
+    });
+    c.addEventListener('disconnected', () => {
+      delete c.userData.gamepad;
+    });
+    c.addEventListener('selectstart', () => {
+      currentExhibit?.onSelectStart(c);
+    });
+    c.addEventListener('selectend', () => {
+      currentExhibit?.onSelectEnd(c);
+    });
+  }
+  const controllers: readonly THREE.Object3D[] = [controller0, controller1];
+
   // URL-param exhibit selector (#120). Default = first registered.
   // Unknown id → console-warn and fall back so the page still renders
   // something rather than failing silently. Selection happens at boot
-  // only; there's no in-session swap path today.
+  // only; there's no in-session swap path today — step 5 (#150) adds the
+  // SceneRack-driven swap and a cluster-only URL resolver. For step 4 the
+  // existing single-exhibit boot routing is retained verbatim, so
+  // `?exhibit=hello` still mounts hello (cluster filter lands in step 5).
   const all = listExhibits();
   if (all.length === 0) {
     console.warn('geometer: no exhibits registered; nothing to mount.');
@@ -66,8 +119,17 @@ export function bootShell(): void {
     }
   }
 
-  const ctx: ExhibitContext = { scene, renderer, camera };
+  // Per-exhibit root group (#150). The shell owns scene-graph parenting;
+  // exhibits add their content to `ctx.group`, not to the scene root.
+  // Step 5 will replace this with an in-session swap path that drops the
+  // current exhibit's group + mounts the next one.
+  const group = new THREE.Group();
+  group.name = `exhibit:${exhibit.id}`;
+  scene.add(group);
+
+  const ctx: ExhibitContext = { group, renderer, camera, controllers };
   exhibit.mount(ctx);
+  currentExhibit = exhibit;
 
   const timer = new THREE.Timer();
   // Page Visibility integration: prevents huge delta spikes after the tab


### PR DESCRIPTION
Refs #150

## Summary

Step 4 of the #150 cluster-navigation migration per
`_private/plans/150-cluster-navigation.md` §6 row 4 (v5). Widens the
`Exhibit` interface and migrates quadrics + hello to the new contract.
The shell now owns the XR controllers, the per-exhibit `THREE.Group`,
and the `selectstart` / `selectend` dispatch. User-visible behavior is
unchanged in this PR — there's still no in-session swap path, no
SceneRack, no cluster filter; those land in the step-5 commit.

The plan went through a roundtable plan-review (Sonnet + GPT-5.5 Pro
+ DeepSeek V4 Pro) on v3 → v4 revisions → second-Sonnet sanity pass on
v4 → v5 patches before any code was written. The implementation
follows §3.5's named-handle-vs-generic-array ownership rule and the
30-name `let` audit (24 inherited + 6 added in this step).

## What changed

- `src/shell/Exhibit.ts` — `unmount`, `onSelectStart`, `onSelectEnd`
  required; `ExhibitContext.scene` → `group`; `controllers` field;
  optional `cluster?` field.
- `src/shell/clusters.ts` (new) — `CLUSTER_CALCULUS3` const + `ClusterId`
  typed alias.
- `src/shell/shell.ts` — shell-owned XR controllers + aim-ray Line +
  shell-registered listeners that dispatch to the current exhibit; per-
  exhibit Group construction with `name = 'exhibit:<id>'`; new ctx shape.
- `src/exhibits/quadrics/index.ts` — `setupControllers` removed; its
  selectstart/selectend body relocated into exhibit methods. `unmount`
  implements the §3.5 audit (named-handle disposal + generic-array
  drain + state reset). `addFloorStrip` now pushes per-strip
  `PlaneGeometry` into module-scoped `floorGeometries` for disposal.
  `cluster: CLUSTER_CALCULUS3` set.
- `src/exhibits/hello/index.ts` — small `unmount` (cube + floor geo
  / material), no-op `onSelectStart` / `onSelectEnd`. No `cluster` set
  — step 5's SceneRack filter will exclude it.

## Test plan

- [x] `npm run build` — green ✅
- [x] `npm test` — 96 / 96 pass ✅
- [x] `npx eslint .` — clean ✅
- [x] Browser smoke at `/?exhibit=quadrics` (default): all UI elements
  render — sliders, presets row, section tabs, canonical-forms heading,
  classifier readout, equation readout, world axes, floor with hole-punch.
- [x] Browser smoke at `/?exhibit=hello`: floor + cube spinning, no console
  errors. (Cluster filter lands in step 5, so hello is still URL-reachable
  in step 4.)
- [x] Browser smoke at `/?exhibit=bogus`: console-warns, falls back to
  default (quadrics). Existing single-exhibit boot routing retained.
- [ ] Cloudflare PR preview Quest 3S smoke (#146): controller dispatch
  routes — slider grab + drag works; preset tap works; section tab tap
  works; canonical-forms heading expand/collapse works; cross-section
  axis toggles work; aim-ray visible on both controllers.
- [ ] DevTools `scene.children`: contains the two shell-owned controllers
  + one group named `exhibit:quadrics`. No stray top-level meshes.

## Plan-review trail

- Roundtable plan-review on v3: 2 HIGH (sequencing contradiction; pre-warm
  invalidation) + 7 MEDIUM + 5 LOW → addressed in v4.
- Second-Sonnet sanity pass on v4: 2 MEDIUM revision-introduced
  (`resolveExhibitId('')` warn semantics; `rack` out-of-scope between
  steps 4 and 5) + 1 LOW → addressed in v5.
- v5 carries the v3 → v4 + v4 → v5 revision summaries at the top of
  the plan file (gitignored under `_private/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)