### PR TITLE
feat(shell): in-session navigation between cluster exhibits (#150 step 5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,17 +16,28 @@ deployment from `main` via `.github/workflows/pages.yml`.
 - `src/main.ts` — entry; imports each exhibit as a side-effect
   registration and calls `bootShell()`.
 - `src/shell/` — the WebXR shell: scene/camera/renderer setup, the
-  `Exhibit` interface, and the registry. URL param `?exhibit=<id>`
-  picks which registered exhibit mounts at boot (defaults to first).
+  `Exhibit` interface (mount/update/unmount + `onSelectStart` /
+  `onSelectEnd`), the registry, the `SceneRack` cluster-navigation
+  surface, and the `?exhibit=<id>` URL router. The shell owns the
+  XR controllers and dispatches `selectstart` / `selectend` to the
+  currently-mounted exhibit (rack-first-refusal: a tap on a
+  SceneTab is consumed by the rack and not forwarded). Cluster
+  membership is set per-exhibit via `Exhibit.cluster?: ClusterId`
+  (see `shell/clusters.ts`); only cluster members appear in the
+  rack and are reachable via `?exhibit=<id>` — non-cluster
+  exhibits stay registered but are reachable only via direct dev
+  import. URL routing helpers (`resolveExhibitId`, `planUrlSync`)
+  and the request-and-defer scheduler live in `shell/url-routing.ts`
+  and `shell/switch-scheduler.ts`; both are pure and Vitest-covered.
 - `src/scaffold/` — domain-agnostic primitives shared across
   exhibits (#120). Subdivided by concern:
   - `scaffold/design/tokens.ts` — Wong/Okabe-Ito palette + axis tints.
   - `scaffold/math/frames.ts` — math ↔ world frame helpers (math-Y
     forward maps to −world-Z; tested in `test/scaffold/math/`).
-  - `scaffold/ui/` — `Slider`, `Preset`, `SectionTab`, `Section`,
-    `WorldAxes`, `Label`, `rayHit`. Quadric-tuned constants
-    (`snapDetent`, `grabRadiusMultiplier`) are required ctor opts;
-    each scene declares the design-feel choice explicitly.
+  - `scaffold/ui/` — `Slider`, `Preset`, `SectionTab`, `SceneTab`,
+    `Section`, `WorldAxes`, `Label`, `rayHit`. Quadric-tuned
+    constants (`snapDetent`, `grabRadiusMultiplier`) are required
+    ctor opts; each scene declares the design-feel choice explicitly.
   - `scaffold/perf/` — `FpsOverlay`, `RendererInfoProbe`.
   - `scaffold/anim/PresetTween` — durationMs + easing required opts.
 - `src/exhibits/<topic>/` — per-exhibit code. Each exhibit owns its

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,17 +80,42 @@ If your PR introduces a new exhibit (typically `src/exhibits/<topic>/`):
   rendering invariants, explicit scope boundaries.
 - Implement the `Exhibit` interface from `src/shell/Exhibit.ts` and
   call `registerExhibit(...)` at module top level so a side-effect
-  import lands the registration.
+  import lands the registration. The interface requires:
+  - `mount(ctx)` / `update(frame)` / `unmount(ctx)` — `unmount` is
+    required (no `?`) and must dispose every owned GPU resource
+    (geometries, materials, troika text instances, primitives that
+    expose `dispose()`) and unregister any side-effects (timers,
+    RAFs, listeners). The shell removes the per-exhibit `group`
+    afterwards; you don't need to clear its children manually. Each
+    re-mount must allocate fresh — keep module-scoped handles, reset
+    them in `unmount`, and guard double-dispose with
+    `if (handle) { handle.dispose(); handle = undefined; }`.
+  - `onSelectStart(controller)` / `onSelectEnd(controller)` — the
+    shell owns the XR controllers and dispatches `selectstart` /
+    `selectend` here after a rack-first-refusal check. Exhibits
+    never call `addEventListener` on controllers themselves and
+    never own the visual aim ray. A no-interaction exhibit can
+    leave both methods as `() => {}`.
 - Add a side-effect `import './exhibits/<topic>'` to `src/main.ts`
-  so the registration runs at boot. The shell's URL-param selector
-  (`?exhibit=<id>`) routes to whichever exhibit's `id` matches.
+  so the registration runs at boot. To appear in the SceneRack
+  navigation row and be reachable via `?exhibit=<id>`, set
+  `cluster: CLUSTER_CALCULUS3` (or your future cluster's `ClusterId`)
+  on the exhibit. Without a `cluster`, the exhibit is filtered out
+  of the rack and the URL resolver — useful for toolchain smoke
+  tests like `hello`, which is reachable only via direct dev import.
+- The SceneRack lives at worldspace anchors `Y = 1.73`, `X = -0.44`,
+  `Z = -0.7` with horizontal `SCENE_TAB_PITCH = 0.20` (see
+  `src/shell/SceneRack.ts`). For the calculus3 cluster the existing
+  quadrics layout has free space above `Y = 1.50`; if your scene's
+  rack stacks bring elements above `Y = 1.65`, lay them out beside
+  the SectionTab column instead so the navigation row stays readable.
 - **Lean on `src/scaffold/`** for shared infrastructure rather than
   copying from `quadrics/`:
-  - UI primitives (`Slider`, `Preset`, `SectionTab`, `Section`,
-    `WorldAxes`, `Label`) live in `scaffold/ui/`. Their quadric-tuned
-    constants are required constructor options — declare your scene's
-    `snapDetent` / `grabRadiusMultiplier` / etc. explicitly so the
-    intent is visible at the call site.
+  - UI primitives (`Slider`, `Preset`, `SectionTab`, `SceneTab`,
+    `Section`, `WorldAxes`, `Label`) live in `scaffold/ui/`. Their
+    quadric-tuned constants are required constructor options —
+    declare your scene's `snapDetent` / `grabRadiusMultiplier` /
+    etc. explicitly so the intent is visible at the call site.
   - Math ↔ world frame helpers are in `scaffold/math/frames.ts`
     (math-Y forward = −world-Z; covered by basis-vector tests).
     Use these instead of open-coding the swap.

--- a/src/shell/SceneRack.ts
+++ b/src/shell/SceneRack.ts
@@ -102,10 +102,21 @@ export class SceneRack {
    * the event to the current exhibit's `onSelectStart` if the rack
    * passed. On hit, fires the matched tab's press flash + haptics
    * and invokes `onSelect(id)`.
+   *
+   * **Immediate active-state update (#150 plan v4 §3.2 / DeepSeek #4).**
+   * The tapped tab's visual active state is promoted *before*
+   * invoking `onSelect`, so the highlight switches in the same
+   * render frame as the tap rather than waiting on the deferred
+   * `switchExhibitNow` (one-frame defer + the unmount/mount cost).
+   * The shell's later `setActiveExhibit(resolvedId)` is idempotent
+   * if already active and re-syncs the rack if the deferred switch
+   * resolved to a different id (e.g., bogus or non-cluster id that
+   * fell back to the cluster default).
    */
   tryActivate(controller: THREE.Object3D): boolean {
     for (let i = 0; i < this.tabs.length; i++) {
       if (this.tabs[i].tryActivate(controller)) {
+        this.setActiveExhibit(this.exhibitIds[i]);
         this.onSelect(this.exhibitIds[i]);
         return true;
       }

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -1,7 +1,15 @@
 import * as THREE from 'three';
 import { VRButton } from 'three/addons/webxr/VRButton.js';
+import { CLUSTER_CALCULUS3 } from './clusters';
 import type { Exhibit, ExhibitContext } from './Exhibit';
 import { listExhibits } from './registry';
+import { SceneRack } from './SceneRack';
+import { createSwitchScheduler } from './switch-scheduler';
+import {
+  planUrlSync,
+  resolveExhibitId,
+  type HistoryMode,
+} from './url-routing';
 
 // Vite HMR can re-execute module-level code in dev. `bootShell` is
 // idempotent against double-invocation: subsequent calls early-return
@@ -50,13 +58,32 @@ export function bootShell(): void {
     renderer.setSize(window.innerWidth, window.innerHeight);
   });
 
-  // Shell-owned XR controllers (#150 step 4). Listeners are registered
-  // once at boot; controller events dispatch to the currently-mounted
-  // exhibit via `currentExhibit.onSelectStart` / `onSelectEnd`. Step 5
-  // will add rack-first-refusal arbitration before the dispatch line —
-  // the SceneRack instance is constructed in step 5, so step 4's
-  // selectstart body is a direct dispatch with no rack reference.
+  // Cluster filter (#150 step 5). The SceneRack and the URL-param
+  // resolver both operate over cluster members only; non-cluster
+  // exhibits (today: `hello`) stay registered so they're reachable
+  // via direct dev import, but are excluded from the rack and from
+  // `?exhibit=` resolution. An unknown / non-cluster / empty id at
+  // boot console-warns and falls back to `clusterExhibits[0]` — see
+  // `resolveExhibitId` semantics in `url-routing.ts`.
+  const clusterExhibits = listExhibits().filter(
+    (e) => e.cluster === CLUSTER_CALCULUS3,
+  );
+  if (clusterExhibits.length === 0) {
+    console.warn('geometer: no cluster exhibits registered; nothing to mount.');
+    return;
+  }
+  const defaultId = clusterExhibits[0].id;
+
+  // Shell-owned XR controllers (#150 step 4). Listeners are
+  // registered once at boot; controller events route through
+  // rack-first-refusal (step 5) and then dispatch to the
+  // currently-mounted exhibit. The `selectstart` listener checks
+  // `rack.tryActivate(c)` first — if the rack consumed the event
+  // (a tab was tapped), the exhibit's `onSelectStart` is skipped
+  // for that frame, preventing a slider grab from also firing the
+  // navigation switch.
   let currentExhibit: Exhibit | null = null;
+  let currentCtx: ExhibitContext | null = null;
   // Iterate over the literal tuple so each `c` keeps its
   // `renderer.xr.getController` return type — the XR event overload
   // (`'connected'` / `'disconnected'` / `'selectstart'` / `'selectend'`)
@@ -89,6 +116,14 @@ export function bootShell(): void {
       delete c.userData.gamepad;
     });
     c.addEventListener('selectstart', () => {
+      // Rack first refusal (#150 step 5): the rack consumes a tap
+      // when it lands on a SceneTab; otherwise the event flows to
+      // the current exhibit. SceneRack.tryActivate fires the
+      // tapped tab's immediate active-state update before
+      // returning, so the highlight switches in the same render
+      // frame even though the actual mount swap is deferred to
+      // the next animation frame by the scheduler.
+      if (rack.tryActivate(c)) return;
       currentExhibit?.onSelectStart(c);
     });
     c.addEventListener('selectend', () => {
@@ -97,58 +132,140 @@ export function bootShell(): void {
   }
   const controllers: readonly THREE.Object3D[] = [controller0, controller1];
 
-  // URL-param exhibit selector (#120). Default = first registered.
-  // Unknown id → console-warn and fall back so the page still renders
-  // something rather than failing silently. Selection happens at boot
-  // only; there's no in-session swap path today — step 5 (#150) adds the
-  // SceneRack-driven swap and a cluster-only URL resolver. For step 4 the
-  // existing single-exhibit boot routing is retained verbatim, so
-  // `?exhibit=hello` still mounts hello (cluster filter lands in step 5).
-  const all = listExhibits();
-  if (all.length === 0) {
-    console.warn('geometer: no exhibits registered; nothing to mount.');
-    return;
+  // SceneRack (#150 step 5): one tab per cluster member, tap →
+  // `requestSwitch(id, 'push')` so a SceneTab tap pushes a new
+  // history entry the user can back-button out of. The rack's
+  // `onSelect` runs at tap time; the actual mount swap happens
+  // on the next animation-loop tick via the scheduler.
+  const rack = new SceneRack({
+    exhibits: clusterExhibits,
+    grabRadiusMultiplier: 2.75,
+    onSelect: (id) => scheduler.requestSwitch(id, 'push'),
+  });
+  scene.add(rack.group);
+
+  function applyUrlSync(id: string, mode: HistoryMode): void {
+    const plan = planUrlSync(id, mode, defaultId, window.location.href);
+    if (plan.write === 'push') history.pushState(null, '', plan.href);
+    else if (plan.write === 'replace') history.replaceState(null, '', plan.href);
   }
-  const requestedId = new URLSearchParams(window.location.search).get('exhibit');
-  let exhibit = all[0];
-  if (requestedId !== null) {
-    const match = all.find((e) => e.id === requestedId);
-    if (match) {
-      exhibit = match;
-    } else {
+
+  function switchExhibitNow(
+    requestedId: string | null,
+    mode: HistoryMode,
+  ): void {
+    // 1. Resolve to a definite cluster-member id. `requestedId`
+    //    rides through as `null` for the bare-URL boot path
+    //    (silent fallback) and as `''` for an empty `?exhibit=`
+    //    (warn + fall back) — see `resolveExhibitId` semantics.
+    const { id: targetId, fellBack } = resolveExhibitId(
+      requestedId,
+      clusterExhibits,
+    );
+    if (fellBack) {
       console.warn(
         `geometer: unknown exhibit id "${requestedId}"; ` +
-          `falling back to "${exhibit.id}". ` +
-          `Registered ids: ${all.map((e) => e.id).join(', ')}.`,
+          `falling back to "${targetId}". ` +
+          `Cluster ids: ${clusterExhibits.map((e) => e.id).join(', ')}.`,
       );
     }
+
+    // 2. Sync rack + URL on the resolved target id, UNCONDITIONALLY.
+    //    Even when the mount swap is skipped (already on this
+    //    exhibit), this normalizes a stale `?exhibit=bogus` URL or
+    //    out-of-date rack highlight (Sonnet #2 + GPT #6).
+    rack.setActiveExhibit(targetId);
+    applyUrlSync(targetId, mode);
+
+    // 3. Skip the mount swap if already there.
+    if (currentExhibit?.id === targetId) return;
+
+    const target = clusterExhibits.find((e) => e.id === targetId)!;
+    if (currentExhibit && currentCtx) {
+      currentExhibit.unmount(currentCtx);
+      scene.remove(currentCtx.group);
+    }
+    const group = new THREE.Group();
+    group.name = `exhibit:${targetId}`;
+    scene.add(group);
+    const ctx: ExhibitContext = { group, renderer, camera, controllers };
+    target.mount(ctx);
+    currentExhibit = target;
+    currentCtx = ctx;
   }
 
-  // Per-exhibit root group (#150). The shell owns scene-graph parenting;
-  // exhibits add their content to `ctx.group`, not to the scene root.
-  // Step 5 will replace this with an in-session swap path that drops the
-  // current exhibit's group + mounts the next one.
-  const group = new THREE.Group();
-  group.name = `exhibit:${exhibit.id}`;
-  scene.add(group);
+  const scheduler = createSwitchScheduler({ commit: switchExhibitNow });
 
-  const ctx: ExhibitContext = { group, renderer, camera, controllers };
-  exhibit.mount(ctx);
-  currentExhibit = exhibit;
+  // `popstate` fires when the user uses the browser back/forward
+  // button. Read the param off the URL the browser has already
+  // committed to; pass `'none'` so we don't push another entry
+  // (which would loop). The raw value (which may be null for a
+  // bare URL or '' for `?exhibit=` with no value) rides through
+  // to the resolver, which distinguishes the two: bare URL is
+  // silent, empty value warns.
+  window.addEventListener('popstate', () => {
+    const id = new URLSearchParams(window.location.search).get('exhibit');
+    scheduler.requestSwitch(id, 'none');
+  });
+
+  // Best-effort shader pre-warm (#150 plan §4.4). Walks the
+  // non-default cluster exhibits at boot and runs a mount → compile
+  // → unmount cycle so the first in-session switch into a
+  // not-yet-mounted exhibit has a chance of skipping the cold
+  // ShaderMaterial compile. **Two known limitations make this an
+  // experiment, not a guarantee:** (1) `unmount` disposes owned
+  // materials, which may release the renderer-side compiled
+  // program; (2) `renderer.compile(scene, camera)` runs against
+  // the desktop `PerspectiveCamera`, but in-XR rendering uses an
+  // `ArrayCamera` whose program-cache key may differ. The cost is
+  // small (handful of allocations at boot); efficacy is measured
+  // in headset smoke (§7) and we file a follow-up if first-switch
+  // visibly stalls.
+  const requestedParam = new URLSearchParams(window.location.search).get(
+    'exhibit',
+  );
+  const { id: initialId } = resolveExhibitId(requestedParam, clusterExhibits);
+  for (const e of clusterExhibits) {
+    if (e.id === initialId) continue;
+    const warmGroup = new THREE.Group();
+    warmGroup.name = `warm:${e.id}`;
+    scene.add(warmGroup);
+    const warmCtx: ExhibitContext = {
+      group: warmGroup,
+      renderer,
+      camera,
+      controllers,
+    };
+    e.mount(warmCtx);
+    renderer.compile(scene, camera);
+    e.unmount(warmCtx);
+    scene.remove(warmGroup);
+  }
+
+  // Initial-boot mount: route through the same scheduler so the
+  // `'replace'` history mode normalizes a bogus / non-cluster /
+  // empty `?exhibit=` without leaving a forward history entry the
+  // user has to back through. The raw `requestedParam` (which may
+  // be null for a bare URL) rides through unchanged so the
+  // resolver can keep the bare-URL boot silent.
+  scheduler.requestSwitch(requestedParam, 'replace');
 
   const timer = new THREE.Timer();
   // Page Visibility integration: prevents huge delta spikes after the tab
   // (or Quest headset) is backgrounded and re-focused mid-session.
   timer.connect(document);
   renderer.setAnimationLoop(() => {
+    // Drain a pending switch at frame start, before update / render,
+    // so a controller event never unmounts the exhibit currently
+    // dispatching. Coalescing means two `requestSwitch` calls in
+    // the same tick mount only the latest target.
+    scheduler.drain();
     timer.update();
     const delta = timer.getDelta();
-    // Dispatch through `currentExhibit` (matching `selectstart` / `selectend`
-    // dispatch above) so step 5's swap path only needs to reassign
-    // `currentExhibit` — the animation loop picks up the new exhibit
-    // automatically. Equivalent to `exhibit.update` in step 4 (single
-    // exhibit, no swap), but stays correct when step 5 lands.
     currentExhibit?.update({ delta });
+    rack.faceCamera(camera);
+    rack.updateHover(controllers);
+    rack.update();
     renderer.render(scene, camera);
   });
 }

--- a/src/shell/switch-scheduler.ts
+++ b/src/shell/switch-scheduler.ts
@@ -1,0 +1,77 @@
+import type { HistoryMode } from './url-routing';
+
+// Defer-and-coalesce state machine for in-session exhibit switches
+// (#150 step 5). Lives apart from `shell.ts` so the coalescing /
+// re-entrancy semantics can be Vitest-covered without spinning up a
+// renderer.
+//
+// Two contracts the scheduler enforces, each tested in
+// `test/shell/switch-scheduler.test.ts`:
+//
+//   1. **Coalescing.** Two `requestSwitch(id)` calls within the same
+//      tick mount only the *last* id at the next `drain()`. The
+//      shell calls `drain()` from the animation loop, so two taps
+//      processed in the same `selectstart` → `selectstart` window
+//      collapse to a single mount. Prevents the "user double-tapped
+//      and saw a flash of A before landing on B" failure mode.
+//
+//   2. **Re-entrancy guard.** If `commit` happens to call
+//      `requestSwitch` itself (e.g. an exhibit's `mount` hook
+//      indirectly triggers a routing change), the scheduler does
+//      not re-enter `commit` mid-execution. The new request is
+//      queued and drained on the next tick. This is the "controller
+//      event never unmounts mid-dispatch" guarantee from §4.2 of the
+//      plan, generalized to any commit-time triggered switch.
+//
+// `commit` is the caller-provided hook that does the actual
+// resolve → unmount → mount work. The scheduler doesn't know or
+// care about Three.js, the registry, or URL state — it owns
+// scheduling only.
+//
+// `id` carries through nullable so the resolver downstream can
+// distinguish `null` (bare URL — silent fallback) from `''` (empty
+// `?exhibit=` — fall back with a console warn). Coercing both to
+// `''` upstream of the resolver loses that distinction and would
+// warn on every bare-URL boot.
+
+type PendingRequest = {
+  id: string | null;
+  mode: HistoryMode;
+};
+
+export interface SwitchScheduler {
+  requestSwitch(id: string | null, mode: HistoryMode): void;
+  /**
+   * Drain a pending request, if any. Calls `commit(id, mode)`
+   * exactly once per drain when a request is pending; no-ops
+   * otherwise. Safe to call every frame.
+   */
+  drain(): void;
+}
+
+export interface SchedulerOptions {
+  commit: (id: string | null, mode: HistoryMode) => void;
+}
+
+export function createSwitchScheduler(opts: SchedulerOptions): SwitchScheduler {
+  let pending: PendingRequest | null = null;
+  let committing = false;
+
+  return {
+    requestSwitch(id, mode) {
+      pending = { id, mode };
+    },
+    drain() {
+      if (committing) return;
+      if (pending === null) return;
+      const { id, mode } = pending;
+      pending = null;
+      committing = true;
+      try {
+        opts.commit(id, mode);
+      } finally {
+        committing = false;
+      }
+    },
+  };
+}

--- a/src/shell/url-routing.ts
+++ b/src/shell/url-routing.ts
@@ -1,0 +1,80 @@
+import type { Exhibit } from './Exhibit';
+
+// Pure URL-routing helpers for the cluster-navigation shell (#150
+// step 5). Extracted from `shell.ts` so the routing logic can be
+// Vitest-covered without spinning up a renderer. Keep these
+// functions side-effect-free: the shell turns the planned writes
+// into `history.pushState` / `replaceState` calls in `applyUrlSync`.
+
+export type HistoryMode = 'push' | 'replace' | 'none';
+
+export interface ResolveResult {
+  // The cluster-member id we ended up on. When the requested id was
+  // unrecognized / empty / non-cluster, this is `clusterExhibits[0].id`.
+  id: string;
+  // True when the resolver had to fall back from a non-null requested
+  // value. The shell uses this to decide whether to console-warn:
+  //   - `null` (bare URL, no `?exhibit=`)         → fellBack=false
+  //   - `''`   (`?exhibit=` empty)                → fellBack=true
+  //   - any unknown / non-cluster id              → fellBack=true
+  //   - a valid cluster id                        → fellBack=false
+  // The empty-string case warns because it represents a user-typed
+  // (or programmatically-built) URL that meant to specify an exhibit
+  // and got it wrong, vs. a bare URL which is the default-load shape.
+  fellBack: boolean;
+}
+
+/**
+ * Resolve an arbitrary requested id to a cluster-member id, falling
+ * back to `clusterExhibits[0]` on unknown / empty values. Pure;
+ * caller (`shell.ts`) handles the console-warn and the URL
+ * normalization.
+ */
+export function resolveExhibitId(
+  requested: string | null | undefined,
+  clusterExhibits: readonly Exhibit[],
+): ResolveResult {
+  if (requested && clusterExhibits.find((e) => e.id === requested)) {
+    return { id: requested, fellBack: false };
+  }
+  return { id: clusterExhibits[0].id, fellBack: requested != null };
+}
+
+export interface UrlSyncPlan {
+  // `null` means "no history write needed" — either the URL already
+  // matches the desired state, or the caller asked for `'none'`
+  // (popstate, where writing would loop). Otherwise the field tells
+  // the caller which `history.*State` to invoke.
+  write: 'push' | 'replace' | null;
+  // The target href as a fully-qualified URL string. Equal to
+  // `currentHref` when `write` is `null`.
+  href: string;
+}
+
+/**
+ * Decide what URL to write for a given exhibit id. The cluster
+ * default canonicalizes to a bare URL (no `?exhibit=` param) — this
+ * preserves the "default == bare URL" invariant mid-session, not
+ * just at boot, so back-button history doesn't accumulate redundant
+ * `?exhibit=<defaultId>` entries when the user hops to a non-default
+ * scene and back.
+ */
+export function planUrlSync(
+  id: string,
+  mode: HistoryMode,
+  defaultId: string,
+  currentHref: string,
+): UrlSyncPlan {
+  if (mode === 'none') return { write: null, href: currentHref };
+  const url = new URL(currentHref);
+  const isDefault = id === defaultId;
+  const currentParam = url.searchParams.get('exhibit');
+  if (isDefault) {
+    if (currentParam === null) return { write: null, href: currentHref };
+    url.searchParams.delete('exhibit');
+  } else {
+    if (currentParam === id) return { write: null, href: currentHref };
+    url.searchParams.set('exhibit', id);
+  }
+  return { write: mode, href: url.toString() };
+}

--- a/test/shell/switch-scheduler.test.ts
+++ b/test/shell/switch-scheduler.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createSwitchScheduler } from '@/shell/switch-scheduler';
+
+describe('createSwitchScheduler', () => {
+  it('drain with no pending request is a no-op', () => {
+    const commit = vi.fn();
+    const s = createSwitchScheduler({ commit });
+    s.drain();
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  it('coalesces same-tick requests: only the last id commits', () => {
+    const commit = vi.fn();
+    const s = createSwitchScheduler({ commit });
+    s.requestSwitch('a', 'push');
+    s.requestSwitch('b', 'push');
+    s.requestSwitch('c', 'replace');
+    s.drain();
+    expect(commit).toHaveBeenCalledTimes(1);
+    expect(commit).toHaveBeenCalledWith('c', 'replace');
+  });
+
+  it('forwards the latest history mode along with the latest id', () => {
+    const commit = vi.fn();
+    const s = createSwitchScheduler({ commit });
+    s.requestSwitch('a', 'push');
+    s.requestSwitch('b', 'replace');
+    s.drain();
+    expect(commit).toHaveBeenCalledWith('b', 'replace');
+  });
+
+  it('drain after a successful commit is a no-op (queue cleared)', () => {
+    const commit = vi.fn();
+    const s = createSwitchScheduler({ commit });
+    s.requestSwitch('a', 'push');
+    s.drain();
+    s.drain();
+    expect(commit).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-entrancy guard: commit-time requestSwitch defers to next drain', () => {
+    // Simulates the §4.2 "controller event never unmounts mid-
+    // dispatch" guarantee, generalized: if `commit` triggers
+    // another `requestSwitch`, it must not re-enter the same
+    // commit call. The new request rides on the next drain().
+    let nestedRequested = false;
+    const commitOrder: (string | null)[] = [];
+    const commit = vi.fn((id: string | null) => {
+      commitOrder.push(id);
+      if (!nestedRequested) {
+        nestedRequested = true;
+        s.requestSwitch('b', 'push');
+      }
+    });
+    const s = createSwitchScheduler({ commit });
+    s.requestSwitch('a', 'push');
+    s.drain();
+    // After first drain: commit('a') ran exactly once. The nested
+    // requestSwitch('b') is pending but did NOT re-enter commit.
+    expect(commit).toHaveBeenCalledTimes(1);
+    expect(commitOrder).toEqual(['a']);
+    // Second drain: now commit('b') fires.
+    s.drain();
+    expect(commit).toHaveBeenCalledTimes(2);
+    expect(commitOrder).toEqual(['a', 'b']);
+  });
+
+  it('passes null id through commit (bare-URL boot stays distinct from empty `?exhibit=`)', () => {
+    // The boot path passes `requestedParam` (which is `null` for
+    // a bare URL) directly through `requestSwitch` so the
+    // downstream resolver can keep the bare-URL boot silent
+    // while still warning on `?exhibit=` (empty). Coercing null
+    // to '' upstream of the resolver would warn on every
+    // bare-URL boot.
+    const commit = vi.fn();
+    const s = createSwitchScheduler({ commit });
+    s.requestSwitch(null, 'replace');
+    s.drain();
+    expect(commit).toHaveBeenCalledWith(null, 'replace');
+  });
+
+  it('repeated drains without new requests stay no-ops', () => {
+    const commit = vi.fn();
+    const s = createSwitchScheduler({ commit });
+    s.requestSwitch('a', 'push');
+    s.drain();
+    s.drain();
+    s.drain();
+    expect(commit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/shell/url-routing.test.ts
+++ b/test/shell/url-routing.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import type { Exhibit } from '@/shell/Exhibit';
+import { CLUSTER_CALCULUS3 } from '@/shell/clusters';
+import { resolveExhibitId, planUrlSync } from '@/shell/url-routing';
+
+// Stand-in cluster exhibits for the resolver tests. Only the `id`
+// and `cluster` fields matter for `resolveExhibitId`; the rest are
+// stubbed because the resolver looks at neither. `'hello'` is
+// included as a *registered-but-not-in-cluster* sibling — i.e. the
+// shape `listExhibits()` would return after registration but
+// *before* `shell.ts` filters it out — so `resolveExhibitId('hello',
+// clusterExhibits)` exercises the "non-cluster id" branch. The plan
+// promise (#150 §4.3) is that hello is reachable only via direct dev
+// import, never via `?exhibit=hello`.
+
+function stubExhibit(id: string, cluster?: string): Exhibit {
+  return {
+    id,
+    title: id,
+    cluster,
+    mount: () => {},
+    update: () => {},
+    unmount: () => {},
+    onSelectStart: () => {},
+    onSelectEnd: () => {},
+  };
+}
+
+const clusterExhibits = [
+  stubExhibit('quadrics', CLUSTER_CALCULUS3),
+  stubExhibit('tangent-planes', CLUSTER_CALCULUS3),
+];
+const defaultId = clusterExhibits[0].id;
+
+describe('resolveExhibitId', () => {
+  it('null requested → cluster default, no fallback (silent bare-URL boot)', () => {
+    const r = resolveExhibitId(null, clusterExhibits);
+    expect(r.id).toBe(defaultId);
+    expect(r.fellBack).toBe(false);
+  });
+  it('undefined requested → cluster default, no fallback', () => {
+    const r = resolveExhibitId(undefined, clusterExhibits);
+    expect(r.id).toBe(defaultId);
+    expect(r.fellBack).toBe(false);
+  });
+  it("empty string ('?exhibit=') → cluster default, fellBack=true", () => {
+    const r = resolveExhibitId('', clusterExhibits);
+    expect(r.id).toBe(defaultId);
+    expect(r.fellBack).toBe(true);
+  });
+  it("unknown id ('?exhibit=bogus') → cluster default, fellBack=true", () => {
+    const r = resolveExhibitId('bogus', clusterExhibits);
+    expect(r.id).toBe(defaultId);
+    expect(r.fellBack).toBe(true);
+  });
+  it("non-cluster registered id ('?exhibit=hello') → cluster default, fellBack=true", () => {
+    // `clusterExhibits` is the post-filter list, so hello is
+    // already excluded — the resolver doesn't need to know hello
+    // exists to reject it.
+    const r = resolveExhibitId('hello', clusterExhibits);
+    expect(r.id).toBe(defaultId);
+    expect(r.fellBack).toBe(true);
+  });
+  it('valid cluster default id → that id, no fallback', () => {
+    const r = resolveExhibitId('quadrics', clusterExhibits);
+    expect(r.id).toBe('quadrics');
+    expect(r.fellBack).toBe(false);
+  });
+  it('valid non-default cluster id → that id, no fallback', () => {
+    const r = resolveExhibitId('tangent-planes', clusterExhibits);
+    expect(r.id).toBe('tangent-planes');
+    expect(r.fellBack).toBe(false);
+  });
+});
+
+describe('planUrlSync', () => {
+  const base = 'https://example.com/geometer/';
+  const baseWithDefault = 'https://example.com/geometer/?exhibit=quadrics';
+  const baseWithTangent = 'https://example.com/geometer/?exhibit=tangent-planes';
+
+  it("mode='none' → no write, regardless of state", () => {
+    const plan = planUrlSync('tangent-planes', 'none', defaultId, baseWithDefault);
+    expect(plan.write).toBe(null);
+    expect(plan.href).toBe(baseWithDefault);
+  });
+
+  it('default id + bare URL → no write (settled state)', () => {
+    const plan = planUrlSync(defaultId, 'replace', defaultId, base);
+    expect(plan.write).toBe(null);
+    expect(plan.href).toBe(base);
+  });
+
+  it("default id + ?exhibit=<defaultId> → write bare URL (canonicalize)", () => {
+    const plan = planUrlSync(defaultId, 'replace', defaultId, baseWithDefault);
+    expect(plan.write).toBe('replace');
+    // URL normalizes to drop the trailing `?` when no params remain.
+    expect(plan.href).toBe(base);
+  });
+
+  it("default id + ?exhibit=bogus → write bare URL (canonicalize)", () => {
+    const plan = planUrlSync(
+      defaultId,
+      'replace',
+      defaultId,
+      'https://example.com/geometer/?exhibit=bogus',
+    );
+    expect(plan.write).toBe('replace');
+    expect(plan.href).toBe(base);
+  });
+
+  it('non-default id + bare URL → push ?exhibit=<id>', () => {
+    const plan = planUrlSync('tangent-planes', 'push', defaultId, base);
+    expect(plan.write).toBe('push');
+    expect(plan.href).toBe(baseWithTangent);
+  });
+
+  it('non-default id + ?exhibit=<same-id> → no write (already settled)', () => {
+    const plan = planUrlSync('tangent-planes', 'push', defaultId, baseWithTangent);
+    expect(plan.write).toBe(null);
+    expect(plan.href).toBe(baseWithTangent);
+  });
+
+  it('non-default id + ?exhibit=<other-id> → push the new id', () => {
+    const plan = planUrlSync('tangent-planes', 'push', defaultId, baseWithDefault);
+    expect(plan.write).toBe('push');
+    expect(plan.href).toBe(baseWithTangent);
+  });
+
+  it('preserves unrelated query params when canonicalizing default', () => {
+    const plan = planUrlSync(
+      defaultId,
+      'replace',
+      defaultId,
+      'https://example.com/geometer/?exhibit=quadrics&fps=1',
+    );
+    expect(plan.write).toBe('replace');
+    expect(plan.href).toBe('https://example.com/geometer/?fps=1');
+  });
+
+  it('preserves unrelated query params when setting a non-default id', () => {
+    const plan = planUrlSync(
+      'tangent-planes',
+      'push',
+      defaultId,
+      'https://example.com/geometer/?fps=1',
+    );
+    expect(plan.write).toBe('push');
+    expect(plan.href).toBe('https://example.com/geometer/?fps=1&exhibit=tangent-planes');
+  });
+});


### PR DESCRIPTION
Refs #150

## Summary

Wires up the SceneRack so users can move between sibling scenes in the calculus3 cluster without leaving the page. Step 5 is the navigation machinery on top of step 4's contract migration: the rack-first-refusal arbitration on `selectstart`, the request-and-defer scheduler that keeps switches off the controller-event critical path, and pure URL helpers that canonicalize the cluster default to a bare URL throughout the session. Today's cluster has one member (`quadrics`) so the rack is a single-tab row and the pre-warm loop is a no-op; the felt-smoke value lands once `tangent-planes` (#121) registers.

## Implementation

- **Pure helpers** in `shell/url-routing.ts`: `resolveExhibitId` (cluster-only; `null` bare URL stays silent, `''` / unknown / non-cluster id warns and falls back to `clusterExhibits[0]`) and `planUrlSync` (canonicalizes the cluster default to a bare URL, preserves unrelated query params).
- **Defer-and-coalesce scheduler** in `shell/switch-scheduler.ts`: two `requestSwitch` calls in the same tick mount only the latest; commit-time `requestSwitch` defers to the next drain (re-entrancy guard).
- **`shell.ts` rewrite**: cluster filter at boot, `switchExhibitNow` with unconditional rack + URL sync on the resolved target id (normalizes a stale `?exhibit=bogus` URL or out-of-date rack highlight even when the mount swap is skipped), `popstate` handler with `'none'` history mode (no loop), best-effort shader pre-warm per plan §4.4.
- **`SceneRack.tryActivate`** now updates the tapped tab's active state before `onSelect`, so the highlight switches in the same render frame as the tap rather than waiting on the deferred mount swap.
- **`CLAUDE.md` + `CONTRIBUTING.md`** document the cluster filter, the unmount + controller-dispatch contracts, and the SceneRack worldspace anchors.

One subtlety patched vs. the plan pseudocode: the boot path passes the raw `requestedParam` (which may be `null`) through the scheduler unchanged, so the resolver can keep the bare-URL boot silent. Coercing `null` → `''` upstream of the resolver would have warned on every default load.

## Test plan

- [x] `npm run build` clean
- [x] `npx vitest run` — 119 tests pass (24 new across `url-routing.test.ts` + `switch-scheduler.test.ts` covering the §7 cases enumerated in `_private/plans/150-cluster-navigation.md`)
- [x] `npx eslint .` clean
- [x] Cloudflare preview headset smoke (Quest 3S):
  - [x] Bare URL boots silently into quadrics; URL stays bare.
  - [x] `?exhibit=bogus` and `?exhibit=hello` both console-warn and canonicalize to bare URL.
  - [x] SceneRack reads at Y=1.73 without overlapping the SectionTab column at X=-0.44, Y∈[0.81, 1.50].
  - [x] (Pending tangent-planes #121 — single-tab rack today; in-session switching can't be exercised yet.)