### PR TITLE
refactor(scaffold): consolidate Preset/SectionTab/SceneTab onto TapButton (#156)

### DIFF
--- a/src/scaffold/ui/Preset.ts
+++ b/src/scaffold/ui/Preset.ts
@@ -1,12 +1,10 @@
-import * as THREE from 'three';
-import { Text } from 'troika-three-text';
-import { raySphereHit } from '@/scaffold/ui/rayHit';
+import { TapButton, type TapButtonVisuals } from '@/scaffold/ui/TapButton';
 
-// One canonical-pose preset button (#46). A small sphere with a text label
-// below it; pressing snaps the slider rack to a named family member
-// (Sphere, Cylinder, Cone, Hyperboloid 1- or 2-sheet, …). Read as a tap-
-// affordance distinct from the warm slider thumbs by use of a cool fill
-// color and a brief press flash on activation.
+// One canonical-pose preset button (#46). Pressing snaps the slider rack
+// to a named family member (Sphere, Cylinder, Cone, Hyperboloid 1- or
+// 2-sheet, …). Read as a tap-affordance distinct from the warm slider
+// thumbs by use of a cool fill color and a brief press flash on
+// activation.
 //
 // Label placement is below-button rather than right-of-button (#93): the
 // preset rack is a horizontal sub-row beneath the section tabs, so right-
@@ -14,6 +12,11 @@ import { raySphereHit } from '@/scaffold/ui/rayHit';
 // SectionTab's above-button label arrangement (with the offset flipped so
 // labels fall toward the family classifier rather than crowding the tabs
 // above).
+//
+// Mechanics (sphere mesh + ray-hit + press-flash + haptic + yaw-billboard
+// label) live in the shared `TapButton` base (#156). This subclass only
+// declares the visual identity (cool blue, no sticky-active) and the two
+// extra fields callers read off the preset (`values`, `linearValues`).
 
 export type PresetValues = readonly [number, number, number, number];
 // Linear-term coefficients (u, v, w) in math frame — see index.ts for the
@@ -24,11 +27,6 @@ export type LinearPresetValues = readonly [number, number, number];
 export interface PresetOptions {
   name: string;
   values: PresetValues;
-  // Ray–button hit-test sphere radius is `BUTTON_RADIUS *
-  // grabRadiusMultiplier`. Required so each scene declares the
-  // affordance scale rather than inheriting a primitive-internal
-  // default; the quadrics rack passes 2.75 so it matches Slider /
-  // SectionTab in the same exhibit.
   grabRadiusMultiplier: number;
   // Optional. Defaults to (0, 0, 0). Paraboloid uses (0, 0, -1) so that
   // ax² + by² + wz = 0 with a=b=1, w=-1 reads as z = x² + y² (open along
@@ -36,155 +34,39 @@ export interface PresetOptions {
   linearValues?: LinearPresetValues;
 }
 
-const BUTTON_RADIUS = 0.02;
-
-const HAPTIC_AMPLITUDE = 0.5;
-const HAPTIC_DURATION_MS = 10;
-
 // Cool fill so presets read as "tap to apply" rather than "drag" — the
-// slider thumbs use a warm orange for drag affordance.
-const BUTTON_BASE_COLOR = 0x44aabb;
-const BUTTON_HOVER_EMISSIVE = 0x224455;
-const BUTTON_PRESS_EMISSIVE = 0x88ddff;
-
-// Momentary press flash duration. Long enough to register as feedback,
-// short enough not to read as a sticky toggle.
-const PRESS_FLASH_DURATION_MS = 150;
-
-// Smaller than the original 0.03 to keep adjacent labels from running
+// slider thumbs use a warm orange for drag affordance. No
+// `activeEmissive`: presets are one-shot, the press flash *is* the
+// feedback.
+//
+// Smaller font than the tabs to keep adjacent labels from running
 // together in the horizontal preset row introduced in #93. Paired with
 // the row pitch in index.ts: 0.13 m pitch + 0.022 m font leaves clear
-// air between "H 2-sheets" and its neighbors.
-const LABEL_FONT_SIZE = 0.022;
-// Offset just clears the button (radius 0.02) plus a small breathing gap.
-// Negative because the label sits *below* the button.
-const LABEL_OFFSET_Y = -0.025;
-const LABEL_COLOR = 0xffffff;
-const LABEL_OUTLINE_WIDTH = '8%';
-const LABEL_OUTLINE_COLOR = 0x000000;
+// air between "H 2-sheets" and its neighbors. Label sits below the
+// button (anchor 'top' + negative offset) so it falls toward the family
+// classifier rather than crowding the section tabs above.
+const VISUALS: TapButtonVisuals = {
+  groupNamePrefix: 'preset',
+  buttonRadius: 0.02,
+  baseColor: 0x44aabb,
+  hoverEmissive: 0x224455,
+  pressEmissive: 0x88ddff,
+  labelFontSize: 0.022,
+  labelOffsetY: -0.025,
+  labelAnchorY: 'top',
+};
 
-interface ControllerWithGamepad extends THREE.Object3D {
-  userData: { gamepad?: Gamepad };
-}
-
-export class Preset {
-  readonly group: THREE.Group;
-  readonly name: string;
+export class Preset extends TapButton {
   readonly values: PresetValues;
   readonly linearValues: LinearPresetValues;
 
-  private readonly grabRadiusMultiplier: number;
-  private readonly button: THREE.Mesh;
-  private readonly label: Text;
-  private readonly buttonWorld = new THREE.Vector3();
-  private readonly camWorld = new THREE.Vector3();
-  private readonly labelWorld = new THREE.Vector3();
-  private hovered = false;
-  private pressedUntilMs = 0;
-
   constructor(opts: PresetOptions) {
-    this.name = opts.name;
+    super({
+      name: opts.name,
+      grabRadiusMultiplier: opts.grabRadiusMultiplier,
+      visuals: VISUALS,
+    });
     this.values = opts.values;
     this.linearValues = opts.linearValues ?? [0, 0, 0];
-    this.grabRadiusMultiplier = opts.grabRadiusMultiplier;
-
-    this.group = new THREE.Group();
-    this.group.name = `preset:${opts.name}`;
-
-    this.button = new THREE.Mesh(
-      new THREE.SphereGeometry(BUTTON_RADIUS, 16, 12),
-      new THREE.MeshStandardMaterial({ color: BUTTON_BASE_COLOR }),
-    );
-    this.group.add(this.button);
-
-    this.label = new Text();
-    this.label.text = opts.name;
-    this.label.fontSize = LABEL_FONT_SIZE;
-    this.label.color = LABEL_COLOR;
-    this.label.anchorX = 'center';
-    this.label.anchorY = 'top';
-    this.label.outlineWidth = LABEL_OUTLINE_WIDTH;
-    this.label.outlineColor = LABEL_OUTLINE_COLOR;
-    this.label.position.set(0, LABEL_OFFSET_Y, 0);
-    this.label.sync();
-    this.group.add(this.label);
   }
-
-  /**
-   * Test whether `controller`'s forward ray hits the button. On hit, fire
-   * haptics, kick off the press flash, and return true. The caller owns
-   * applying `values` to the slider rack — keeping the dispatch out here
-   * means the preset itself doesn't need a reference to the sliders.
-   */
-  tryActivate(controller: THREE.Object3D): boolean {
-    if (!this.rayHitsButton(controller)) return false;
-    this.pressedUntilMs = performance.now() + PRESS_FLASH_DURATION_MS;
-    this.refreshButtonEmissive();
-    pulse(controller);
-    return true;
-  }
-
-  updateHover(controllers: readonly THREE.Object3D[]): void {
-    const hovered = controllers.some((c) => this.rayHitsButton(c));
-    if (hovered === this.hovered) return;
-    this.hovered = hovered;
-    this.refreshButtonEmissive();
-  }
-
-  /** Per-frame: clears the press flash once its window expires. */
-  update(): void {
-    if (this.pressedUntilMs > 0 && performance.now() >= this.pressedUntilMs) {
-      this.pressedUntilMs = 0;
-      this.refreshButtonEmissive();
-    }
-  }
-
-  // Yaw-only billboard for the text label, matching the family / per-slider
-  // labels — head pitch and roll stay out (#29).
-  faceCamera(camera: THREE.Camera): void {
-    camera.getWorldPosition(this.camWorld);
-    this.label.getWorldPosition(this.labelWorld);
-    const dx = this.camWorld.x - this.labelWorld.x;
-    const dz = this.camWorld.z - this.labelWorld.z;
-    this.label.rotation.set(0, Math.atan2(dx, dz), 0);
-  }
-
-  dispose(): void {
-    this.label.dispose();
-    this.button.geometry.dispose();
-    (this.button.material as THREE.Material).dispose();
-  }
-
-  private refreshButtonEmissive(): void {
-    const mat = this.button.material as THREE.MeshStandardMaterial;
-    const hex =
-      this.pressedUntilMs > 0
-        ? BUTTON_PRESS_EMISSIVE
-        : this.hovered
-          ? BUTTON_HOVER_EMISSIVE
-          : 0x000000;
-    mat.emissive.setHex(hex);
-  }
-
-  private rayHitsButton(controller: THREE.Object3D): boolean {
-    const rayOrigin = new THREE.Vector3();
-    const rayDir = new THREE.Vector3();
-    controller.getWorldPosition(rayOrigin);
-    rayDir.set(0, 0, -1).applyQuaternion(
-      controller.getWorldQuaternion(new THREE.Quaternion()),
-    );
-    this.button.getWorldPosition(this.buttonWorld);
-    const r = BUTTON_RADIUS * this.grabRadiusMultiplier;
-    return raySphereHit(rayOrigin, rayDir, this.buttonWorld, r);
-  }
-}
-
-function pulse(controller: THREE.Object3D): void {
-  const gamepad = (controller as ControllerWithGamepad).userData.gamepad;
-  const actuator = gamepad?.hapticActuators?.[0];
-  if (!actuator) return;
-  (actuator as { pulse?: (a: number, d: number) => void }).pulse?.(
-    HAPTIC_AMPLITUDE,
-    HAPTIC_DURATION_MS,
-  );
 }

--- a/src/scaffold/ui/SceneTab.ts
+++ b/src/scaffold/ui/SceneTab.ts
@@ -1,211 +1,52 @@
-import * as THREE from 'three';
-import { Text } from 'troika-three-text';
-import { raySphereHit } from '@/scaffold/ui/rayHit';
+import { TapButton, type TapButtonVisuals } from '@/scaffold/ui/TapButton';
 
 // Tap button for the SceneRack — the in-app navigation surface that
 // lets the user move between sibling exhibits in a cluster (#150).
-// Visually a sibling of `SectionTab` (sticky-active sphere + yaw-
-// billboard label + ray-hit + press-flash machinery), but tuned a step
-// larger and recolored warm amber so the SceneRack reads as a higher-
-// level affordance than the SectionTab row beneath it.
+// Sibling of `SectionTab` (sticky-active sphere + yaw-billboard label
+// + ray-hit + press-flash machinery), but tuned a step larger and
+// recolored warm amber so the SceneRack reads as a higher-level
+// affordance than the SectionTab row beneath it.
 //
-// Light intentional duplication of `SectionTab` rather than a shared
-// base class (matching SectionTab's own copy-of-Preset stance). With
-// SceneTab landing, the project now has three tap-button-like
-// primitives — `Preset`, `SectionTab`, `SceneTab` — which trips the
-// rule-of-three trigger called out in `SectionTab.ts`. Consolidation
-// onto a shared `TapButton` base is filed as a #150 follow-up; this
-// file ships the third concrete instance first so the abstraction can
-// be designed against three real call-sites instead of two.
+// Mechanics live in the shared `TapButton` base (#156). This subclass
+// only declares the visual identity (larger button, warm-amber active,
+// label above the button).
 
 export interface SceneTabOptions {
   name: string;
-  // Ray–button hit-test sphere radius is `BUTTON_RADIUS *
-  // grabRadiusMultiplier`. Required so each scene declares the
-  // affordance scale rather than inheriting a primitive-internal
-  // default; the calculus3 cluster's SceneRack passes 2.75 so the
-  // SceneTabs feel like the rack's Slider / Preset / SectionTab.
   grabRadiusMultiplier: number;
 }
 
-// Larger than SectionTab's 0.022 so the SceneRack reads as the
-// outer / higher-priority navigation layer when the two racks share
-// the user's field of view.
-const BUTTON_RADIUS = 0.028;
+// Same slate base as SectionTab so the off / inactive vocabulary stays
+// consistent across rack tiers (cf. AxisToggle's matching disabled
+// slate). Active emissive is warm amber, distinct from SectionTab's
+// sky-blue, so users can tell at a glance which rack owns the
+// currently-glowing tab. Hover / press scale the same way — soft pre-
+// light → bright press flash on top of any sustained active glow.
+//
+// Larger button radius and label font than SectionTab's so the
+// SceneRack reads as the outer / higher-priority navigation layer when
+// the two racks share the user's field of view. Label placement matches
+// SectionTab's (anchor 'bottom' + positive offset) — the SceneRack lays
+// out horizontally, so right-of-button labels would collide with the
+// next tab's button.
+const VISUALS: TapButtonVisuals = {
+  groupNamePrefix: 'scene-tab',
+  buttonRadius: 0.028,
+  baseColor: 0x556677,
+  hoverEmissive: 0x442200,
+  activeEmissive: 0xddaa66,
+  pressEmissive: 0xffeebb,
+  labelFontSize: 0.04,
+  labelOffsetY: 0.04,
+  labelAnchorY: 'bottom',
+};
 
-const HAPTIC_AMPLITUDE = 0.5;
-const HAPTIC_DURATION_MS = 10;
-
-// Same slate base as SectionTab so the off / inactive vocabulary
-// stays consistent across rack tiers (cf. AxisToggle's matching
-// disabled slate). Active emissive is warm amber, distinct from
-// SectionTab's sky-blue, so users can tell at a glance which rack
-// owns the currently-glowing tab. Hover / press scale the same way
-// SectionTab's do — soft pre-light → bright press flash on top of
-// any sustained active glow.
-const BUTTON_BASE_COLOR = 0x556677;
-const BUTTON_HOVER_EMISSIVE = 0x442200;
-const BUTTON_ACTIVE_EMISSIVE = 0xddaa66;
-const BUTTON_PRESS_EMISSIVE = 0xffeebb;
-
-const PRESS_FLASH_DURATION_MS = 150;
-
-// Larger than SectionTab's 0.035 to match the larger button.
-const LABEL_FONT_SIZE = 0.04;
-const LABEL_OFFSET_Y = 0.04;
-const LABEL_COLOR = 0xffffff;
-const LABEL_OUTLINE_WIDTH = '8%';
-const LABEL_OUTLINE_COLOR = 0x000000;
-
-interface ControllerWithGamepad extends THREE.Object3D {
-  userData: { gamepad?: Gamepad };
-}
-
-export class SceneTab {
-  readonly group: THREE.Group;
-  readonly name: string;
-
-  private readonly grabRadiusMultiplier: number;
-  private readonly button: THREE.Mesh;
-  private readonly label: Text;
-  private readonly buttonWorld = new THREE.Vector3();
-  private readonly camWorld = new THREE.Vector3();
-  private readonly labelWorld = new THREE.Vector3();
-  private hovered = false;
-  private active = false;
-  private pressedUntilMs = 0;
-
+export class SceneTab extends TapButton {
   constructor(opts: SceneTabOptions) {
-    this.name = opts.name;
-    this.grabRadiusMultiplier = opts.grabRadiusMultiplier;
-
-    this.group = new THREE.Group();
-    this.group.name = `scene-tab:${opts.name}`;
-
-    this.button = new THREE.Mesh(
-      new THREE.SphereGeometry(BUTTON_RADIUS, 16, 12),
-      new THREE.MeshStandardMaterial({ color: BUTTON_BASE_COLOR }),
-    );
-    this.group.add(this.button);
-
-    // Label sits above the button rather than to the right: the
-    // SceneRack lays out horizontally, so right-of-button labels
-    // would collide with the next tab's button. Same rationale as
-    // SectionTab.
-    this.label = new Text();
-    this.label.text = opts.name;
-    this.label.fontSize = LABEL_FONT_SIZE;
-    this.label.color = LABEL_COLOR;
-    this.label.anchorX = 'center';
-    this.label.anchorY = 'bottom';
-    this.label.outlineWidth = LABEL_OUTLINE_WIDTH;
-    this.label.outlineColor = LABEL_OUTLINE_COLOR;
-    this.label.position.set(0, LABEL_OFFSET_Y, 0);
-    this.label.sync();
-    this.group.add(this.label);
+    super({
+      name: opts.name,
+      grabRadiusMultiplier: opts.grabRadiusMultiplier,
+      visuals: VISUALS,
+    });
   }
-
-  get isActive(): boolean {
-    return this.active;
-  }
-
-  setActive(active: boolean): void {
-    if (active === this.active) return;
-    this.active = active;
-    this.refreshButtonEmissive();
-  }
-
-  // Dynamic label update — kept on the API for parity with SectionTab,
-  // even though SceneRack tabs don't currently rename mid-session.
-  // Issues a troika sync; the cost is a one-frame text re-layout.
-  setName(name: string): void {
-    if (this.label.text === name) return;
-    this.label.text = name;
-    this.label.sync();
-  }
-
-  /**
-   * Test whether `controller`'s forward ray hits the button. On hit, fire
-   * haptics, kick off the press flash, and return true. The caller
-   * (SceneRack) owns the active-state bookkeeping (clearing the
-   * previously-active tab, setting this one) — keeps the tab itself
-   * unaware of its peers, matching SectionTab's contract.
-   */
-  tryActivate(controller: THREE.Object3D): boolean {
-    if (!this.rayHitsButton(controller)) return false;
-    this.pressedUntilMs = performance.now() + PRESS_FLASH_DURATION_MS;
-    this.refreshButtonEmissive();
-    pulse(controller);
-    return true;
-  }
-
-  updateHover(controllers: readonly THREE.Object3D[]): void {
-    const hovered = controllers.some((c) => this.rayHitsButton(c));
-    if (hovered === this.hovered) return;
-    this.hovered = hovered;
-    this.refreshButtonEmissive();
-  }
-
-  /** Per-frame: clears the press flash once its window expires. */
-  update(): void {
-    if (this.pressedUntilMs > 0 && performance.now() >= this.pressedUntilMs) {
-      this.pressedUntilMs = 0;
-      this.refreshButtonEmissive();
-    }
-  }
-
-  faceCamera(camera: THREE.Camera): void {
-    camera.getWorldPosition(this.camWorld);
-    this.label.getWorldPosition(this.labelWorld);
-    const dx = this.camWorld.x - this.labelWorld.x;
-    const dz = this.camWorld.z - this.labelWorld.z;
-    this.label.rotation.set(0, Math.atan2(dx, dz), 0);
-  }
-
-  dispose(): void {
-    this.label.dispose();
-    this.button.geometry.dispose();
-    (this.button.material as THREE.Material).dispose();
-  }
-
-  // Emissive priority (highest first): press flash, active, hover, idle.
-  // Press flash sits on top of active so the user gets a beat of feedback
-  // even when re-tapping the already-active tab.
-  private refreshButtonEmissive(): void {
-    const mat = this.button.material as THREE.MeshStandardMaterial;
-    let hex: number;
-    if (this.pressedUntilMs > 0) {
-      hex = BUTTON_PRESS_EMISSIVE;
-    } else if (this.active) {
-      hex = BUTTON_ACTIVE_EMISSIVE;
-    } else if (this.hovered) {
-      hex = BUTTON_HOVER_EMISSIVE;
-    } else {
-      hex = 0x000000;
-    }
-    mat.emissive.setHex(hex);
-  }
-
-  private rayHitsButton(controller: THREE.Object3D): boolean {
-    const rayOrigin = new THREE.Vector3();
-    const rayDir = new THREE.Vector3();
-    controller.getWorldPosition(rayOrigin);
-    rayDir.set(0, 0, -1).applyQuaternion(
-      controller.getWorldQuaternion(new THREE.Quaternion()),
-    );
-    this.button.getWorldPosition(this.buttonWorld);
-    const r = BUTTON_RADIUS * this.grabRadiusMultiplier;
-    return raySphereHit(rayOrigin, rayDir, this.buttonWorld, r);
-  }
-}
-
-
-function pulse(controller: THREE.Object3D): void {
-  const gamepad = (controller as ControllerWithGamepad).userData.gamepad;
-  const actuator = gamepad?.hapticActuators?.[0];
-  if (!actuator) return;
-  (actuator as { pulse?: (a: number, d: number) => void }).pulse?.(
-    HAPTIC_AMPLITUDE,
-    HAPTIC_DURATION_MS,
-  );
 }

--- a/src/scaffold/ui/SectionTab.ts
+++ b/src/scaffold/ui/SectionTab.ts
@@ -1,200 +1,47 @@
-import * as THREE from 'three';
-import { Text } from 'troika-three-text';
-import { raySphereHit } from '@/scaffold/ui/rayHit';
+import { TapButton, type TapButtonVisuals } from '@/scaffold/ui/TapButton';
 
-// Tap button for the rack section selector (#57). Visually a sibling of
-// `Preset` — same sphere + label + ray-hit + yaw-billboard machinery —
-// but with a *sustained* "active" emissive that persists until another
-// tab claims active. Press flash still fires on tap as feedback that the
-// switch was registered, layered on top of the active state.
+// Tap button for the rack section selector (#57). Sticky-active state
+// persists until another tab claims active; press flash still fires on
+// tap as feedback that the switch was registered, layered on top of the
+// active state.
 //
-// Light intentional duplication of Preset rather than a shared base
-// class: the two serve different mental models (Preset = one-shot
-// "snap to this configuration", Tab = sticky "switch to this section"),
-// and the issue explicitly recommends "build concretely first; generalize
-// only if a second instance shows up." A third tap-button-like primitive
-// would be the trigger for refactoring all three onto a shared base.
+// Mechanics (sphere mesh + emissive priority + ray-hit + press-flash +
+// haptic + yaw-billboard label + sticky active) live in the shared
+// `TapButton` base (#156). This subclass only declares the visual
+// identity (slate base, sky-blue active, label above the button).
 
 export interface SectionTabOptions {
   name: string;
-  // Ray–button hit-test sphere radius is `BUTTON_RADIUS *
-  // grabRadiusMultiplier`. Required so each scene declares the
-  // affordance scale rather than inheriting a primitive-internal
-  // default; the quadrics rack passes 2.75 so it matches Slider /
-  // Preset in the same exhibit.
   grabRadiusMultiplier: number;
 }
-
-const BUTTON_RADIUS = 0.022;
-
-const HAPTIC_AMPLITUDE = 0.5;
-const HAPTIC_DURATION_MS = 10;
 
 // Slate base reads as a "mode" affordance, distinct from Preset's cool
 // blue ("snap to family member") and the warm orange slider thumbs
 // ("drag to change a value"). Active emissive is bright enough to read
 // at a glance which section is current; hover is a softer pre-light;
 // press flash is the brightest, layered momentarily on top of active.
-const BUTTON_BASE_COLOR = 0x556677;
-const BUTTON_HOVER_EMISSIVE = 0x223344;
-const BUTTON_ACTIVE_EMISSIVE = 0x88bbdd;
-const BUTTON_PRESS_EMISSIVE = 0xddeeff;
+//
+// Label sits above the button (anchor 'bottom' + positive offset) rather
+// than to the right (Preset's layout): the tab row is horizontal, so
+// right-of-button labels would collide with the next tab's button.
+const VISUALS: TapButtonVisuals = {
+  groupNamePrefix: 'tab',
+  buttonRadius: 0.022,
+  baseColor: 0x556677,
+  hoverEmissive: 0x223344,
+  activeEmissive: 0x88bbdd,
+  pressEmissive: 0xddeeff,
+  labelFontSize: 0.035,
+  labelOffsetY: 0.04,
+  labelAnchorY: 'bottom',
+};
 
-const PRESS_FLASH_DURATION_MS = 150;
-
-const LABEL_FONT_SIZE = 0.035;
-const LABEL_OFFSET_Y = 0.04;
-const LABEL_COLOR = 0xffffff;
-const LABEL_OUTLINE_WIDTH = '8%';
-const LABEL_OUTLINE_COLOR = 0x000000;
-
-interface ControllerWithGamepad extends THREE.Object3D {
-  userData: { gamepad?: Gamepad };
-}
-
-export class SectionTab {
-  readonly group: THREE.Group;
-  readonly name: string;
-
-  private readonly grabRadiusMultiplier: number;
-  private readonly button: THREE.Mesh;
-  private readonly label: Text;
-  private readonly buttonWorld = new THREE.Vector3();
-  private readonly camWorld = new THREE.Vector3();
-  private readonly labelWorld = new THREE.Vector3();
-  private hovered = false;
-  private active = false;
-  private pressedUntilMs = 0;
-
+export class SectionTab extends TapButton {
   constructor(opts: SectionTabOptions) {
-    this.name = opts.name;
-    this.grabRadiusMultiplier = opts.grabRadiusMultiplier;
-
-    this.group = new THREE.Group();
-    this.group.name = `tab:${opts.name}`;
-
-    this.button = new THREE.Mesh(
-      new THREE.SphereGeometry(BUTTON_RADIUS, 16, 12),
-      new THREE.MeshStandardMaterial({ color: BUTTON_BASE_COLOR }),
-    );
-    this.group.add(this.button);
-
-    // Label sits above the button rather than to the right (Preset's
-    // layout): the tab row is horizontal, so right-of-button labels
-    // would collide with the next tab's button.
-    this.label = new Text();
-    this.label.text = opts.name;
-    this.label.fontSize = LABEL_FONT_SIZE;
-    this.label.color = LABEL_COLOR;
-    this.label.anchorX = 'center';
-    this.label.anchorY = 'bottom';
-    this.label.outlineWidth = LABEL_OUTLINE_WIDTH;
-    this.label.outlineColor = LABEL_OUTLINE_COLOR;
-    this.label.position.set(0, LABEL_OFFSET_Y, 0);
-    this.label.sync();
-    this.group.add(this.label);
+    super({
+      name: opts.name,
+      grabRadiusMultiplier: opts.grabRadiusMultiplier,
+      visuals: VISUALS,
+    });
   }
-
-  get isActive(): boolean {
-    return this.active;
-  }
-
-  setActive(active: boolean): void {
-    if (active === this.active) return;
-    this.active = active;
-    this.refreshButtonEmissive();
-  }
-
-  // Dynamic label update — used for the canonical-forms heading's
-  // chevron flip on expand / collapse (#93). Issues a troika sync;
-  // the cost is a one-frame text re-layout, fine on a press cadence.
-  setName(name: string): void {
-    if (this.label.text === name) return;
-    this.label.text = name;
-    this.label.sync();
-  }
-
-  /**
-   * Test whether `controller`'s forward ray hits the button. On hit, fire
-   * haptics, kick off the press flash, and return true. The caller owns
-   * the active-state bookkeeping (clearing the previously-active tab,
-   * setting this one) — keeps the tab itself unaware of its peers.
-   */
-  tryActivate(controller: THREE.Object3D): boolean {
-    if (!this.rayHitsButton(controller)) return false;
-    this.pressedUntilMs = performance.now() + PRESS_FLASH_DURATION_MS;
-    this.refreshButtonEmissive();
-    pulse(controller);
-    return true;
-  }
-
-  updateHover(controllers: readonly THREE.Object3D[]): void {
-    const hovered = controllers.some((c) => this.rayHitsButton(c));
-    if (hovered === this.hovered) return;
-    this.hovered = hovered;
-    this.refreshButtonEmissive();
-  }
-
-  /** Per-frame: clears the press flash once its window expires. */
-  update(): void {
-    if (this.pressedUntilMs > 0 && performance.now() >= this.pressedUntilMs) {
-      this.pressedUntilMs = 0;
-      this.refreshButtonEmissive();
-    }
-  }
-
-  faceCamera(camera: THREE.Camera): void {
-    camera.getWorldPosition(this.camWorld);
-    this.label.getWorldPosition(this.labelWorld);
-    const dx = this.camWorld.x - this.labelWorld.x;
-    const dz = this.camWorld.z - this.labelWorld.z;
-    this.label.rotation.set(0, Math.atan2(dx, dz), 0);
-  }
-
-  dispose(): void {
-    this.label.dispose();
-    this.button.geometry.dispose();
-    (this.button.material as THREE.Material).dispose();
-  }
-
-  // Emissive priority (highest first): press flash, active, hover, idle.
-  // Press flash sits on top of active so the user gets a beat of feedback
-  // even when re-tapping the already-active tab.
-  private refreshButtonEmissive(): void {
-    const mat = this.button.material as THREE.MeshStandardMaterial;
-    let hex: number;
-    if (this.pressedUntilMs > 0) {
-      hex = BUTTON_PRESS_EMISSIVE;
-    } else if (this.active) {
-      hex = BUTTON_ACTIVE_EMISSIVE;
-    } else if (this.hovered) {
-      hex = BUTTON_HOVER_EMISSIVE;
-    } else {
-      hex = 0x000000;
-    }
-    mat.emissive.setHex(hex);
-  }
-
-  private rayHitsButton(controller: THREE.Object3D): boolean {
-    const rayOrigin = new THREE.Vector3();
-    const rayDir = new THREE.Vector3();
-    controller.getWorldPosition(rayOrigin);
-    rayDir.set(0, 0, -1).applyQuaternion(
-      controller.getWorldQuaternion(new THREE.Quaternion()),
-    );
-    this.button.getWorldPosition(this.buttonWorld);
-    const r = BUTTON_RADIUS * this.grabRadiusMultiplier;
-    return raySphereHit(rayOrigin, rayDir, this.buttonWorld, r);
-  }
-}
-
-
-function pulse(controller: THREE.Object3D): void {
-  const gamepad = (controller as ControllerWithGamepad).userData.gamepad;
-  const actuator = gamepad?.hapticActuators?.[0];
-  if (!actuator) return;
-  (actuator as { pulse?: (a: number, d: number) => void }).pulse?.(
-    HAPTIC_AMPLITUDE,
-    HAPTIC_DURATION_MS,
-  );
 }

--- a/src/scaffold/ui/TapButton.ts
+++ b/src/scaffold/ui/TapButton.ts
@@ -1,0 +1,237 @@
+import * as THREE from 'three';
+import { Text } from 'troika-three-text';
+import { raySphereHit } from '@/scaffold/ui/rayHit';
+
+// Shared base for the project's tap-button-like primitives — `Preset`
+// (#46), `SectionTab` (#57), and `SceneTab` (#150). Owns the bits that
+// every variant has had verbatim since first instance: a sphere mesh,
+// a yaw-billboarded text label, ray-from-controller hit-testing, a
+// haptic pulse on activation, a press-flash emissive that decays after
+// PRESS_FLASH_DURATION_MS, and an optional sticky-active emissive
+// layered underneath the press flash.
+//
+// Lifted out per #156 once the project hit the rule-of-three trigger
+// called out across two prior PRs (`SectionTab.ts` for two instances,
+// `SceneTab.ts` for three). Each subclass picks its visual identity
+// (radius / colors / label size / label placement) via the `visuals`
+// option block; the machinery here is identical across all three.
+//
+// Subclasses are thin: they call `super()` with their visual config
+// and add any per-primitive extra fields (e.g., `Preset` carries
+// `values` / `linearValues`). The full inherited method set
+// (`tryActivate`, `updateHover`, `update`, `faceCamera`, `dispose`,
+// `setActive`, `setName`, `isActive`) is available on all three —
+// Preset doesn't call sticky-active in practice, and `setActive` is a
+// silent visual no-op when `activeEmissive` is omitted from `visuals`
+// (the active branch falls through to hover-or-idle).
+
+export interface TapButtonVisuals {
+  // Prefix for the THREE.Group.name; the full name is
+  // `${groupNamePrefix}:${tap-button name}`. Matches the per-primitive
+  // naming the three originals used (`preset:`, `tab:`, `scene-tab:`).
+  groupNamePrefix: string;
+  buttonRadius: number;
+  baseColor: number;
+  hoverEmissive: number;
+  pressEmissive: number;
+  // Sticky-active emissive. Omit for one-shot tap affordances (Preset)
+  // — `setActive` still flips the internal flag but the active branch
+  // in `refreshButtonEmissive` won't fire, so the visual is unchanged.
+  activeEmissive?: number;
+  labelFontSize: number;
+  // Vertical offset of the label from the button center. Pair with
+  // `labelAnchorY`: 'top' anchor + negative offset places the label
+  // below; 'bottom' anchor + positive offset places it above.
+  labelOffsetY: number;
+  labelAnchorY: 'top' | 'bottom';
+}
+
+export interface TapButtonOptions {
+  name: string;
+  // Ray–button hit-test sphere radius is `buttonRadius *
+  // grabRadiusMultiplier`. Required so each scene declares the
+  // affordance scale rather than inheriting a primitive-internal
+  // default; quadrics passes 2.75 across its rack so Slider /
+  // Preset / SectionTab / SceneTab all share the same feel.
+  grabRadiusMultiplier: number;
+  visuals: TapButtonVisuals;
+}
+
+const HAPTIC_AMPLITUDE = 0.5;
+const HAPTIC_DURATION_MS = 10;
+
+// Momentary press flash duration. Long enough to register as feedback,
+// short enough not to read as a sticky toggle.
+const PRESS_FLASH_DURATION_MS = 150;
+
+const LABEL_COLOR = 0xffffff;
+const LABEL_OUTLINE_WIDTH = '8%';
+const LABEL_OUTLINE_COLOR = 0x000000;
+
+interface ControllerWithGamepad extends THREE.Object3D {
+  userData: { gamepad?: Gamepad };
+}
+
+export class TapButton {
+  readonly group: THREE.Group;
+  readonly name: string;
+
+  private readonly grabRadiusMultiplier: number;
+  private readonly buttonRadius: number;
+  private readonly hoverEmissive: number;
+  private readonly pressEmissive: number;
+  private readonly activeEmissive: number | undefined;
+
+  private readonly button: THREE.Mesh;
+  private readonly label: Text;
+  private readonly buttonWorld = new THREE.Vector3();
+  private readonly camWorld = new THREE.Vector3();
+  private readonly labelWorld = new THREE.Vector3();
+
+  private hovered = false;
+  private active = false;
+  private pressedUntilMs = 0;
+
+  constructor(opts: TapButtonOptions) {
+    this.name = opts.name;
+    this.grabRadiusMultiplier = opts.grabRadiusMultiplier;
+    this.buttonRadius = opts.visuals.buttonRadius;
+    this.hoverEmissive = opts.visuals.hoverEmissive;
+    this.pressEmissive = opts.visuals.pressEmissive;
+    this.activeEmissive = opts.visuals.activeEmissive;
+
+    this.group = new THREE.Group();
+    this.group.name = `${opts.visuals.groupNamePrefix}:${opts.name}`;
+
+    this.button = new THREE.Mesh(
+      new THREE.SphereGeometry(this.buttonRadius, 16, 12),
+      new THREE.MeshStandardMaterial({ color: opts.visuals.baseColor }),
+    );
+    this.group.add(this.button);
+
+    this.label = new Text();
+    this.label.text = opts.name;
+    this.label.fontSize = opts.visuals.labelFontSize;
+    this.label.color = LABEL_COLOR;
+    this.label.anchorX = 'center';
+    this.label.anchorY = opts.visuals.labelAnchorY;
+    this.label.outlineWidth = LABEL_OUTLINE_WIDTH;
+    this.label.outlineColor = LABEL_OUTLINE_COLOR;
+    this.label.position.set(0, opts.visuals.labelOffsetY, 0);
+    this.label.sync();
+    this.group.add(this.label);
+  }
+
+  // Gated on `activeEmissive` so one-shot tap affordances (Preset, which
+  // omits `activeEmissive` from its visuals) can never report a sticky-
+  // active state — `setActive(true)` flips the internal flag but the
+  // emissive priority skips the active branch, so externally there is
+  // nothing "active" to report. Tightens the API/visual contract: if the
+  // button can't *show* active, it can't *be* active.
+  get isActive(): boolean {
+    return this.active && this.activeEmissive !== undefined;
+  }
+
+  setActive(active: boolean): void {
+    if (active === this.active) return;
+    this.active = active;
+    this.refreshButtonEmissive();
+  }
+
+  // Dynamic label update — used by the canonical-forms heading's
+  // chevron flip on expand / collapse (#93). Issues a troika sync;
+  // the cost is a one-frame text re-layout, fine on a press cadence.
+  setName(name: string): void {
+    if (this.label.text === name) return;
+    this.label.text = name;
+    this.label.sync();
+  }
+
+  /**
+   * Test whether `controller`'s forward ray hits the button. On hit, fire
+   * haptics, kick off the press flash, and return true. The caller owns
+   * any sticky-active bookkeeping (clearing the previously-active peer,
+   * setting this one) — keeping the dispatch out here means a button
+   * doesn't need a reference to its peers.
+   */
+  tryActivate(controller: THREE.Object3D): boolean {
+    if (!this.rayHitsButton(controller)) return false;
+    this.pressedUntilMs = performance.now() + PRESS_FLASH_DURATION_MS;
+    this.refreshButtonEmissive();
+    pulse(controller);
+    return true;
+  }
+
+  updateHover(controllers: readonly THREE.Object3D[]): void {
+    const hovered = controllers.some((c) => this.rayHitsButton(c));
+    if (hovered === this.hovered) return;
+    this.hovered = hovered;
+    this.refreshButtonEmissive();
+  }
+
+  /** Per-frame: clears the press flash once its window expires. */
+  update(): void {
+    if (this.pressedUntilMs > 0 && performance.now() >= this.pressedUntilMs) {
+      this.pressedUntilMs = 0;
+      this.refreshButtonEmissive();
+    }
+  }
+
+  // Yaw-only billboard for the text label, matching the family / per-
+  // slider labels — head pitch and roll stay out (#29).
+  faceCamera(camera: THREE.Camera): void {
+    camera.getWorldPosition(this.camWorld);
+    this.label.getWorldPosition(this.labelWorld);
+    const dx = this.camWorld.x - this.labelWorld.x;
+    const dz = this.camWorld.z - this.labelWorld.z;
+    this.label.rotation.set(0, Math.atan2(dx, dz), 0);
+  }
+
+  dispose(): void {
+    this.label.dispose();
+    this.button.geometry.dispose();
+    (this.button.material as THREE.Material).dispose();
+  }
+
+  // Emissive priority (highest first): press flash, active, hover, idle.
+  // Press flash sits on top of active so the user gets a beat of feedback
+  // even when re-tapping the already-active button. When `activeEmissive`
+  // is omitted (one-shot tap affordances), the active branch falls
+  // through and `setActive(true)` is a visual no-op.
+  private refreshButtonEmissive(): void {
+    const mat = this.button.material as THREE.MeshStandardMaterial;
+    let hex: number;
+    if (this.pressedUntilMs > 0) {
+      hex = this.pressEmissive;
+    } else if (this.active && this.activeEmissive !== undefined) {
+      hex = this.activeEmissive;
+    } else if (this.hovered) {
+      hex = this.hoverEmissive;
+    } else {
+      hex = 0x000000;
+    }
+    mat.emissive.setHex(hex);
+  }
+
+  private rayHitsButton(controller: THREE.Object3D): boolean {
+    const rayOrigin = new THREE.Vector3();
+    const rayDir = new THREE.Vector3();
+    controller.getWorldPosition(rayOrigin);
+    rayDir.set(0, 0, -1).applyQuaternion(
+      controller.getWorldQuaternion(new THREE.Quaternion()),
+    );
+    this.button.getWorldPosition(this.buttonWorld);
+    const r = this.buttonRadius * this.grabRadiusMultiplier;
+    return raySphereHit(rayOrigin, rayDir, this.buttonWorld, r);
+  }
+}
+
+function pulse(controller: THREE.Object3D): void {
+  const gamepad = (controller as ControllerWithGamepad).userData.gamepad;
+  const actuator = gamepad?.hapticActuators?.[0];
+  if (!actuator) return;
+  (actuator as { pulse?: (a: number, d: number) => void }).pulse?.(
+    HAPTIC_AMPLITUDE,
+    HAPTIC_DURATION_MS,
+  );
+}


### PR DESCRIPTION
Closes #156

## Summary

Three primitives — `Preset` (#46), `SectionTab` (#57), `SceneTab` (#150) — shared a verbatim-duplicate copy of the same machinery (sphere mesh + ray-hit + press-flash + haptic + yaw-billboard label + emissive priority + dispose) and differed only in visual config (radius, colors, label size/anchor) and per-primitive extras. The rule-of-three trigger called out in `SectionTab.ts` and `SceneTab.ts` for two PRs running has fired; this lifts the shared machinery into a new `scaffold/ui/TapButton` base. Each primitive becomes a thin subclass that calls `super()` with its visual identity; Preset keeps its `values` / `linearValues` extra fields.

`isActive` on the base is gated on `activeEmissive !== undefined` so one-shot affordances (Preset, which omits `activeEmissive`) can never report a sticky-active state — if the button can't show active, it can't be active.

Pure refactor — no user-visible change. Net: −197 lines (−536 from the three originals + 339 in the new base + thin subclasses).

## Test plan

- [x] `npm run build` — tsc + vite clean.
- [x] `npm test` — 119/119 vitest pass.
- [x] `npm run lint` — eslint clean.
- [x] Roundtable review (Sonnet + GPT-5.5 Pro + DeepSeek V4 Pro) — round 2 unanimous PUSH after two tightening patches (drop dead `LabelAnchorY` export; gate `isActive` on `activeEmissive`).
- [ ] Cloudflare PR preview headset smoke (no behavior change expected; verify quadrics presets + section tabs + scene rack still tap, hover, sticky-active correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)