### PR TITLE
feat(scene): tangent-planes — point-selection sliders walking the surface (#147)

### DIFF
--- a/src/exhibits/tangent-planes/SPEC.md
+++ b/src/exhibits/tangent-planes/SPEC.md
@@ -1,0 +1,128 @@
+# `tangent-planes` exhibit — SPEC
+
+> Math + UX contract for the tangent-planes scene. v0.6 first cut: point
+> selection on a fixed unit sphere (#147). Tangent plane mesh (#148) and
+> live readout (#149) extend this in subsequent PRs.
+
+## Goal
+
+An interactive WebXR scene where the learner drags two angular sliders to
+walk a point continuously across an implicit quadric surface, watching
+the contact point move while the same surface stays put. Anchors the
+"tangent plane reorients as the contact point moves" intuition for APPM
+2350 §11.4 (Tangent Planes and Linear Approximations) — without yet
+showing the plane (which lands in #148).
+
+Sibling of `quadrics` in the `calculus3` cluster; the SceneRack swaps
+between them at runtime.
+
+## Equation form
+
+The surface is the level set of `f(x, y, z) = x² + y² + z² − 1` — the
+canonical unit sphere. Coefficient editability is **out of scope for
+v0.6** by deliberate choice (not by accident):
+
+- The §11.4 pedagogy goal is internalizing what the tangent plane *is* —
+  a flat local approximation that reorients as the contact point moves.
+  That story is fully told by *one* surface; varying the surface family
+  swaps in a competing "different surfaces have different curvatures"
+  lesson that belongs in a separate scene if anywhere.
+- The quadrics manipulator scene already covers the
+  "morph the surface family" story. Sibling scenes should differ in
+  *what they teach*, not duplicate the surface UI.
+- This satisfies the conditional `if a/b/c/d remain editable` line in
+  the #147 acceptance vacuously — coefficient sliders are absent, so
+  there are no coefficient changes to track.
+
+Revisit if pedagogy demands; v0.7+ may layer in coefficient sliders, at
+which point the `SURFACE` block in `index.ts` would split into a tagged
+union of fixed surfaces.
+
+## Point parameterization
+
+Math frame (X right, Y forward, Z up; per `scaffold/math/frames.ts`).
+
+- `θ ∈ [0, π]` — polar angle from +math-Z (up).
+  - θ = 0 ⇒ direction = +math-Z (north pole, up)
+  - θ = π ⇒ direction = −math-Z (south pole, down)
+- `φ ∈ [−π, π]` — azimuth in the math-XY plane, from +math-X.
+  - φ = 0 ⇒ +math-X (right)
+  - φ = π/2 ⇒ +math-Y (forward, away from the user)
+  - φ = ±π ⇒ −math-X (left)
+
+Direction (math frame): `d_math = (sin θ cos φ, sin θ sin φ, cos θ)`.
+The point is the nearest *forward* surface intersection along that ray
+from the surface center. CPU-side raymarch + bisection in
+`raycastSurface.ts`; visually agrees with the GPU shader because both
+share the same `f` definition (paired GLSL/JS in `index.ts`).
+
+## Initial pose
+
+`θ₀ = π/3`, `φ₀ = π/4`. Off both poles, off every snap point. On first
+load both sliders show immediate response — avoiding the failure mode
+where θ = 0 (north pole) makes φ visually inert until θ moves.
+
+## Slider model
+
+Mirrors quadrics' detent contract: the emitted value (`currentValue`)
+snaps inside each detent's half-width, while the underlying accumulator
+(`rawValue`) integrates hand motion freely so slow drags escape the snap
+naturally.
+
+- `snapDetent` half-width: 0.05 (matches quadrics).
+- θ snap points: `[0, π/2, π]` — north pole, equator, south pole.
+- φ snap points: `[−π, −π/2, 0, π/2, π]` — four cardinal compass
+  directions plus the wrap-equivalent ±π.
+
+The `±π` φ snap points map to the same spatial direction (−math-X), so
+the −X cardinal has an effective ~2× capture window compared to the
+other three φ cardinals. This is deliberate: the slider range is
+**closed (non-wrapping)** — `−π` and `π` are distinct slider positions
+even though they produce identical surface points. v0.7+ could wrap
+φ if headset feel asks for it.
+
+Slider visuals: neutral light gray base color (`0xaaaaaa`), sphere thumb
+shape — angular parameters carry no spatial axis to map an arrow to,
+and a non-axis color separates them from the axis-coefficient sliders
+in quadrics' rack.
+
+## Indicator
+
+Small sphere mesh — radius 0.04 m, neutral light gray (`0xdddddd`),
+`MeshStandardMaterial`. Sized to read as "a point on the surface"
+rather than a sphere of its own. Hidden when the raymarch returns a
+miss — for v0.6's unit sphere no miss can happen (every direction from
+the origin hits at distance 1), but the path is in place for future
+coefficient editing where ray-origin choice may not enclose the
+surface.
+
+## Render
+
+Minimal lambert: `uBaseColor * (0.2 + 0.8 * max(dot(n, normalize(uLightDir)), 0))`.
+No grid, no parametric grid, no cross-section glow. The visual focus
+belongs on the indicator + (later) the tangent plane; a busy surface
+competes.
+
+Same `SURFACE_CENTER`, `LIGHT_DIR`, and `uBaseColor` as quadrics so the
+surface reads as a sibling. World-axis grid deferred to a later cut if
+headset feel calls for orientation continuity beyond the math-frame
+indicator.
+
+## Out of scope (v0.6)
+
+- **Tangent plane mesh** (#148) — consumes `result.point` + `result.normal`
+  from `raycastImplicit`'s return type. No new entry points needed in
+  `raycastSurface.ts`.
+- **Live readout of plane equation / normal** (#149) — same.
+- **Coefficient editing** — see "Equation form" above.
+- **Controller-aim point picking** — natural in headset, unusable on
+  the pancake build (#105) and Cloudflare PR previews. Deferred to v0.9.
+- **Floor** — quadrics needs a hole-punched floor for its 3.5 m
+  bounding cube; tangent-planes' 1.5 m cube doesn't intersect a
+  ground-level floor at the surface center, so a floor is unwarranted
+  for v0.6.
+- **Equation readout, preset rack, sections.** Not warranted by this
+  scene's UI.
+- **Ray-origin choice for translated quadrics.** Currently fixed at the
+  surface-local origin, which works only because the unit sphere
+  encloses it. Note for any future surface that doesn't.

--- a/src/exhibits/tangent-planes/directionFromAngles.ts
+++ b/src/exhibits/tangent-planes/directionFromAngles.ts
@@ -1,0 +1,37 @@
+import type { MathVec3 } from '@/scaffold/math/frames';
+
+// Pure math-frame helper for the tangent-planes scene's θ/φ point parametrization
+// (#147). Lives in its own file so test/exhibits/tangent-planes/* can import it
+// without triggering `index.ts`'s `registerExhibit` side effect at unit-test
+// import time — the same isolation pattern as quadrics' `classify.ts`.
+//
+// Math frame: X right, Y forward, Z up (#43, scaffold/math/frames.ts).
+//   θ ∈ [0, π]  is polar angle from +math-Z (up).
+//                 θ = 0 ⇒ direction = +math-Z (north pole, up)
+//                 θ = π ⇒ direction = −math-Z (south pole, down)
+//   φ ∈ [−π, π] is azimuth in the math-XY plane, measured from +math-X.
+//                 φ = 0   ⇒ +math-X (right)
+//                 φ = π/2 ⇒ +math-Y (forward, away from the user)
+//                 φ = ±π  ⇒ −math-X (left; both ±π map to the same direction
+//                           — the slider range is closed, not wrapping)
+
+/**
+ * Compute the math-frame direction for spherical angles (θ, φ).
+ *
+ * `out` is mutated in place to keep this allocation-free in the per-frame
+ * update path. `out` must be a mutable tuple — declaring it as `MathVec3`
+ * (which is `readonly [number, number, number]`) would block the index
+ * writes here. The return is typed `MathVec3` so callers reading the value
+ * see the immutable view; the underlying tuple is shared with the caller.
+ */
+export function directionFromAngles(
+  theta: number,
+  phi: number,
+  out: [number, number, number],
+): MathVec3 {
+  const sinT = Math.sin(theta);
+  out[0] = sinT * Math.cos(phi);
+  out[1] = sinT * Math.sin(phi);
+  out[2] = Math.cos(theta);
+  return out;
+}

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -1,0 +1,334 @@
+import * as THREE from 'three';
+import type { Exhibit, ExhibitContext } from '../../shell/Exhibit';
+import { CLUSTER_CALCULUS3 } from '../../shell/clusters';
+import { registerExhibit } from '../../shell/registry';
+import { writeMathToWorld, type MathVec3 } from '@/scaffold/math/frames';
+import { createImplicitSurface } from '@/scaffold/render/ImplicitSurface';
+import { Slider } from '@/scaffold/ui/Slider';
+import { WorldAxes, type AxisName } from '@/scaffold/ui/WorldAxes';
+import { DEFAULT_AXIS_COLORS } from '@/scaffold/design/tokens';
+import { directionFromAngles } from './directionFromAngles';
+import { raycastImplicit } from './raycastSurface';
+
+// Tangent-planes scene (#147). First sub-issue of the #121 epic — sets up
+// the v0.6 scene's surface + θ/φ point selection so #148 (tangent-plane
+// mesh) and #149 (live readout) can hang their visuals off the indicator.
+//
+// Pedagogy target: APPM 2350 §11.4 (Tangent Planes and Linear Approximations).
+// Stuck-point: students treat tangent-plane problems as rote symbol
+// manipulation — compute the gradient, dot it with (x − x₀, y − y₀, z − z₀),
+// set equal to zero. They don't internalize that the plane *reorients* as
+// the point moves. v0.6's contribution: a slider-driven point that walks
+// the surface continuously; v0.7+ (#148) hangs the actual plane on it.
+//
+// Surface choice: fixed canonical unit sphere `x² + y² + z² = 1`. No
+// coefficient sliders — the quadrics manipulator already covers
+// surface-family morphing; sibling scenes should differ in *what they
+// teach*, not duplicate the surface UI. Decision recorded in SPEC.md.
+
+// ────────────────────────────────────────────────────────────────────
+// Constants
+// ────────────────────────────────────────────────────────────────────
+
+// Match quadrics' SURFACE_CENTER + SLIDER_RACK_CENTER + axis-indicator
+// position so navigating between cluster siblings doesn't visually
+// relocate the surface. The same arm's-length depth (z = -0.7) carries
+// across all rack tiers (slider rack, SectionTab rack, SceneRack).
+const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
+const SLIDER_RACK_CENTER = new THREE.Vector3(0, 1.0, -0.7);
+const AXIS_INDICATOR_POSITION = new THREE.Vector3(0.35, 1.17, -0.7);
+
+// Tighter than quadrics' BOUND=3.5: the unit sphere fits in [-1, 1]³ with
+// room to spare; no coefficient-driven expansion to budget for.
+const BOUND = 1.5;
+
+// Same lighting + base color as quadrics so the surface reads as a sibling.
+const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
+const BASE_COLOR = new THREE.Color(0.4, 0.7, 0.95);
+
+// Quadrics' design feel ports across.
+const SLIDER_SNAP_DETENT = 0.05;
+const GRAB_RADIUS_MULTIPLIER = 2.75;
+const SLIDER_ROW_PITCH = 0.14;
+
+// θ ∈ [0, π], snap at the two poles + the equator. φ ∈ [-π, π], snap at
+// the four cardinal compass directions; the ±π double-snap makes the
+// −math-X cardinal a 2× wider capture window than the others, accepted
+// per §3.2 of the plan (closed-range slider, not wrapping).
+const THETA_SNAP_POINTS: readonly number[] = [0, Math.PI / 2, Math.PI];
+const PHI_SNAP_POINTS: readonly number[] = [
+  -Math.PI,
+  -Math.PI / 2,
+  0,
+  Math.PI / 2,
+  Math.PI,
+];
+
+// Initial pose: off both poles AND off every snap point so the user sees
+// both sliders responding immediately on first load. Matches the §3.5
+// plan choice locked after the GPT #2 v1-roundtable finding.
+const THETA_INITIAL = Math.PI / 3;
+const PHI_INITIAL = Math.PI / 4;
+
+// Off-axis neutral gray so the user doesn't read these as
+// axis-coefficient sliders (vermillion / bluish-green / sky-blue carry
+// math-X / Y / Z meaning across the cluster).
+const SLIDER_BASE_COLOR = 0xaaaaaa;
+
+// Indicator visual: small enough to read as "a point on the surface"
+// rather than as a sphere of its own; large enough to remain visible
+// from the user's spawn ~2.5 m away.
+const INDICATOR_RADIUS = 0.04;
+const INDICATOR_COLOR = 0xdddddd;
+
+const AXIS_COLORS: Record<AxisName, number> = DEFAULT_AXIS_COLORS;
+
+// ────────────────────────────────────────────────────────────────────
+// Surface model — paired GLSL + JS so the rendered surface and the CPU
+// raymarch stay in sync. Drift between the two would surface as the
+// indicator tracking a different surface than the user sees rendered.
+// Co-locating them here makes drift a code-review-visible event.
+//
+// `fImplicit(p)` is evaluated in surface-local coords — the
+// `createImplicitSurface` harness pre-positions the mesh at
+// `surfaceCenter` and computes `ro = cameraPosition - uSurfaceCenter`
+// internally, so the consumer sees a surface centered on the origin
+// even though the rendered mesh sits at `SURFACE_CENTER` in world.
+// ────────────────────────────────────────────────────────────────────
+
+const SURFACE_F_IMPLICIT_GLSL = /* glsl */ `
+  float fImplicit(vec3 p) {
+    return p.x * p.x + p.y * p.y + p.z * p.z - 1.0;
+  }
+`;
+const SURFACE_GRAD_F_GLSL = /* glsl */ `
+  vec3 gradF(vec3 p) {
+    return 2.0 * p;
+  }
+`;
+const fJs = (x: number, y: number, z: number): number =>
+  x * x + y * y + z * z - 1;
+const gradJs = (x: number, y: number, z: number): MathVec3 => [
+  2 * x,
+  2 * y,
+  2 * z,
+];
+
+const SURFACE_UNIFORM_DECLS = /* glsl */ `
+  uniform vec3 uLightDir;
+  uniform vec3 uBaseColor;
+`;
+const SURFACE_SHADE = /* glsl */ `
+  vec3 shadeHit(vec3 pHit, vec3 n, vec3 hitWorld, vec3 rd) {
+    float lambert = max(dot(n, normalize(uLightDir)), 0.0);
+    return uBaseColor * (0.2 + 0.8 * lambert);
+  }
+`;
+
+// ────────────────────────────────────────────────────────────────────
+// Module-scoped state
+// ────────────────────────────────────────────────────────────────────
+
+// Persistent scratch — allocated once at module scope, never disposed.
+// `dirMath` MUST be the mutable tuple form (not `MathVec3`, which is
+// `readonly [...]` — the readonly annotation would block the index
+// writes inside `directionFromAngles`).
+const indicatorWorld = new THREE.Vector3();
+const dirMath: [number, number, number] = [0, 0, 0];
+
+// Named handles — initialized in mount, disposed inline in unmount.
+let surfaceMesh: THREE.Mesh | undefined;
+let surfaceMaterial: THREE.ShaderMaterial | undefined;
+let thetaSlider: Slider | undefined;
+let phiSlider: Slider | undefined;
+let indicator: THREE.Mesh | undefined;
+let worldAxes: WorldAxes | undefined;
+let controllers: readonly THREE.Object3D[] = [];
+// Cached at mount; cleared at unmount. Used for the WorldAxes label
+// yaw-billboarding in update().
+let camera: THREE.Camera | undefined;
+
+// ────────────────────────────────────────────────────────────────────
+// Exhibit
+// ────────────────────────────────────────────────────────────────────
+
+const tangentPlanesExhibit: Exhibit = {
+  id: 'tangent-planes',
+  title: 'Tangent planes',
+  cluster: CLUSTER_CALCULUS3,
+
+  mount({ group, camera: cam, controllers: shellControllers }: ExhibitContext) {
+    controllers = shellControllers;
+    camera = cam;
+
+    // Ambient + directional lights matching quadrics' lighting setup.
+    group.add(new THREE.AmbientLight(0xffffff, 0.4));
+    const directional = new THREE.DirectionalLight(0xffffff, 0.8);
+    directional.position.copy(LIGHT_DIR).multiplyScalar(5);
+    group.add(directional);
+
+    // Implicit-surface mesh + ShaderMaterial via the shared harness.
+    const surfaceHandles = createImplicitSurface({
+      surfaceCenter: SURFACE_CENTER,
+      bound: BOUND,
+      uniforms: SURFACE_UNIFORM_DECLS,
+      fImplicit: SURFACE_F_IMPLICIT_GLSL,
+      gradF: SURFACE_GRAD_F_GLSL,
+      shade: SURFACE_SHADE,
+      extraUniforms: {
+        uLightDir: { value: LIGHT_DIR.clone() },
+        uBaseColor: { value: BASE_COLOR.clone() },
+      },
+    });
+    surfaceMesh = surfaceHandles.mesh;
+    surfaceMaterial = surfaceHandles.material;
+    group.add(surfaceHandles.mesh);
+
+    // θ slider on top, φ below. Centered horizontally on the rack;
+    // pitch matches quadrics' SLIDER_ROW_PITCH so the rack reads as a
+    // sibling.
+    const thetaY = SLIDER_RACK_CENTER.y + 0.5 * SLIDER_ROW_PITCH;
+    const phiY = SLIDER_RACK_CENTER.y - 0.5 * SLIDER_ROW_PITCH;
+
+    thetaSlider = new Slider({
+      label: 'θ',
+      min: 0,
+      max: Math.PI,
+      initial: THETA_INITIAL,
+      snapDetent: SLIDER_SNAP_DETENT,
+      snapPoints: THETA_SNAP_POINTS,
+      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER,
+      baseColor: SLIDER_BASE_COLOR,
+      thumbShape: 'sphere',
+    });
+    thetaSlider.group.position.set(
+      SLIDER_RACK_CENTER.x,
+      thetaY,
+      SLIDER_RACK_CENTER.z,
+    );
+    group.add(thetaSlider.group);
+
+    phiSlider = new Slider({
+      label: 'φ',
+      min: -Math.PI,
+      max: Math.PI,
+      initial: PHI_INITIAL,
+      snapDetent: SLIDER_SNAP_DETENT,
+      snapPoints: PHI_SNAP_POINTS,
+      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER,
+      baseColor: SLIDER_BASE_COLOR,
+      thumbShape: 'sphere',
+    });
+    phiSlider.group.position.set(
+      SLIDER_RACK_CENTER.x,
+      phiY,
+      SLIDER_RACK_CENTER.z,
+    );
+    group.add(phiSlider.group);
+
+    // Point indicator. Positioned in update() each frame.
+    indicator = new THREE.Mesh(
+      new THREE.SphereGeometry(INDICATOR_RADIUS, 16, 12),
+      new THREE.MeshStandardMaterial({ color: INDICATOR_COLOR }),
+    );
+    group.add(indicator);
+
+    // Math-frame axis indicator — same anchor as quadrics.
+    worldAxes = new WorldAxes({ axisColors: AXIS_COLORS });
+    worldAxes.group.position.copy(AXIS_INDICATOR_POSITION);
+    group.add(worldAxes.group);
+  },
+
+  update() {
+    if (!thetaSlider || !phiSlider || !indicator) return;
+
+    // Slider hover + drag tick.
+    thetaSlider.updateHover(controllers);
+    phiSlider.updateHover(controllers);
+    thetaSlider.update();
+    phiSlider.update();
+
+    // Math-frame direction from θ/φ — mutates `dirMath` in place; no
+    // per-frame allocation.
+    directionFromAngles(thetaSlider.value, phiSlider.value, dirMath);
+
+    // CPU raymarch in surface-local coords. Origin is the sphere center
+    // (sphere is centered at the surface-local origin by construction).
+    const result = raycastImplicit({
+      f: fJs,
+      gradF: gradJs,
+      origin: [0, 0, 0],
+      dir: dirMath,
+      bound: BOUND,
+    });
+
+    if (result.hit) {
+      indicator.visible = true;
+      // Surface-local math-frame point → world. `writeMathToWorld` is
+      // the non-allocating helper from scaffold/math/frames.ts;
+      // `indicatorWorld` is the module-scope scratch.
+      writeMathToWorld(result.point, indicatorWorld);
+      indicator.position.copy(indicatorWorld).add(SURFACE_CENTER);
+      // result.normal is unused in this PR; #148 will read it to orient
+      // the tangent-plane mesh.
+    } else {
+      indicator.visible = false;
+    }
+
+    // Yaw-only billboard on the WorldAxes letter labels (X / Y / Z), so
+    // they read at any user yaw. Same per-frame contract as quadrics.
+    if (worldAxes && camera) worldAxes.faceCamera(camera);
+  },
+
+  unmount() {
+    // 1. Release any active controller grabs so disposed sliders don't
+    //    leak grab references back into the shell's controller objects.
+    for (const c of controllers) {
+      thetaSlider?.releaseFromController(c);
+      phiSlider?.releaseFromController(c);
+    }
+
+    // 2. Dispose named handles — geometry + material per Three.js
+    //    convention. Each resource has exactly one disposal owner; named
+    //    handles are NEVER pushed into generic disposal arrays (per the
+    //    quadrics #150-v4 ownership rule, mirrored here).
+    if (surfaceMesh) {
+      surfaceMesh.geometry.dispose();
+      surfaceMesh = undefined;
+    }
+    if (surfaceMaterial) {
+      surfaceMaterial.dispose();
+      surfaceMaterial = undefined;
+    }
+    if (indicator) {
+      indicator.geometry.dispose();
+      (indicator.material as THREE.Material).dispose();
+      indicator = undefined;
+    }
+    thetaSlider?.dispose();
+    thetaSlider = undefined;
+    phiSlider?.dispose();
+    phiSlider = undefined;
+    worldAxes?.dispose();
+    worldAxes = undefined;
+
+    // 3. Drop external references so a re-mount starts clean. The shell
+    //    removes ctx.group and its descendants automatically.
+    controllers = [];
+    camera = undefined;
+  },
+
+  onSelectStart(controller: THREE.Object3D) {
+    if (thetaSlider?.tryGrab(controller)) return;
+    phiSlider?.tryGrab(controller);
+  },
+
+  onSelectEnd(controller: THREE.Object3D) {
+    thetaSlider?.releaseFromController(controller);
+    phiSlider?.releaseFromController(controller);
+  },
+};
+
+registerExhibit(tangentPlanesExhibit);
+
+export default tangentPlanesExhibit;

--- a/src/exhibits/tangent-planes/raycastSurface.ts
+++ b/src/exhibits/tangent-planes/raycastSurface.ts
@@ -1,0 +1,177 @@
+import type { MathVec3 } from '@/scaffold/math/frames';
+
+// CPU-side raymarch + bisect against an axis-aligned bounded implicit surface
+// f(p) = 0 (#147). Mirrors the GPU pass in `scaffold/render/ImplicitSurface.ts`
+// — same fixed-step march for sign change, same bisection refinement — so the
+// indicator (CPU) and the rendered surface (GPU) agree on hit position. Pure;
+// allocation-light (one `Vec3Mut` for the hit point built up in place, plus
+// the gradient eval's return).
+//
+// Domain: forward-only. After AABB clip, `t0 = max(tNear, 0)` so origins
+// allowed *inside* the AABB don't pick up back-side intersections (the v1
+// plan-review's GPT #1 / HIGH finding — without the clamp, an origin at
+// [0,0,0] inside the unit-sphere AABB and a +x direction marches from
+// t = -1.5, finds the back-side sign change at t ≈ -1, and returns the
+// wrong-side hit).
+
+export type Vec3Mut = [number, number, number];
+
+export interface RaycastHit {
+  hit: true;
+  point: MathVec3;   // surface-local
+  normal: MathVec3;  // surface-local, unit, outward (= normalize(gradF(point)))
+}
+
+export interface RaycastMiss {
+  hit: false;
+}
+
+export type RaycastResult = RaycastHit | RaycastMiss;
+
+export interface RaycastOptions {
+  /** Implicit surface scalar in surface-local coords. Surface is `f = 0`. */
+  f: (x: number, y: number, z: number) => number;
+  /**
+   * Closed-form gradient of `f` in surface-local coords. Required — keep
+   * `raycastImplicit` thin and force the consumer to supply analytic
+   * gradients for every surface used here. Central differences are not
+   * a fallback: they amplify floating-point noise on flat regions
+   * (#116-style artifact) and the v0.6 surfaces all have closed forms.
+   */
+  gradF: (x: number, y: number, z: number) => MathVec3;
+  /** Ray origin in surface-local coords. */
+  origin: MathVec3;
+  /** Ray direction in surface-local coords; assumed unit-length. */
+  dir: MathVec3;
+  /** Half-extent of the AABB around the surface origin. */
+  bound: number;
+  /**
+   * Number of uniform march steps across `[t0, tFar]`. Defaults to 64 — the
+   * GPU harness's tuned default per #102. Lower is cheaper and more
+   * aliasing-prone.
+   */
+  steps?: number;
+  /**
+   * Bisection iterations after a sign change is detected. Defaults to 8 —
+   * yields ~stepWidth/2^8 precision; for the v0.6 unit sphere with
+   * `bound=1.5, steps=64`, that's ~1.8e-4 m.
+   */
+  bisect?: number;
+}
+
+const DEFAULT_STEPS = 64;
+const DEFAULT_BISECT = 8;
+
+/**
+ * Raymarch a ray against an implicit surface, returning the nearest forward
+ * intersection (and its outward unit normal) or a miss.
+ *
+ * The returned `point` and `normal` are fresh tuples — safe to retain across
+ * frames. Allocates two `MathVec3` per hit; the per-frame caller in
+ * `tangent-planes/index.ts` accepts this since it only happens on hit
+ * frames (and v0.6's unit sphere always hits, so two allocs/frame).
+ */
+export function raycastImplicit(opts: RaycastOptions): RaycastResult {
+  const { f, gradF, origin, dir, bound } = opts;
+  const steps = opts.steps ?? DEFAULT_STEPS;
+  const bisect = opts.bisect ?? DEFAULT_BISECT;
+
+  // 1. AABB clip via the slabs method. Direction components of zero are
+  //    handled correctly by `1.0 / 0 = ±Infinity`: the resulting slab
+  //    intervals collapse to `±Infinity`, and `min`/`max` propagate them
+  //    so the on-axis cardinal-direction tests still resolve.
+  const invDx = 1 / dir[0];
+  const invDy = 1 / dir[1];
+  const invDz = 1 / dir[2];
+  const t0x = (-bound - origin[0]) * invDx;
+  const t1x = (+bound - origin[0]) * invDx;
+  const t0y = (-bound - origin[1]) * invDy;
+  const t1y = (+bound - origin[1]) * invDy;
+  const t0z = (-bound - origin[2]) * invDz;
+  const t1z = (+bound - origin[2]) * invDz;
+  const tMinX = Math.min(t0x, t1x);
+  const tMaxX = Math.max(t0x, t1x);
+  const tMinY = Math.min(t0y, t1y);
+  const tMaxY = Math.max(t0y, t1y);
+  const tMinZ = Math.min(t0z, t1z);
+  const tMaxZ = Math.max(t0z, t1z);
+  const tNear = Math.max(tMinX, tMinY, tMinZ);
+  const tFar = Math.min(tMaxX, tMaxY, tMaxZ);
+  if (tFar < tNear) return { hit: false };
+  // Ray entirely behind the origin — nothing forward can hit.
+  if (tFar < 0) return { hit: false };
+
+  // 2. Forward-only domain.
+  const t0 = Math.max(tNear, 0);
+
+  // 3. Uniform march from t0 to tFar, watching for a sign flip in f.
+  const dt = (tFar - t0) / steps;
+  // Guard the degenerate case where t0 ≈ tFar (e.g., origin exactly at a
+  // corner). No interval to march; treat as a miss.
+  if (!(dt > 0)) return { hit: false };
+
+  let tPrev = t0;
+  let fPrev = f(
+    origin[0] + dir[0] * tPrev,
+    origin[1] + dir[1] * tPrev,
+    origin[2] + dir[2] * tPrev,
+  );
+  let tHit = 0;
+  let foundSignChange = false;
+
+  for (let i = 1; i <= steps; i++) {
+    const tNext = t0 + i * dt;
+    const fNext = f(
+      origin[0] + dir[0] * tNext,
+      origin[1] + dir[1] * tNext,
+      origin[2] + dir[2] * tNext,
+    );
+    if (fPrev * fNext < 0) {
+      // 4. Bisect to refine the bracket.
+      let lo = tPrev;
+      let hi = tNext;
+      let fLo = fPrev;
+      for (let b = 0; b < bisect; b++) {
+        const mid = 0.5 * (lo + hi);
+        const fMid = f(
+          origin[0] + dir[0] * mid,
+          origin[1] + dir[1] * mid,
+          origin[2] + dir[2] * mid,
+        );
+        if (fLo * fMid < 0) {
+          hi = mid;
+        } else {
+          lo = mid;
+          fLo = fMid;
+        }
+      }
+      tHit = 0.5 * (lo + hi);
+      foundSignChange = true;
+      break;
+    }
+    tPrev = tNext;
+    fPrev = fNext;
+  }
+
+  if (!foundSignChange) return { hit: false };
+
+  // 5. Compose the hit point + outward unit normal. `gradF` points outward
+  //    by convention (∇f points in the direction of increasing f, and for
+  //    `f < 0` inside / `f > 0` outside that's outward).
+  const px = origin[0] + dir[0] * tHit;
+  const py = origin[1] + dir[1] * tHit;
+  const pz = origin[2] + dir[2] * tHit;
+  const g = gradF(px, py, pz);
+  const gLen = Math.hypot(g[0], g[1], g[2]);
+  // Defensive: at a critical point (∇f = 0) the normal is undefined.
+  // Treat as miss rather than emit a NaN-laced normal that would propagate
+  // into the indicator's transform. For non-degenerate quadrics this
+  // branch never fires inside the visible region.
+  if (gLen === 0 || !Number.isFinite(gLen)) return { hit: false };
+
+  return {
+    hit: true,
+    point: [px, py, pz],
+    normal: [g[0] / gLen, g[1] / gLen, g[2] / gLen],
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,14 @@ import { bootShell } from './shell/shell';
 // Side-effect imports register each exhibit with the shell registry.
 // Add new exhibits here as they ship; the URL-param selector in
 // shell.ts then routes ?exhibit=<id> to the matching registration.
+//
+// Order matters: `registerExhibit` appends in import order, the shell's
+// cluster filter preserves it, and `clusterExhibits[0]` is the bare-URL
+// boot default. Quadrics stays first (cluster default + first SceneRack
+// tab); tangent-planes second (pre-warmed as a non-default sibling at
+// boot). `hello` stays last — cluster-less, filtered out of the rack.
 import './exhibits/quadrics';
+import './exhibits/tangent-planes';
 import './exhibits/hello';
 
 bootShell();

--- a/test/exhibits/tangent-planes/directionFromAngles.test.ts
+++ b/test/exhibits/tangent-planes/directionFromAngles.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { directionFromAngles } from '../../../src/exhibits/tangent-planes/directionFromAngles.ts';
+import { writeMathToWorld } from '../../../src/scaffold/math/frames.ts';
+import * as THREE from 'three';
+
+// Math-frame typo guard for the tangent-planes scene's θ/φ point
+// parametrization (#147). Keeps the (sin θ cos φ, sin θ sin φ, cos θ)
+// convention pinned at the unit-test level so a transposition (e.g.
+// `(sin θ sin φ, sin θ cos φ, …)`) fails CI rather than slipping
+// through to a manual headset smoke pass.
+
+function expectMathClose(
+  v: readonly [number, number, number],
+  expected: readonly [number, number, number],
+  precision = 12,
+) {
+  expect(v[0]).toBeCloseTo(expected[0], precision);
+  expect(v[1]).toBeCloseTo(expected[1], precision);
+  expect(v[2]).toBeCloseTo(expected[2], precision);
+}
+
+describe('directionFromAngles — math-frame cardinal directions', () => {
+  it('θ=0, φ=0 → +math-Z (north pole, "up")', () => {
+    const out: [number, number, number] = [0, 0, 0];
+    expectMathClose(directionFromAngles(0, 0, out), [0, 0, 1]);
+  });
+
+  it('θ=0, φ=π/4 → +math-Z (φ irrelevant at the north pole)', () => {
+    const out: [number, number, number] = [0, 0, 0];
+    expectMathClose(directionFromAngles(0, Math.PI / 4, out), [0, 0, 1]);
+  });
+
+  it('θ=π → −math-Z (south pole, "down")', () => {
+    const out: [number, number, number] = [0, 0, 0];
+    expectMathClose(directionFromAngles(Math.PI, 0, out), [0, 0, -1]);
+  });
+
+  it('θ=π/2, φ=0 → +math-X ("right")', () => {
+    const out: [number, number, number] = [0, 0, 0];
+    expectMathClose(directionFromAngles(Math.PI / 2, 0, out), [1, 0, 0]);
+  });
+
+  it('θ=π/2, φ=π/2 → +math-Y ("forward, away from user")', () => {
+    const out: [number, number, number] = [0, 0, 0];
+    expectMathClose(directionFromAngles(Math.PI / 2, Math.PI / 2, out), [0, 1, 0]);
+  });
+
+  it('θ=π/2, φ=π → −math-X ("left")', () => {
+    const out: [number, number, number] = [0, 0, 0];
+    expectMathClose(directionFromAngles(Math.PI / 2, Math.PI, out), [-1, 0, 0]);
+  });
+
+  it('θ=π/2, φ=−π/2 → −math-Y ("back, toward user")', () => {
+    const out: [number, number, number] = [0, 0, 0];
+    expectMathClose(
+      directionFromAngles(Math.PI / 2, -Math.PI / 2, out),
+      [0, -1, 0],
+    );
+  });
+
+  it('θ=π/2, φ=−π → −math-X (same point as φ=π — closed-range double-snap)', () => {
+    const out: [number, number, number] = [0, 0, 0];
+    expectMathClose(directionFromAngles(Math.PI / 2, -Math.PI, out), [-1, 0, 0]);
+  });
+});
+
+describe('directionFromAngles — out-tuple aliasing', () => {
+  it('mutates `out` in place and returns the same tuple', () => {
+    const out: [number, number, number] = [99, 99, 99];
+    const result = directionFromAngles(Math.PI / 2, 0, out);
+    expect(result).toBe(out);
+    // cos(π/2) is not exactly 0 in IEEE 754 (≈ 6.12e-17), so toEqual
+    // would fail on the z component despite the math being correct.
+    expectMathClose(out, [1, 0, 0]);
+  });
+
+  it('reusing the same `out` on successive calls overwrites cleanly', () => {
+    const out: [number, number, number] = [0, 0, 0];
+    directionFromAngles(0, 0, out);
+    expectMathClose(out, [0, 0, 1]);
+    directionFromAngles(Math.PI / 2, Math.PI / 2, out);
+    expectMathClose(out, [0, 1, 0]);
+    directionFromAngles(Math.PI, 0, out);
+    expectMathClose(out, [0, 0, -1]);
+  });
+});
+
+describe('directionFromAngles + writeMathToWorld round-trip — math-frame routing', () => {
+  // Lock the full math → world chain: the indicator's world position is
+  // derived by applying writeMathToWorld to directionFromAngles' output,
+  // so a regression in either step would surface here.
+  function expectWorldClose(
+    v: { x: number; y: number; z: number },
+    [x, y, z]: readonly [number, number, number],
+  ) {
+    expect(v.x).toBeCloseTo(x);
+    expect(v.y).toBeCloseTo(y);
+    expect(v.z).toBeCloseTo(z);
+  }
+
+  it('θ=0 (north pole) → world +Y ("up")', () => {
+    const dirMath: [number, number, number] = [0, 0, 0];
+    const target = new THREE.Vector3();
+    writeMathToWorld(directionFromAngles(0, 0, dirMath), target);
+    expectWorldClose(target, [0, 1, 0]);
+  });
+
+  it('θ=π/2, φ=π/2 (math-Y forward) → world −Z ("away from camera")', () => {
+    const dirMath: [number, number, number] = [0, 0, 0];
+    const target = new THREE.Vector3();
+    writeMathToWorld(
+      directionFromAngles(Math.PI / 2, Math.PI / 2, dirMath),
+      target,
+    );
+    expectWorldClose(target, [0, 0, -1]);
+  });
+
+  it('θ=π/2, φ=0 (math-X right) → world +X', () => {
+    const dirMath: [number, number, number] = [0, 0, 0];
+    const target = new THREE.Vector3();
+    writeMathToWorld(directionFromAngles(Math.PI / 2, 0, dirMath), target);
+    expectWorldClose(target, [1, 0, 0]);
+  });
+});

--- a/test/exhibits/tangent-planes/raycastSurface.test.ts
+++ b/test/exhibits/tangent-planes/raycastSurface.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest';
+import {
+  raycastImplicit,
+  type RaycastResult,
+} from '../../../src/exhibits/tangent-planes/raycastSurface.ts';
+import type { MathVec3 } from '../../../src/scaffold/math/frames.ts';
+
+// Unit-sphere test surface: f = x² + y² + z² − 1, ∇f = (2x, 2y, 2z).
+const sphereF = (x: number, y: number, z: number): number =>
+  x * x + y * y + z * z - 1;
+const sphereGradF = (x: number, y: number, z: number): MathVec3 => [
+  2 * x,
+  2 * y,
+  2 * z,
+];
+
+// 2-sheet hyperboloid: f = x² − y² − z² − 1, ∇f = (2x, −2y, −2z).
+// Sheets at x = ±√(1 + y² + z²); the y-axis passes through the gap.
+const twoSheetF = (x: number, y: number, z: number): number =>
+  x * x - y * y - z * z - 1;
+const twoSheetGradF = (x: number, y: number, z: number): MathVec3 => [
+  2 * x,
+  -2 * y,
+  -2 * z,
+];
+
+const SPHERE_BOUND = 1.5;
+
+function expectHit(r: RaycastResult): asserts r is Extract<RaycastResult, { hit: true }> {
+  expect(r.hit).toBe(true);
+}
+
+function expectClose(
+  v: MathVec3,
+  expected: readonly [number, number, number],
+  tol = 1e-2,
+) {
+  expect(v[0]).toBeCloseTo(expected[0], -Math.log10(tol));
+  expect(v[1]).toBeCloseTo(expected[1], -Math.log10(tol));
+  expect(v[2]).toBeCloseTo(expected[2], -Math.log10(tol));
+}
+
+describe('raycastImplicit — forward-only domain (GPT #1 / HIGH from v1 plan-review)', () => {
+  // The bug guarded against here: with origin at [0,0,0] inside the unit
+  // sphere's AABB and `+x` direction, a march from `tNear = -1.5` finds
+  // the back-side sign change at `t ≈ -1` first and would return
+  // `[-1, 0, 0]`. The `t0 = max(tNear, 0)` clamp gives `[+1, 0, 0]`.
+  it('+X direction returns +X-side hit, not −X', () => {
+    const r = raycastImplicit({
+      f: sphereF,
+      gradF: sphereGradF,
+      origin: [0, 0, 0],
+      dir: [1, 0, 0],
+      bound: SPHERE_BOUND,
+    });
+    expectHit(r);
+    expectClose(r.point, [1, 0, 0]);
+  });
+
+  it('−X direction returns −X-side hit, not +X', () => {
+    const r = raycastImplicit({
+      f: sphereF,
+      gradF: sphereGradF,
+      origin: [0, 0, 0],
+      dir: [-1, 0, 0],
+      bound: SPHERE_BOUND,
+    });
+    expectHit(r);
+    expectClose(r.point, [-1, 0, 0]);
+  });
+
+  it('+Y direction returns +Y-side hit', () => {
+    const r = raycastImplicit({
+      f: sphereF,
+      gradF: sphereGradF,
+      origin: [0, 0, 0],
+      dir: [0, 1, 0],
+      bound: SPHERE_BOUND,
+    });
+    expectHit(r);
+    expectClose(r.point, [0, 1, 0]);
+  });
+
+  it('−Y direction returns −Y-side hit', () => {
+    const r = raycastImplicit({
+      f: sphereF,
+      gradF: sphereGradF,
+      origin: [0, 0, 0],
+      dir: [0, -1, 0],
+      bound: SPHERE_BOUND,
+    });
+    expectHit(r);
+    expectClose(r.point, [0, -1, 0]);
+  });
+
+  it('+Z direction returns +Z-side hit', () => {
+    const r = raycastImplicit({
+      f: sphereF,
+      gradF: sphereGradF,
+      origin: [0, 0, 0],
+      dir: [0, 0, 1],
+      bound: SPHERE_BOUND,
+    });
+    expectHit(r);
+    expectClose(r.point, [0, 0, 1]);
+  });
+
+  it('−Z direction returns −Z-side hit', () => {
+    const r = raycastImplicit({
+      f: sphereF,
+      gradF: sphereGradF,
+      origin: [0, 0, 0],
+      dir: [0, 0, -1],
+      bound: SPHERE_BOUND,
+    });
+    expectHit(r);
+    expectClose(r.point, [0, 0, -1]);
+  });
+});
+
+describe('raycastImplicit — outward unit normal', () => {
+  // For the unit sphere, `gradF(p) = 2p`, so `normalize(gradF(p)) = p`
+  // when `|p| = 1`. The hit point at distance 1 should equal its normal.
+  it.each([
+    ['+X', [1, 0, 0]],
+    ['+Y', [0, 1, 0]],
+    ['+Z', [0, 0, 1]],
+    ['−X', [-1, 0, 0]],
+    ['−Y', [0, -1, 0]],
+    ['−Z', [0, 0, -1]],
+  ] as const)('cardinal %s: normal ≈ point', (_label, dir) => {
+    const r = raycastImplicit({
+      f: sphereF,
+      gradF: sphereGradF,
+      origin: [0, 0, 0],
+      dir: dir as MathVec3,
+      bound: SPHERE_BOUND,
+    });
+    expectHit(r);
+    expect(r.normal[0]).toBeCloseTo(r.point[0], 3);
+    expect(r.normal[1]).toBeCloseTo(r.point[1], 3);
+    expect(r.normal[2]).toBeCloseTo(r.point[2], 3);
+    // Normal must be unit-length.
+    const nLen = Math.hypot(r.normal[0], r.normal[1], r.normal[2]);
+    expect(nLen).toBeCloseTo(1);
+  });
+
+  it('off-axis [1,1,1]/√3 direction hits at the same diagonal point', () => {
+    const inv = 1 / Math.sqrt(3);
+    const r = raycastImplicit({
+      f: sphereF,
+      gradF: sphereGradF,
+      origin: [0, 0, 0],
+      dir: [inv, inv, inv],
+      bound: SPHERE_BOUND,
+    });
+    expectHit(r);
+    expectClose(r.point, [inv, inv, inv]);
+    expectClose(r.normal, [inv, inv, inv], 1e-3);
+  });
+});
+
+describe('raycastImplicit — miss cases', () => {
+  it('2-sheet hyperboloid, +Y from origin: misses through the gap', () => {
+    const r = raycastImplicit({
+      f: twoSheetF,
+      gradF: twoSheetGradF,
+      origin: [0, 0, 0],
+      dir: [0, 1, 0],
+      bound: 3,
+    });
+    expect(r.hit).toBe(false);
+  });
+
+  it('AABB miss: origin outside, ray pointing away', () => {
+    const r = raycastImplicit({
+      f: sphereF,
+      gradF: sphereGradF,
+      origin: [10, 0, 0],
+      dir: [1, 0, 0],
+      bound: SPHERE_BOUND,
+    });
+    expect(r.hit).toBe(false);
+  });
+
+  it('tFar < 0: origin past the AABB on the +X side, ray pointing further +X', () => {
+    // Origin at +5 in X, AABB ends at +1.5, ray heads further +X — entirely
+    // behind tNear once you flip into the slab math, so the early return
+    // for `tFar < 0` fires.
+    const r = raycastImplicit({
+      f: sphereF,
+      gradF: sphereGradF,
+      origin: [5, 0, 0],
+      dir: [1, 0, 0],
+      bound: SPHERE_BOUND,
+    });
+    expect(r.hit).toBe(false);
+  });
+
+  it('zero direction component: dir [1, 0, 0] still resolves cleanly (slab clip with ±Infinity)', () => {
+    const r = raycastImplicit({
+      f: sphereF,
+      gradF: sphereGradF,
+      origin: [0, 0, 0],
+      dir: [1, 0, 0],
+      bound: SPHERE_BOUND,
+    });
+    expectHit(r);
+    expectClose(r.point, [1, 0, 0]);
+  });
+});
+
+describe('raycastImplicit — tangent / glancing edge', () => {
+  // A ray that grazes the unit sphere's surface very near `f = 0` may or
+  // may not register a sign change depending on step alignment — both
+  // outcomes are spec-permissible. The contract is "does not throw, does
+  // not return a junk hit outside the AABB."
+  it('does not throw on a tangent-grazing ray; if hit, point is within bound', () => {
+    // Origin at [0, 1, 0] (on the surface), direction [1, 0, 0] (tangent
+    // to the sphere at that point in the XY plane). Whether the march
+    // catches a sign change depends on numerical luck.
+    const r = raycastImplicit({
+      f: sphereF,
+      gradF: sphereGradF,
+      origin: [0, 1, 0],
+      dir: [1, 0, 0],
+      bound: SPHERE_BOUND,
+    });
+    if (r.hit) {
+      expect(Math.abs(r.point[0])).toBeLessThanOrEqual(SPHERE_BOUND);
+      expect(Math.abs(r.point[1])).toBeLessThanOrEqual(SPHERE_BOUND);
+      expect(Math.abs(r.point[2])).toBeLessThanOrEqual(SPHERE_BOUND);
+    }
+    // Either branch is acceptable — the assertion is "doesn't throw".
+  });
+});
+
+describe('raycastImplicit — bisection precision', () => {
+  // With steps=64 over diagonal 2*bound=3, initial bracket ≈ 0.047 m.
+  // After 8 bisections (default), bracket halves 8× to ≈ 1.8e-4 m. The
+  // forward-only-domain tests above use a 1e-2 m tolerance for slack;
+  // this test pins the actual achieved precision tighter.
+  it('+X cardinal hit on unit sphere lands within 5e-4 m of [1,0,0]', () => {
+    const r = raycastImplicit({
+      f: sphereF,
+      gradF: sphereGradF,
+      origin: [0, 0, 0],
+      dir: [1, 0, 0],
+      bound: SPHERE_BOUND,
+    });
+    expectHit(r);
+    expect(Math.abs(r.point[0] - 1)).toBeLessThan(5e-4);
+    expect(Math.abs(r.point[1])).toBeLessThan(5e-4);
+    expect(Math.abs(r.point[2])).toBeLessThan(5e-4);
+  });
+});


### PR DESCRIPTION
Closes #147

## Summary

First sub-issue of the #121 (tangent-planes scene) epic. Adds a new exhibit registered in the `calculus3` cluster: fixed canonical unit sphere `x² + y² + z² = 1`, with two θ/φ sliders that walk a point indicator continuously across the surface. The indicator hangs the visual chain that #148 (tangent-plane mesh) and #149 (live readout) attach to in subsequent PRs.

CPU-side raymarch + bisect mirrors the GPU shader's algorithm (same fixed-step march for sign change, same bisection refinement) so the indicator and the rendered surface agree on hit position. The analytic gradient `∇f = 2p` feeds an outward unit normal that #148 will consume directly — no provisional interface to redesign later. Coefficient editability is deliberately deferred to a v0.7+ follow-up: the §11.4 pedagogy goal is internalized by one surface, and the quadrics manipulator already covers surface-family morphing.

This is the first sibling exhibit since #150 landed cluster navigation, so the SceneRack tab + URL routing + boot pre-warm get their first felt smoke against a real second cluster member.

Plan + roundtable-plan-review trail in `_private/plans/147-tangent-planes-point-selection.md` — Sonnet REVISE + GPT-5.5 REVISE + DeepSeek HOLD on v1 → 11 findings closed in v2 → second-Sonnet sanity pass PROCEED with one narrow `MathVec3` readonly-tuple type fix.

## Test plan

Unit tests (33 new, 151 total — all passing locally):

- [x] `raycastSurface.test.ts` — forward-only domain (the GPT #1 / HIGH plan-review finding: ray from origin along `+x` returns `[+1,0,0]`, **not** `[-1,0,0]`); 6 cardinal directions; outward unit-normal correctness; off-axis hit; 2-sheet hyperboloid miss; AABB miss; `tFar < 0` shortcut; zero-direction-component slab clip; tangent-grazing edge (no-throw contract); bisection precision pinned at <5e-4 m.
- [x] `directionFromAngles.test.ts` — math-frame routing for 6 cardinal directions plus the `±π` double-snap; `out`-tuple aliasing; round-trip through `writeMathToWorld` for the 3 most load-bearing world-frame anchors.

Build / lint:

- [x] `npm run build` (tsc + vite) — clean.
- [x] `npm run lint` (eslint) — clean.

Cloudflare PR preview headset smoke (run after the preview comment lands):

- [x] Open `?exhibit=tangent-planes` on the preview. Surface renders centered; indicator parks at the off-pole, off-snap initial pose `(θ=π/3, φ=π/4)`.
- [x] Tap the SceneRack tab to swap to `quadrics`, then back. Both surfaces render at correct positions; both scenes' sliders grabbable; no console errors. (Smokes mount/unmount symmetry against the steady-state path.)
- [x] Set θ to π/2 (snap at equator). Drag φ across `[−π, π]`; verify the indicator walks the equator continuously, snap detents fire at all 5 cardinals, and `φ = π/2` parks the indicator at +math-Y (forward, world −Z).
- [x] Set φ to π/4 (off-snap). Drag θ across `[0, π]`; verify indicator walks a great circle from north pole (world +Y) through the equator to south pole (world −Y), with snap detents at the three points.
- [x] Release each slider mid-drag and re-grab; confirm no visible snap between release and re-grab (slider's split rawValue/currentValue contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)