### PR TITLE
feat(scene): tangent-planes — tangent-plane mesh anchored at the selected point (#148)

### DIFF
--- a/src/exhibits/quadrics/SlicingPlane.ts
+++ b/src/exhibits/quadrics/SlicingPlane.ts
@@ -1,4 +1,8 @@
 import * as THREE from 'three';
+import {
+  createTranslucentRect,
+  type TranslucentRectHandles,
+} from '@/scaffold/render/TranslucentRect';
 
 // Translucent slicing-plane meshes for the Cross sections section
 // (#113). Layers above the on-surface intersection ring shipped in
@@ -7,18 +11,22 @@ import * as THREE from 'three';
 // cross-section reads as "a sheet of light passing through the surface"
 // rather than just a curve drawn on the surface.
 //
-// One mesh per math axis (x₀, y₀, z₀), parented to a single group so
-// the slicing rack moves with the surface center. Each mesh shares the
-// same shader — body sky-blue at low alpha plus a brighter rim along
-// the four boundary edges — and only differs by orientation. Rim color
-// is intentionally one tone lighter than the on-surface ring color from
-// the shipped shader (`PLANE_GLOW_COLOR = vec3(0.34, 0.71, 0.91)`) so
-// the two glow tiers read as separate elements at a glance.
+// One translucent rect per math axis (x₀, y₀, z₀), parented to a single
+// group so the slicing rack moves with the surface center. Each rect
+// shares the same shader (the locked #113 recipe, now in
+// `scaffold/render/TranslucentRect.ts` since #148) — body sky-blue at
+// low alpha plus a brighter rim along the four boundary edges — and
+// only differs by orientation. Rim color is intentionally one tone
+// lighter than the on-surface ring color from the shipped shader
+// (`PLANE_GLOW_COLOR = vec3(0.34, 0.71, 0.91)`) so the two glow tiers
+// read as separate elements at a glance.
 //
 // Per-axis rim color differentiation is explicitly out of scope per
 // #113 — the slider thumbs and per-axis on-surface ring colors already
 // carry the per-axis identity.
 
+// Locked #113 visual recipe — keep in sync with
+// src/exhibits/tangent-planes/TangentPlane.ts.
 const PLANE_BODY_COLOR = new THREE.Color(0.34, 0.71, 0.91);
 const PLANE_BODY_ALPHA = 0.10;
 // One step lighter than PLANE_BODY_COLOR / the on-surface ring color
@@ -29,80 +37,21 @@ const PLANE_RIM_COLOR = new THREE.Color(0.70, 0.90, 0.99);
 const PLANE_RIM_ALPHA = 0.65;
 // Rim band width in plane-local meters (#113: "outer ~5 cm").
 const PLANE_RIM_WIDTH = 0.05;
-// Surface-mesh has the default renderOrder of 0; bumping to 1 puts the
-// transparent planes after it so depth-tested blending Just Works (the
-// raymarcher writes per-fragment depth via gl_FragDepth from #67).
-const PLANE_RENDER_ORDER = 1;
 
-const VERTEX_SHADER = /* glsl */ `
-  varying vec2 vLocal;
-
-  void main() {
-    // PlaneGeometry's local position spans [-halfExtent, +halfExtent]
-    // on x and y, with normal +Z. Pass the local (x, y) so the rim
-    // distance computes in plane-local meters regardless of the mesh's
-    // world orientation.
-    vLocal = position.xy;
-    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-  }
-`;
-
-const FRAGMENT_SHADER = /* glsl */ `
-  precision highp float;
-
-  uniform float uHalfExtent;
-  uniform float uRimWidth;
-  uniform vec3  uBodyColor;
-  uniform float uBodyAlpha;
-  uniform vec3  uRimColor;
-  uniform float uRimAlpha;
-
-  varying vec2 vLocal;
-
-  void main() {
-    // Distance from the nearest edge in plane-local meters: 0 at the
-    // edge, uHalfExtent at the plane center. smoothstep gives an
-    // anti-aliased band over the outer uRimWidth, with rim = 1 at the
-    // edge falling smoothly to 0 inside the body.
-    float distFromEdge = uHalfExtent - max(abs(vLocal.x), abs(vLocal.y));
-    float rim = 1.0 - smoothstep(0.0, uRimWidth, distFromEdge);
-    vec3 color = mix(uBodyColor, uRimColor, rim);
-    float alpha = mix(uBodyAlpha, uRimAlpha, rim);
-    gl_FragColor = vec4(color, alpha);
-  }
-`;
-
-function buildPlaneMaterial(halfExtent: number): THREE.ShaderMaterial {
-  return new THREE.ShaderMaterial({
-    vertexShader: VERTEX_SHADER,
-    fragmentShader: FRAGMENT_SHADER,
-    transparent: true,
-    // Surface raymarcher writes correct per-fragment depth, so depth
-    // testing against the slicing plane occludes the half of the plane
-    // behind the surface. Disabling depth *write* keeps the planes
-    // from blocking each other in their mutual intersections.
-    depthWrite: false,
-    side: THREE.DoubleSide,
-    uniforms: {
-      uHalfExtent: { value: halfExtent },
-      uRimWidth:   { value: PLANE_RIM_WIDTH },
-      uBodyColor:  { value: PLANE_BODY_COLOR.clone() },
-      uBodyAlpha:  { value: PLANE_BODY_ALPHA },
-      uRimColor:   { value: PLANE_RIM_COLOR.clone() },
-      uRimAlpha:   { value: PLANE_RIM_ALPHA },
-    },
-  });
-}
-
-function buildPlaneMesh(
+function buildPlaneHandle(
   halfExtent: number,
   orient: (mesh: THREE.Mesh) => void,
-): THREE.Mesh {
-  const geometry = new THREE.PlaneGeometry(halfExtent * 2, halfExtent * 2);
-  const mesh = new THREE.Mesh(geometry, buildPlaneMaterial(halfExtent));
-  mesh.renderOrder = PLANE_RENDER_ORDER;
-  orient(mesh);
-  return mesh;
+): TranslucentRectHandles {
+  const handle = createTranslucentRect({
+    halfExtent,
+    bodyColor: PLANE_BODY_COLOR,
+    bodyAlpha: PLANE_BODY_ALPHA,
+    rimColor: PLANE_RIM_COLOR,
+    rimAlpha: PLANE_RIM_ALPHA,
+    rimWidth: PLANE_RIM_WIDTH,
+  });
+  orient(handle.mesh);
+  return handle;
 }
 
 export interface SlicingPlanesOptions {
@@ -174,19 +123,19 @@ export function createSlicingPlanes(
   //   math-Z plane → normal +world-Y (rotate -90° around X)
   // This matches the math→world axis routing already documented at
   // the slider→uniform block in quadrics/index.ts.
-  const xPlane = buildPlaneMesh(halfExtent, (m) => {
+  const xPlane = buildPlaneHandle(halfExtent, (m) => {
     m.rotation.y = Math.PI / 2;
   });
-  const yPlane = buildPlaneMesh(halfExtent, () => {
+  const yPlane = buildPlaneHandle(halfExtent, () => {
     /* default orientation: normal +Z */
   });
-  const zPlane = buildPlaneMesh(halfExtent, (m) => {
+  const zPlane = buildPlaneHandle(halfExtent, (m) => {
     m.rotation.x = -Math.PI / 2;
   });
 
-  group.add(xPlane);
-  group.add(yPlane);
-  group.add(zPlane);
+  group.add(xPlane.mesh);
+  group.add(yPlane.mesh);
+  group.add(zPlane.mesh);
 
   return {
     group,
@@ -200,19 +149,22 @@ export function createSlicingPlanes(
       // Each mesh slides along its own normal axis only; the other
       // two coords stay zero so the plane always passes through the
       // surface center along its non-slicing dimensions.
-      xPlane.position.x = x0;
-      yPlane.position.z = -y0;
-      zPlane.position.y = z0;
+      xPlane.mesh.position.x = x0;
+      yPlane.mesh.position.z = -y0;
+      zPlane.mesh.position.y = z0;
     },
     setVisibility(x: boolean, y: boolean, z: boolean): void {
-      xPlane.visible = x;
-      yPlane.visible = y;
-      zPlane.visible = z;
+      xPlane.mesh.visible = x;
+      yPlane.mesh.visible = y;
+      zPlane.mesh.visible = z;
     },
     dispose(): void {
-      for (const mesh of [xPlane, yPlane, zPlane]) {
-        mesh.geometry.dispose();
-        (mesh.material as THREE.Material).dispose();
+      // TranslucentRectHandles.dispose() is the single GPU-resource
+      // owner per the #150 step-1 disposal contract — it disposes
+      // both geometry and material together. Don't also call
+      // mesh.geometry.dispose() / mesh.material.dispose() here.
+      for (const handle of [xPlane, yPlane, zPlane]) {
+        handle.dispose();
       }
     },
   };

--- a/src/exhibits/tangent-planes/SPEC.md
+++ b/src/exhibits/tangent-planes/SPEC.md
@@ -1,17 +1,17 @@
 # `tangent-planes` exhibit — SPEC
 
-> Math + UX contract for the tangent-planes scene. v0.6 first cut: point
-> selection on a fixed unit sphere (#147). Tangent plane mesh (#148) and
-> live readout (#149) extend this in subsequent PRs.
+> Math + UX contract for the tangent-planes scene. v0.6 cuts: point
+> selection on a fixed unit sphere (#147) + tangent-plane mesh anchored
+> at the selected point (#148). Live readout (#149) extends this in a
+> subsequent PR.
 
 ## Goal
 
 An interactive WebXR scene where the learner drags two angular sliders to
 walk a point continuously across an implicit quadric surface, watching
-the contact point move while the same surface stays put. Anchors the
+the tangent plane reorient as the contact point moves. Anchors the
 "tangent plane reorients as the contact point moves" intuition for APPM
-2350 §11.4 (Tangent Planes and Linear Approximations) — without yet
-showing the plane (which lands in #148).
+2350 §11.4 (Tangent Planes and Linear Approximations).
 
 Sibling of `quadrics` in the `calculus3` cluster; the SceneRack swaps
 between them at runtime.
@@ -96,12 +96,38 @@ the origin hits at distance 1), but the path is in place for future
 coefficient editing where ray-origin choice may not enclose the
 surface.
 
+## Tangent plane mesh
+
+A translucent rectangular mesh, 0.9 m × 0.9 m, anchored at the
+selected surface point with normal aligned to ∇f at that point.
+Visual treatment matches the cross-section slicing-plane recipe locked
+in #113: sky-blue translucent body (alpha 0.10), one-tone-lighter rim
+(alpha 0.65) along the outer ~5 cm, double-sided so the back face is
+visible from inside the surface, depth-tested against the surface's
+`gl_FragDepth` write.
+
+Pose drives off `result.point` + `result.normal` from the same per-frame
+raymarch that drives the indicator; positioning math (math → world +
+surfaceCenter offset) lives in `poseTangentPlaneMesh.ts` so it's
+testable without a renderer. Hides when the indicator hides (same
+`result.hit` gate). For v0.6's unit sphere the hide branch never fires,
+but the path stays in place for future surfaces.
+
+Plane size (`TANGENT_PLANE_HALF_EXTENT = 0.45 m`) is the v0.6 lock,
+tunable in headset. Reads as "a flat patch tangent to the surface"
+rather than "a sheet that swallows the surface."
+
+The shader + geometry primitive (`scaffold/render/TranslucentRect.ts`)
+is shared with `quadrics`'s slicing planes — the locked #113 visual
+recipe lives in one shader. Color/alpha/width *constants* are
+intentionally per-scene so the design language can drift in v0.7+
+without coupling the two scenes.
+
 ## Render
 
 Minimal lambert: `uBaseColor * (0.2 + 0.8 * max(dot(n, normalize(uLightDir)), 0))`.
 No grid, no parametric grid, no cross-section glow. The visual focus
-belongs on the indicator + (later) the tangent plane; a busy surface
-competes.
+belongs on the indicator + tangent plane; a busy surface competes.
 
 Same `SURFACE_CENTER`, `LIGHT_DIR`, and `uBaseColor` as quadrics so the
 surface reads as a sibling. World-axis grid deferred to a later cut if
@@ -110,10 +136,9 @@ indicator.
 
 ## Out of scope (v0.6)
 
-- **Tangent plane mesh** (#148) — consumes `result.point` + `result.normal`
-  from `raycastImplicit`'s return type. No new entry points needed in
-  `raycastSurface.ts`.
-- **Live readout of plane equation / normal** (#149) — same.
+- **Live readout of plane equation / normal** (#149) — consumes
+  `result.normal` directly from `raycastImplicit`'s return type. No new
+  entry points needed in `raycastSurface.ts` or in `TangentPlane.ts`.
 - **Coefficient editing** — see "Equation form" above.
 - **Controller-aim point picking** — natural in headset, unusable on
   the pancake build (#105) and Cloudflare PR previews. Deferred to v0.9.

--- a/src/exhibits/tangent-planes/TangentPlane.ts
+++ b/src/exhibits/tangent-planes/TangentPlane.ts
@@ -1,0 +1,113 @@
+import * as THREE from 'three';
+import { createTranslucentRect } from '@/scaffold/render/TranslucentRect';
+import type { MathVec3 } from '@/scaffold/math/frames';
+import { poseTangentPlaneMesh } from './poseTangentPlaneMesh';
+
+// Tangent-plane mesh for the tangent-planes scene (#148). A single
+// translucent rectangle anchored at the user-selected surface point,
+// oriented so its normal matches ∇f at that point. Visual treatment
+// mirrors the cross-section slicing-plane recipe locked in #113.
+//
+// Coordinate convention (locked): this wrapper's `group.position` stays
+// at (0, 0, 0). The full world-space transform —
+// `writeMathToWorld(pointMath) + surfaceCenter` — happens inside
+// `poseTangentPlaneMesh` and writes into the inner mesh's position.
+// Matches the indicator-positioning pattern in
+// `tangent-planes/index.ts:271`. Setting `group.position.copy(surfaceCenter)`
+// would double-offset to `point + 2 × surfaceCenter`.
+//
+// The wrapper constructs with `group.visible = false` so the renderer
+// can't paint a stale construction-time pose between mount and the
+// first update tick. The consumer flips visibility on the first hit
+// frame after calling `setPose`.
+
+// Locked #113 visual recipe — keep in sync with
+// src/exhibits/quadrics/SlicingPlane.ts.
+const PLANE_BODY_COLOR = new THREE.Color(0.34, 0.71, 0.91);
+const PLANE_BODY_ALPHA = 0.10;
+const PLANE_RIM_COLOR = new THREE.Color(0.70, 0.90, 0.99);
+const PLANE_RIM_ALPHA = 0.65;
+const PLANE_RIM_WIDTH = 0.05;
+
+export interface TangentPlaneOptions {
+  /**
+   * World-space center of the surface. Passed through to
+   * poseTangentPlaneMesh on every setPose call so the helper can do
+   * the full math→world + surfaceCenter offset in one place. The
+   * wrapper group itself stays at the exhibit-local origin.
+   */
+  surfaceCenter: THREE.Vector3;
+  /** Half-width / half-height of the plane, in meters. */
+  halfExtent: number;
+}
+
+export interface TangentPlaneHandles {
+  /**
+   * Group containing the plane mesh. Caller adds it to the scene; the
+   * inner mesh is positioned + oriented by setPose. The group stays
+   * at (0, 0, 0); the inner mesh holds the world position.
+   *
+   * Initially `group.visible = false` — the first frame's setPose +
+   * setVisible(true) from the consumer's update path uncloaks it,
+   * preventing a one-frame flash at stale pose.
+   */
+  group: THREE.Group;
+  /**
+   * Drive the plane's pose from the raymarch result. `pointMath` and
+   * `normalMath` are surface-local math-frame; the math→world routing
+   * + the surfaceCenter translation happen inside this call so the
+   * caller passes raw raymarch output.
+   */
+  setPose(pointMath: MathVec3, normalMath: MathVec3): void;
+  /** Toggles `group.visible`, gating the rect (and any future
+   * descendants) together. */
+  setVisible(visible: boolean): void;
+  dispose(): void;
+}
+
+/**
+ * Build the tangent-plane mesh + group wrapper.
+ *
+ * Caller `group.add(handles.group)` to mount; call `setPose` then
+ * `setVisible(true)` on every hit frame; call `setVisible(false)` on
+ * miss frames; `dispose()` from unmount.
+ */
+export function createTangentPlane(
+  opts: TangentPlaneOptions,
+): TangentPlaneHandles {
+  const rectHandle = createTranslucentRect({
+    halfExtent: opts.halfExtent,
+    bodyColor: PLANE_BODY_COLOR,
+    bodyAlpha: PLANE_BODY_ALPHA,
+    rimColor: PLANE_RIM_COLOR,
+    rimAlpha: PLANE_RIM_ALPHA,
+    rimWidth: PLANE_RIM_WIDTH,
+  });
+
+  const group = new THREE.Group();
+  group.visible = false;
+  group.add(rectHandle.mesh);
+
+  const surfaceCenter = opts.surfaceCenter;
+
+  return {
+    group,
+    setPose(pointMath: MathVec3, normalMath: MathVec3): void {
+      poseTangentPlaneMesh(
+        rectHandle.mesh,
+        pointMath,
+        normalMath,
+        surfaceCenter,
+      );
+    },
+    setVisible(visible: boolean): void {
+      group.visible = visible;
+    },
+    dispose(): void {
+      // TranslucentRectHandles.dispose() is the single GPU-resource
+      // owner per the #150 step-1 disposal contract — it disposes
+      // the mesh's geometry and material together.
+      rectHandle.dispose();
+    },
+  };
+}

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -9,6 +9,7 @@ import { WorldAxes, type AxisName } from '@/scaffold/ui/WorldAxes';
 import { DEFAULT_AXIS_COLORS } from '@/scaffold/design/tokens';
 import { directionFromAngles } from './directionFromAngles';
 import { raycastImplicit } from './raycastSurface';
+import { createTangentPlane, type TangentPlaneHandles } from './TangentPlane';
 
 // Tangent-planes scene (#147). First sub-issue of the #121 epic — sets up
 // the v0.6 scene's surface + θ/φ point selection so #148 (tangent-plane
@@ -81,6 +82,11 @@ const SLIDER_BASE_COLOR = 0xaaaaaa;
 const INDICATOR_RADIUS = 0.04;
 const INDICATOR_COLOR = 0xdddddd;
 
+// Tangent-plane size — 0.9 m × 0.9 m on the unit sphere. Reads as "a
+// flat patch tangent to the surface" rather than "a sheet that swallows
+// the surface." Tunable in headset; this is the v0.6 lock.
+const TANGENT_PLANE_HALF_EXTENT = 0.45;
+
 const AXIS_COLORS: Record<AxisName, number> = DEFAULT_AXIS_COLORS;
 
 // ────────────────────────────────────────────────────────────────────
@@ -142,6 +148,7 @@ let surfaceMaterial: THREE.ShaderMaterial | undefined;
 let thetaSlider: Slider | undefined;
 let phiSlider: Slider | undefined;
 let indicator: THREE.Mesh | undefined;
+let tangentPlane: TangentPlaneHandles | undefined;
 let worldAxes: WorldAxes | undefined;
 let controllers: readonly THREE.Object3D[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
@@ -233,6 +240,19 @@ const tangentPlanesExhibit: Exhibit = {
     );
     group.add(indicator);
 
+    // Tangent-plane mesh. Constructed with `group.visible = false` so
+    // the renderer can't paint a stale construction-time pose between
+    // mount and the first update tick — the first hit frame in update
+    // calls setPose then setVisible(true) to uncloak. (Insertion order
+    // in the scene graph doesn't drive Three's render order; that's
+    // governed by renderOrder + opaque/transparent pass sorting. We add
+    // it here only as a human-reader breadcrumb.)
+    tangentPlane = createTangentPlane({
+      surfaceCenter: SURFACE_CENTER,
+      halfExtent: TANGENT_PLANE_HALF_EXTENT,
+    });
+    group.add(tangentPlane.group);
+
     // Math-frame axis indicator — same anchor as quadrics.
     worldAxes = new WorldAxes({ axisColors: AXIS_COLORS });
     worldAxes.group.position.copy(AXIS_INDICATOR_POSITION);
@@ -240,7 +260,7 @@ const tangentPlanesExhibit: Exhibit = {
   },
 
   update() {
-    if (!thetaSlider || !phiSlider || !indicator) return;
+    if (!thetaSlider || !phiSlider || !indicator || !tangentPlane) return;
 
     // Slider hover + drag tick.
     thetaSlider.updateHover(controllers);
@@ -269,10 +289,15 @@ const tangentPlanesExhibit: Exhibit = {
       // `indicatorWorld` is the module-scope scratch.
       writeMathToWorld(result.point, indicatorWorld);
       indicator.position.copy(indicatorWorld).add(SURFACE_CENTER);
-      // result.normal is unused in this PR; #148 will read it to orient
-      // the tangent-plane mesh.
+
+      // Pose first, then uncloak — so the first paint after a mount or
+      // a miss→hit transition lands at the correct pose, not the stale
+      // construction-time identity.
+      tangentPlane.setPose(result.point, result.normal);
+      tangentPlane.setVisible(true);
     } else {
       indicator.visible = false;
+      tangentPlane.setVisible(false);
     }
 
     // Yaw-only billboard on the WorldAxes letter labels (X / Y / Z), so
@@ -305,6 +330,8 @@ const tangentPlanesExhibit: Exhibit = {
       (indicator.material as THREE.Material).dispose();
       indicator = undefined;
     }
+    tangentPlane?.dispose();
+    tangentPlane = undefined;
     thetaSlider?.dispose();
     thetaSlider = undefined;
     phiSlider?.dispose();

--- a/src/exhibits/tangent-planes/poseTangentPlaneMesh.ts
+++ b/src/exhibits/tangent-planes/poseTangentPlaneMesh.ts
@@ -1,0 +1,56 @@
+import * as THREE from 'three';
+import { writeMathToWorld, type MathVec3 } from '@/scaffold/math/frames';
+
+// Pure pose helper for the tangent-planes scene's tangent-plane mesh
+// (#148). Lives in its own file so test/exhibits/tangent-planes/* can
+// import it without triggering `index.ts`'s `registerExhibit` side
+// effect at unit-test import time — same isolation pattern as
+// `directionFromAngles.ts` + `raycastSurface.ts`.
+//
+// Position + orientation are pure functions of (pointMath, normalMath,
+// surfaceCenter): mutate the mesh's `position` and `quaternion` in
+// place. The math→world routing for both vectors happens here so the
+// caller (TangentPlane.ts) passes raw raymarch output without thinking
+// about the frame swap. Allocation-free per call (two module-scope
+// scratches).
+
+// PlaneGeometry's default normal is +Z. Quaternion is computed by
+// rotating +Z to the world-frame normal.
+const PLANE_REF_NORMAL = new THREE.Vector3(0, 0, 1);
+
+// Module-scope scratches — allocated once at import, mutated per-frame.
+// Same convention as `tangent-planes/index.ts:136-137`.
+const positionWorld = new THREE.Vector3();
+const normalWorld = new THREE.Vector3();
+
+/**
+ * Position + orient `mesh` so it sits at `pointMath` (in surface-local
+ * math coords) and faces `normalMath`. `surfaceCenter` is the world-space
+ * center of the surface; the mesh's final world position is
+ * `writeMathToWorld(pointMath) + surfaceCenter`.
+ *
+ * Mutates the mesh's `position` and `quaternion`. Allocation-free. The
+ * helper owns the full math→world + surfaceCenter offset — DO NOT also
+ * translate the parent group by `surfaceCenter`, or the mesh will land
+ * at `point + 2 × surfaceCenter`.
+ *
+ * Edge case: when `normalMath = [0, 1, 0]` (`+math-Y`, world `(0, 0, -1)`),
+ * the world normal is anti-parallel to `PLANE_REF_NORMAL = (0, 0, 1)` and
+ * `setFromUnitVectors` picks an arbitrary perpendicular axis for the 180°
+ * rotation. The resulting normal direction is well-defined; only the roll
+ * about that normal is arbitrary. Fires at the φ = π/2 snap point — see
+ * the headset-smoke continuity check in the tangent-planes plan §6.3.
+ */
+export function poseTangentPlaneMesh(
+  mesh: THREE.Object3D,
+  pointMath: MathVec3,
+  normalMath: MathVec3,
+  surfaceCenter: THREE.Vector3,
+): void {
+  writeMathToWorld(pointMath, positionWorld);
+  positionWorld.add(surfaceCenter);
+  mesh.position.copy(positionWorld);
+
+  writeMathToWorld(normalMath, normalWorld).normalize();
+  mesh.quaternion.setFromUnitVectors(PLANE_REF_NORMAL, normalWorld);
+}

--- a/src/scaffold/render/TranslucentRect.ts
+++ b/src/scaffold/render/TranslucentRect.ts
@@ -1,0 +1,150 @@
+import * as THREE from 'three';
+
+// Single-rect translucent primitive with the locked rim shader (#113):
+// translucent body + a slightly-lighter rim along the four boundary edges.
+// Lifted out of `src/exhibits/quadrics/SlicingPlane.ts` in #148 so the
+// tangent-planes scene can render the same translucent overlay without
+// duplicating the GLSL — same extract-on-second-use pattern as the
+// implicit-surface raymarcher (#129/#130).
+//
+// What this primitive owns:
+// - GLSL shader (vertex + fragment) implementing body+rim mix.
+// - PlaneGeometry sized 2 × halfExtent per side; default normal +Z.
+// - Material flags locked to the #113 visual recipe: transparent, no
+//   depth-write, double-sided.
+// - renderOrder = 1 — both v0.6 consumers (SlicingPlane + TangentPlane)
+//   want this so the rect renders after the implicit surface (which writes
+//   correct per-fragment depth via gl_FragDepth from #67).
+//
+// What this primitive does NOT own:
+// - Orientation / position. The mesh is untransformed at construction;
+//   callers position + orient however they want (axis-aligned rotation
+//   for SlicingPlane, gradient-driven `setFromUnitVectors` for TangentPlane).
+// - The locked color/alpha/width *constants*. Each consumer declares its
+//   own — visually identical today (#113 lock) but per-scene so the design
+//   language can drift in v0.7+ without coupling the scenes.
+
+const VERTEX_SHADER = /* glsl */ `
+  varying vec2 vLocal;
+
+  void main() {
+    // PlaneGeometry's local position spans [-halfExtent, +halfExtent]
+    // on x and y, with normal +Z. Pass the local (x, y) so the rim
+    // distance computes in plane-local meters regardless of the mesh's
+    // world orientation.
+    vLocal = position.xy;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+const FRAGMENT_SHADER = /* glsl */ `
+  precision highp float;
+
+  uniform float uHalfExtent;
+  uniform float uRimWidth;
+  uniform vec3  uBodyColor;
+  uniform float uBodyAlpha;
+  uniform vec3  uRimColor;
+  uniform float uRimAlpha;
+
+  varying vec2 vLocal;
+
+  void main() {
+    // Distance from the nearest edge in plane-local meters: 0 at the
+    // edge, uHalfExtent at the plane center. smoothstep gives an
+    // anti-aliased band over the outer uRimWidth, with rim = 1 at the
+    // edge falling smoothly to 0 inside the body.
+    float distFromEdge = uHalfExtent - max(abs(vLocal.x), abs(vLocal.y));
+    float rim = 1.0 - smoothstep(0.0, uRimWidth, distFromEdge);
+    vec3 color = mix(uBodyColor, uRimColor, rim);
+    float alpha = mix(uBodyAlpha, uRimAlpha, rim);
+    gl_FragColor = vec4(color, alpha);
+  }
+`;
+
+const RENDER_ORDER = 1;
+
+export interface TranslucentRectOptions {
+  /** Half-width / half-height of the rect, in plane-local meters. */
+  halfExtent: number;
+  /** Body color (interior). Cloned on construction; safe to mutate caller's copy. */
+  bodyColor: THREE.Color;
+  /** Body alpha. */
+  bodyAlpha: number;
+  /** Rim color (boundary band). Cloned on construction; safe to mutate caller's copy. */
+  rimColor: THREE.Color;
+  /** Rim alpha. */
+  rimAlpha: number;
+  /** Rim band width in plane-local meters. */
+  rimWidth: number;
+}
+
+export interface TranslucentRectHandles {
+  /**
+   * The mesh — untransformed at construction. Caller positions /
+   * orients however it wants (PlaneGeometry's default normal is +Z).
+   */
+  mesh: THREE.Mesh<THREE.PlaneGeometry, THREE.ShaderMaterial>;
+  /**
+   * The shader material — exposed for callers that want to mutate
+   * uniforms after construction. Today neither v0.6 consumer does;
+   * exposed for the third-user-might-want pattern.
+   */
+  material: THREE.ShaderMaterial;
+  /**
+   * Single GPU-resource owner. Disposes BOTH the geometry and the
+   * material. Callers MUST NOT also call mesh.geometry.dispose() or
+   * material.dispose() — that would double-dispose (per the #150
+   * step-1 disposal contract).
+   */
+  dispose(): void;
+}
+
+/**
+ * Build a translucent rect mesh + material with the locked #113 visual
+ * recipe (translucent body + brighter rim).
+ *
+ * Color uniforms are CLONED from the input so callers can hold the input
+ * `THREE.Color` as a module-scoped constant without risk of accidental
+ * mutation propagating into the GPU uniform.
+ */
+export function createTranslucentRect(
+  opts: TranslucentRectOptions,
+): TranslucentRectHandles {
+  const material = new THREE.ShaderMaterial({
+    vertexShader: VERTEX_SHADER,
+    fragmentShader: FRAGMENT_SHADER,
+    transparent: true,
+    // Surface raymarcher writes correct per-fragment depth, so depth
+    // testing against the rect occludes the half behind the surface.
+    // Disabling depth *write* keeps multiple translucent rects (e.g.,
+    // SlicingPlane's three planes) from blocking each other where they
+    // intersect.
+    depthWrite: false,
+    side: THREE.DoubleSide,
+    uniforms: {
+      uHalfExtent: { value: opts.halfExtent },
+      uRimWidth: { value: opts.rimWidth },
+      uBodyColor: { value: opts.bodyColor.clone() },
+      uBodyAlpha: { value: opts.bodyAlpha },
+      uRimColor: { value: opts.rimColor.clone() },
+      uRimAlpha: { value: opts.rimAlpha },
+    },
+  });
+
+  const geometry = new THREE.PlaneGeometry(
+    opts.halfExtent * 2,
+    opts.halfExtent * 2,
+  );
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.renderOrder = RENDER_ORDER;
+
+  return {
+    mesh,
+    material,
+    dispose(): void {
+      geometry.dispose();
+      material.dispose();
+    },
+  };
+}

--- a/test/exhibits/tangent-planes/poseTangentPlaneMesh.test.ts
+++ b/test/exhibits/tangent-planes/poseTangentPlaneMesh.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import * as THREE from 'three';
+import { poseTangentPlaneMesh } from '../../../src/exhibits/tangent-planes/poseTangentPlaneMesh.ts';
+
+// Unit tests for the pure math→world + orientation helper. The
+// `surfaceCenter` value matches the tangent-planes scene's
+// `SURFACE_CENTER = (0, 1.5, -4)` so position assertions read as
+// "what the user would see in headset."
+const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
+
+// PlaneGeometry's default normal (= the reference vector
+// `setFromUnitVectors` rotates from). Mirrors the constant in
+// poseTangentPlaneMesh.ts; used here only to re-apply the result
+// quaternion and verify the rotated direction.
+const REF_NORMAL = new THREE.Vector3(0, 0, 1);
+
+function transformedNormal(mesh: THREE.Object3D): THREE.Vector3 {
+  return REF_NORMAL.clone().applyQuaternion(mesh.quaternion);
+}
+
+describe('poseTangentPlaneMesh — math→world + position', () => {
+  it.each([
+    {
+      label: '+math-X (right)',
+      pointMath: [1, 0, 0] as const,
+      expectedWorld: [1, 1.5, -4] as const,
+    },
+    {
+      label: '+math-Z (north pole)',
+      pointMath: [0, 0, 1] as const,
+      expectedWorld: [0, 2.5, -4] as const,
+    },
+    {
+      label: '+math-Y (forward)',
+      pointMath: [0, 1, 0] as const,
+      expectedWorld: [0, 1.5, -5] as const,
+    },
+    {
+      label: '−math-Z (south pole)',
+      pointMath: [0, 0, -1] as const,
+      expectedWorld: [0, 0.5, -4] as const,
+    },
+  ])('point $label lands at the expected world position', ({ pointMath, expectedWorld }) => {
+    const mesh = new THREE.Object3D();
+    poseTangentPlaneMesh(mesh, pointMath, [0, 0, 1], SURFACE_CENTER);
+    expect(mesh.position.x).toBeCloseTo(expectedWorld[0], 6);
+    expect(mesh.position.y).toBeCloseTo(expectedWorld[1], 6);
+    expect(mesh.position.z).toBeCloseTo(expectedWorld[2], 6);
+  });
+
+  it('off-axis diagonal point lands at the math→world conversion + surfaceCenter', () => {
+    const inv = 1 / Math.sqrt(3);
+    const mesh = new THREE.Object3D();
+    poseTangentPlaneMesh(
+      mesh,
+      [inv, inv, inv],
+      [inv, inv, inv],
+      SURFACE_CENTER,
+    );
+    // math (X, Y, Z) → world (X, Z, −Y).
+    expect(mesh.position.x).toBeCloseTo(inv, 6);
+    expect(mesh.position.y).toBeCloseTo(1.5 + inv, 6);
+    expect(mesh.position.z).toBeCloseTo(-4 - inv, 6);
+  });
+});
+
+describe('poseTangentPlaneMesh — orientation (deterministic perpendicular cases)', () => {
+  it('+math-Z normal rotates ref +Z to world +Y', () => {
+    const mesh = new THREE.Object3D();
+    poseTangentPlaneMesh(mesh, [0, 0, 1], [0, 0, 1], SURFACE_CENTER);
+    const n = transformedNormal(mesh);
+    expect(n.x).toBeCloseTo(0, 6);
+    expect(n.y).toBeCloseTo(1, 6);
+    expect(n.z).toBeCloseTo(0, 6);
+  });
+
+  it('+math-X normal rotates ref +Z to world +X', () => {
+    const mesh = new THREE.Object3D();
+    poseTangentPlaneMesh(mesh, [1, 0, 0], [1, 0, 0], SURFACE_CENTER);
+    const n = transformedNormal(mesh);
+    expect(n.x).toBeCloseTo(1, 6);
+    expect(n.y).toBeCloseTo(0, 6);
+    expect(n.z).toBeCloseTo(0, 6);
+  });
+
+  it('−math-Z (south pole) normal rotates ref +Z to world −Y (perpendicular case)', () => {
+    // math-Z → world-Y, so normalMath [0,0,-1] → world (0,-1,0). That's
+    // perpendicular to PLANE_REF_NORMAL = (0,0,1), NOT anti-parallel.
+    // setFromUnitVectors is deterministic for perpendicular inputs.
+    const mesh = new THREE.Object3D();
+    poseTangentPlaneMesh(mesh, [0, 0, -1], [0, 0, -1], SURFACE_CENTER);
+    const n = transformedNormal(mesh);
+    expect(n.x).toBeCloseTo(0, 6);
+    expect(n.y).toBeCloseTo(-1, 6);
+    expect(n.z).toBeCloseTo(0, 6);
+  });
+
+  it('off-axis diagonal normal rotates ref +Z to the math→world conversion', () => {
+    const inv = 1 / Math.sqrt(3);
+    const mesh = new THREE.Object3D();
+    poseTangentPlaneMesh(
+      mesh,
+      [inv, inv, inv],
+      [inv, inv, inv],
+      SURFACE_CENTER,
+    );
+    const n = transformedNormal(mesh);
+    // Expected world normal = writeMathToWorld([inv,inv,inv]) = (inv, inv, -inv).
+    expect(n.x).toBeCloseTo(inv, 6);
+    expect(n.y).toBeCloseTo(inv, 6);
+    expect(n.z).toBeCloseTo(-inv, 6);
+  });
+});
+
+describe('poseTangentPlaneMesh — anti-parallel orientation (+math-Y / φ=π/2)', () => {
+  // The TRUE anti-parallel case for PLANE_REF_NORMAL = (0,0,1):
+  //   normalMath [0,1,0] → writeMathToWorld → world (0,0,-1).
+  //   dot((0,0,1), (0,0,-1)) = -1 → anti-parallel.
+  // setFromUnitVectors picks an arbitrary perpendicular axis for the 180°
+  // rotation. The rotated +Z must equal the world normal regardless of
+  // which perpendicular axis is picked; the roll about that normal is
+  // non-deterministic across Three versions (and visually invisible due
+  // to the uniform rim). We therefore assert ONLY the transformed normal
+  // direction, NOT the roll.
+  it('+math-Y normal rotates ref +Z to world (0, 0, −1) — direction only', () => {
+    const mesh = new THREE.Object3D();
+    poseTangentPlaneMesh(mesh, [0, 1, 0], [0, 1, 0], SURFACE_CENTER);
+    const n = transformedNormal(mesh);
+    expect(n.x).toBeCloseTo(0, 6);
+    expect(n.y).toBeCloseTo(0, 6);
+    expect(n.z).toBeCloseTo(-1, 6);
+  });
+
+  // Defensive: regardless of the picked perpendicular roll, the resulting
+  // quaternion must be a unit quaternion. Catches a regression where a
+  // future hand-rolled fallback returns NaN-laced components.
+  it('result quaternion is unit-length at the anti-parallel case', () => {
+    const mesh = new THREE.Object3D();
+    poseTangentPlaneMesh(mesh, [0, 1, 0], [0, 1, 0], SURFACE_CENTER);
+    const q = mesh.quaternion;
+    const len = Math.hypot(q.x, q.y, q.z, q.w);
+    expect(len).toBeCloseTo(1, 6);
+  });
+});

--- a/test/scaffold/render/translucentRect.test.ts
+++ b/test/scaffold/render/translucentRect.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+import { createTranslucentRect } from '../../../src/scaffold/render/TranslucentRect.ts';
+
+// Default-ish input fixture for tests that don't care about specific values.
+function makeOptions(overrides: Partial<Parameters<typeof createTranslucentRect>[0]> = {}) {
+  return {
+    halfExtent: 0.5,
+    bodyColor: new THREE.Color(0.34, 0.71, 0.91),
+    bodyAlpha: 0.10,
+    rimColor: new THREE.Color(0.70, 0.90, 0.99),
+    rimAlpha: 0.65,
+    rimWidth: 0.05,
+    ...overrides,
+  };
+}
+
+describe('createTranslucentRect — geometry', () => {
+  it('builds a PlaneGeometry sized 2 × halfExtent per side', () => {
+    const handle = createTranslucentRect(makeOptions({ halfExtent: 0.45 }));
+    expect(handle.mesh.geometry).toBeInstanceOf(THREE.PlaneGeometry);
+    expect(handle.mesh.geometry.parameters.width).toBeCloseTo(0.9, 6);
+    expect(handle.mesh.geometry.parameters.height).toBeCloseTo(0.9, 6);
+    handle.dispose();
+  });
+});
+
+describe('createTranslucentRect — material flags', () => {
+  it('material is transparent, depthWrite=false, side=DoubleSide', () => {
+    const handle = createTranslucentRect(makeOptions());
+    expect(handle.material.transparent).toBe(true);
+    expect(handle.material.depthWrite).toBe(false);
+    expect(handle.material.side).toBe(THREE.DoubleSide);
+    handle.dispose();
+  });
+
+  it('mesh.renderOrder is 1 (sits above default-0 implicit surface)', () => {
+    const handle = createTranslucentRect(makeOptions());
+    expect(handle.mesh.renderOrder).toBe(1);
+    handle.dispose();
+  });
+});
+
+describe('createTranslucentRect — uniforms', () => {
+  it('numeric uniforms are wired through', () => {
+    const handle = createTranslucentRect(
+      makeOptions({ halfExtent: 0.45, bodyAlpha: 0.10, rimAlpha: 0.65, rimWidth: 0.05 }),
+    );
+    expect(handle.material.uniforms.uHalfExtent.value).toBeCloseTo(0.45, 6);
+    expect(handle.material.uniforms.uBodyAlpha.value).toBeCloseTo(0.10, 6);
+    expect(handle.material.uniforms.uRimAlpha.value).toBeCloseTo(0.65, 6);
+    expect(handle.material.uniforms.uRimWidth.value).toBeCloseTo(0.05, 6);
+    handle.dispose();
+  });
+
+  // The high-value test: a future "I forgot the .clone()" regression
+  // would silently couple two consumers' colors via shared THREE.Color
+  // references. Mutating the input color after construction must NOT
+  // bleed into the GPU uniform.
+  it('bodyColor uniform is cloned (mutating the input color does not mutate the uniform)', () => {
+    const inputBody = new THREE.Color(0.34, 0.71, 0.91);
+    const handle = createTranslucentRect(makeOptions({ bodyColor: inputBody }));
+    inputBody.r = 0.99;
+    inputBody.g = 0.99;
+    inputBody.b = 0.99;
+    const uBody = handle.material.uniforms.uBodyColor.value as THREE.Color;
+    expect(uBody.r).toBeCloseTo(0.34, 6);
+    expect(uBody.g).toBeCloseTo(0.71, 6);
+    expect(uBody.b).toBeCloseTo(0.91, 6);
+    handle.dispose();
+  });
+
+  it('rimColor uniform is cloned (mutating the input color does not mutate the uniform)', () => {
+    const inputRim = new THREE.Color(0.70, 0.90, 0.99);
+    const handle = createTranslucentRect(makeOptions({ rimColor: inputRim }));
+    inputRim.r = 0.01;
+    inputRim.g = 0.01;
+    inputRim.b = 0.01;
+    const uRim = handle.material.uniforms.uRimColor.value as THREE.Color;
+    expect(uRim.r).toBeCloseTo(0.70, 6);
+    expect(uRim.g).toBeCloseTo(0.90, 6);
+    expect(uRim.b).toBeCloseTo(0.99, 6);
+    handle.dispose();
+  });
+});
+
+describe('createTranslucentRect — dispose()', () => {
+  // Three dispatches a 'dispose' event on the resource; spying on that
+  // verifies the dispose actually runs without poking at internal state.
+  it('disposes both geometry and material exactly once', () => {
+    const handle = createTranslucentRect(makeOptions());
+    const geomSpy = vi.fn();
+    const matSpy = vi.fn();
+    handle.mesh.geometry.addEventListener('dispose', geomSpy);
+    handle.material.addEventListener('dispose', matSpy);
+    handle.dispose();
+    expect(geomSpy).toHaveBeenCalledTimes(1);
+    expect(matSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #148

## Summary

Renders the **tangent-plane mesh** — the visual heart of the v0.6 tangent-planes scene, sub-issue of #121. A translucent rectangular patch sits at the user-selected surface point, oriented so its normal matches ∇f at that point; sliding θ/φ swings the plane while it stays tangent. Visual treatment matches the cross-section slicing-plane recipe locked in #113.

The shader + geometry are extracted into a new `scaffold/render/TranslucentRect.ts` primitive (extract-on-second-use, same pattern as #129/#130's ImplicitSurface lift), and `quadrics/SlicingPlane.ts` is refactored onto it. The locked color/alpha/width *constants* intentionally remain per-scene so the design language can drift in v0.7+ without coupling the two scenes — a one-line `// keep in sync with …` cross-reference comment in each file marks the coupling.

Plan + roundtable trail in `_private/plans/148-tangent-planes-mesh.md` (gitignored — maintainer-only). v2 closes 11 findings from the v1 roundtable (Sonnet + GPT-5.5 + DeepSeek; two convergent MED + two singleton HIGH); second-Sonnet sanity pass on v2 returned PROCEED.

## Test plan

Automated:

- [x] `npm run build` clean (no new TypeScript errors).
- [x] `npm test` all green (169 → 184 passing — 15 new cases across `poseTangentPlaneMesh.test.ts` and `translucentRect.test.ts`). The TranslucentRect contract test specifically asserts uniform color clones — guards against the silent-coupling regression where a future "I forgot the .clone()" would couple the two consumers' colors.
- [x] Pre-commit (gitleaks + standard fixers + eslint) clean.

Cloudflare PR preview headset smoke (when the bot comments the URL):

- [x] Open `?exhibit=tangent-planes`. Plane appears at the contact point (off-axis at θ=π/3, φ=π/4 initial), translucent body + brighter rim.
- [x] Sweep θ from π/3 → 0 (north pole). Plane sweeps to horizontal, rim visible.
- [x] Sweep θ → π/2 (equator). Plane sweeps to vertical, oriented outward.
- [x] Sweep φ from π/4 → 0 (+math-X) → π/2 (+math-Y, forward) → −π/2. Plane swings around the equator, always tangent.
- [x] **Anti-parallel-roll continuity check**: pin θ=π/2, sweep φ slowly through π/2. Watch the plane corners — `setFromUnitVectors` is stateless and has a singular region at the +math-Y direction; if the corners visibly snap, the v0.6 cut is still acceptable but a follow-up issue should propose a stable tangent-frame construction.
- [x] Visit `?exhibit=quadrics` → Cross sections section. Slicing planes look identical to before this PR (visual regression check on the SlicingPlane → TranslucentRect refactor).
- [x] Switch back to `?exhibit=tangent-planes` via the SceneRack tab. Tangent plane re-mounts cleanly — no flash at origin, no stale pose. The `group.visible = false` initial state plus pose-before-uncloak ordering in `update()` is what makes this safe.

## Architectural notes for the reviewer

- **Coordinate convention** (locked v2): `TangentPlane`'s wrapper group sits at `(0,0,0)`; `poseTangentPlaneMesh` does the full `writeMathToWorld(point) + surfaceCenter` math and writes into the inner mesh. Mirrors the indicator-positioning pattern in `index.ts:271`. Setting `group.position.copy(surfaceCenter)` would double-offset to `point + 2 × surfaceCenter`.
- **Disposal contract**: `TranslucentRectHandles.dispose()` is the single GPU-resource owner for the plane's geometry + material. The old per-mesh `geometry.dispose() + material.dispose()` traversal in SlicingPlane is removed.
- **Render layering**: indicator dot (opaque, renderOrder 0) writes depth and partially occludes the plane (translucent, renderOrder 1, depthWrite=false). Practical occlusion footprint is small (~8 cm² on a 0.45 m halfExtent plane); the dot reads as an opaque marker at the contact point, not "through" the plane. Documented in `index.ts` mount comments to prevent future-me from re-introducing the wrong "through translucency" claim.

## Out of scope (per #148 acceptance)

- Live readout of plane equation / normal — that's #149's PR. Reuses `result.normal` directly; no new entry points needed.
- Gradient-arrow rendering — deferred to v0.7 (#121 epic OOS).