### PR TITLE
feat(scene): tangent-planes — live readout of the plane equation + normal (#149)

### DIFF
--- a/src/exhibits/tangent-planes/SPEC.md
+++ b/src/exhibits/tangent-planes/SPEC.md
@@ -1,9 +1,9 @@
 # `tangent-planes` exhibit — SPEC
 
 > Math + UX contract for the tangent-planes scene. v0.6 cuts: point
-> selection on a fixed unit sphere (#147) + tangent-plane mesh anchored
-> at the selected point (#148). Live readout (#149) extends this in a
-> subsequent PR.
+> selection on a fixed unit sphere (#147), tangent-plane mesh anchored
+> at the selected point (#148), and live readout of the plane equation
+> + normal (#149).
 
 ## Goal
 
@@ -123,6 +123,44 @@ recipe lives in one shader. Color/alpha/width *constants* are
 intentionally per-scene so the design language can drift in v0.7+
 without coupling the two scenes.
 
+## Live readout
+
+A two-line stacked readout above the slider rack reports the tangent
+plane's algebraic state. Anchored at `(0, 1.32, -0.7)` — the same
+z-plane as the slider rack and the math-frame axis indicator, mirroring
+quadrics' `EQUATION_READOUT_POSITION`.
+
+- **Top line — §11.4 textbook expanded form:**
+  `n_x (x − x₀) + n_y (y − y₀) + n_z (z − z₀) = 0` with all six numerics
+  rendered as `±N.NN`. The parenthesized connector's sign is the sign
+  of `−x₀` — so `x₀ = +0.42` reads `(x − 0.42)`, `x₀ = −0.42` reads
+  `(x + 0.42)`, and exact zero reads `(x − 0.00)` (deliberate; matches
+  the textbook identity form).
+- **Bottom line — geometric handle:**
+  `n = ( ±N.NN , ±N.NN , ±N.NN )` with each component rendered as
+  `±N.NN`.
+
+Numerics are colored to match the math-frame axis story (vermillion =
+math-X, bluish-green = math-Y, sky-blue = math-Z); algebraic glue is
+neutral white with a black SDF outline. troika-three-text drives every
+glyph; layout is computed once at construction (no reflow). `.sync()`
+calls are throttled to ≈30 Hz, mirroring `quadrics/EquationReadout.ts`.
+Yaw-only billboard so the equation reads from any user yaw without
+inheriting head pitch / roll.
+
+For the unit sphere `∇f = 2p` ⇒ unit normal `n̂ = p̂`, so on first
+inspection the readout shows `n_x = x₀`, etc. — pedagogically useful
+("the normal IS the point on a unit sphere") and falls out of the
+component naturally without special handling. Generalizes cleanly to
+v0.7+ surfaces where `n ≠ p`.
+
+The class lives in `src/exhibits/tangent-planes/TangentPlaneReadout.ts`;
+a pure formatter helper in `formatTangentPlaneReadout.ts` produces the
+nine numeric strings and is unit-tested under
+`test/exhibits/tangent-planes/formatTangentPlaneReadout.test.ts`. The
+sibling vs. extending-`EquationReadout` decision is recorded in the
+class header — different slot model, no hide-on-zero, simpler.
+
 ## Render
 
 Minimal lambert: `uBaseColor * (0.2 + 0.8 * max(dot(n, normalize(uLightDir)), 0))`.
@@ -136,9 +174,6 @@ indicator.
 
 ## Out of scope (v0.6)
 
-- **Live readout of plane equation / normal** (#149) — consumes
-  `result.normal` directly from `raycastImplicit`'s return type. No new
-  entry points needed in `raycastSurface.ts` or in `TangentPlane.ts`.
 - **Coefficient editing** — see "Equation form" above.
 - **Controller-aim point picking** — natural in headset, unusable on
   the pancake build (#105) and Cloudflare PR previews. Deferred to v0.9.

--- a/src/exhibits/tangent-planes/TangentPlaneReadout.ts
+++ b/src/exhibits/tangent-planes/TangentPlaneReadout.ts
@@ -1,0 +1,317 @@
+import * as THREE from 'three';
+import { Text } from 'troika-three-text';
+import type { MathVec3 } from '@/scaffold/math/frames';
+import {
+  formatTangentPlaneReadout,
+  type TangentPlaneReadoutStrings,
+} from './formatTangentPlaneReadout';
+
+// Live readout for the tangent-planes scene (#149). Two-line layout:
+//
+//   line 1 (top):    `±N.NN (x ± N.NN) + ±N.NN (y ± N.NN) + ±N.NN (z ± N.NN) = 0`
+//   line 2 (bottom): `n = ( ±N.NN , ±N.NN , ±N.NN )`
+//
+// The top line is the §11.4 textbook expanded form
+// `n_x (x − x₀) + n_y (y − y₀) + n_z (z − z₀) = 0`; the bottom line is
+// the geometric handle (the unit-normal vector). Both update live as
+// θ / φ slide; numerics are colored to match the math-frame axis story
+// (vermillion = math-X, bluish-green = math-Y, sky-blue = math-Z), with
+// algebraic glue (`(`, `=`, `+`, `,`, `n`, `x`, `y`, `z`, `0`, `)`)
+// rendered in neutral white.
+//
+// Sibling design choice (vs. extending `quadrics/EquationReadout.ts`):
+// EquationReadout's slot model is hard-coded to seven slots [a,b,c,u,v,w,d]
+// with a hide-on-zero reflow contract; this readout has nine slots in a
+// two-line static structure with no reflow. Wrapping the troika-Text +
+// yaw-billboard idioms here keeps the surface narrow and avoids
+// coupling two scenes' UIs through a slot abstraction.
+//
+// Layout is computed once at construction and never reflowed — the
+// equation form `(x − 0.00)` reads as the textbook identity at exact
+// zero, so eliding zero terms (the way EquationReadout does) is not
+// needed. Only the numeric .text values change per frame.
+//
+// troika-three-text doesn't support inline rich text / per-span color,
+// so each numeric and each separator is its own Text instance. Numerics
+// are pre-allocated; separators are static at construction.
+
+export interface TangentPlaneReadoutOptions {
+  /**
+   * Diffuse colors for the three math-frame axis slots, in order
+   * `[x, y, z]`. The same color is shared across the top-line normal
+   * coefficient, the top-line point offset, and the bottom-line normal
+   * component for each axis — so the readout tells the same color story
+   * three times per axis, mirroring `quadrics/EquationReadout.ts`'s
+   * convention where linear-term slots reuse axis colors.
+   */
+  axisColors: readonly [number, number, number];
+  fontSize?: number;
+}
+
+const DEFAULT_FONT_SIZE = 0.028;
+
+// Slot widths in em (multiples of fontSize). NUMERIC fits worst-case
+// `−N.NN`; separator widths are sized to their string content with
+// modest breathing room. Tunable in headset; these are the v0.6 lock.
+const NUMERIC_SLOT_EM = 2.6;
+// Top-line separators.
+const OPEN_PAREN_EM = 1.8;        // " (x " / " (y " / " (z "
+const CLOSE_PAREN_OP_EM = 1.6;    // ") + "
+const CLOSE_PAREN_EQ_EM = 1.9;    // ") = 0"
+// Bottom-line separators.
+const EQ_OPEN_EM = 2.2;           // "n = ( "
+const COMMA_EM = 1.0;             // " , "
+const CLOSE_PAREN_EM = 1.0;       // " )"
+
+// Vertical gap between the two lines. Larger than 1× fontSize so the
+// lines read as visually distinct rows; smaller than 2.5× to keep the
+// readout's total height under the gap to the slider rack at y ≈ 1.07
+// (top of the θ slider).
+const LINE_PITCH = 0.06;
+
+const SEPARATOR_COLOR = 0xffffff;
+const OUTLINE_WIDTH = '8%';
+const OUTLINE_COLOR = 0x000000;
+
+// Throttle the troika `.sync()` calls to ≈30 Hz, mirroring
+// `EquationReadout.ts`. Bounds SDF rebuild work during fast drags;
+// per-frame head-pose billboarding (faceCamera) still runs every frame
+// so motion smoothness is unaffected.
+const SYNC_INTERVAL_MS = 33;
+
+// Per-axis slot indices into `axisColors`. The construction loops walk
+// from AXIS_X through AXIS_Z; the AXIS_Y constant is implicit in that
+// range and not referenced directly.
+const AXIS_X = 0;
+const AXIS_Z = 2;
+
+export class TangentPlaneReadout {
+  readonly group: THREE.Group;
+
+  private readonly fontSize: number;
+
+  // Six top-line numerics in visual reading order:
+  //   topNumerics[0] = n_x  (axis-X color)
+  //   topNumerics[1] = x₀   (axis-X color, inverted-sign)
+  //   topNumerics[2] = n_y  (axis-Y color)
+  //   topNumerics[3] = y₀   (axis-Y color, inverted-sign)
+  //   topNumerics[4] = n_z  (axis-Z color)
+  //   topNumerics[5] = z₀   (axis-Z color, inverted-sign)
+  private readonly topNumerics: readonly Text[];
+
+  // Three bottom-line numerics — n_x, n_y, n_z (one per axis).
+  private readonly bottomNumerics: readonly Text[];
+
+  // Static separators. Held only for disposal; never re-written.
+  private readonly separators: Text[] = [];
+
+  // Per-slot string cache so we don't re-write Text.text + re-trigger
+  // troika .sync() when the value hasn't changed past the throttle.
+  private readonly topNumericCache: string[] = new Array(6).fill('');
+  private readonly bottomNumericCache: string[] = new Array(3).fill('');
+
+  private lastSyncMs = 0;
+
+  // Hoisted out of `faceCamera` so per-frame billboarding does no
+  // allocation. Same convention as `EquationReadout.ts:115-116`.
+  private readonly camWorld = new THREE.Vector3();
+  private readonly groupWorld = new THREE.Vector3();
+
+  constructor(opts: TangentPlaneReadoutOptions) {
+    this.fontSize = opts.fontSize ?? DEFAULT_FONT_SIZE;
+
+    this.group = new THREE.Group();
+    this.group.name = 'tangent-plane-readout';
+
+    const numericW = NUMERIC_SLOT_EM * this.fontSize;
+    const openParenW = OPEN_PAREN_EM * this.fontSize;
+    const closeParenOpW = CLOSE_PAREN_OP_EM * this.fontSize;
+    const closeParenEqW = CLOSE_PAREN_EQ_EM * this.fontSize;
+    const eqOpenW = EQ_OPEN_EM * this.fontSize;
+    const commaW = COMMA_EM * this.fontSize;
+    const closeParenW = CLOSE_PAREN_EM * this.fontSize;
+
+    const topY = LINE_PITCH / 2;
+    const bottomY = -LINE_PITCH / 2;
+
+    // ─── Top line ────────────────────────────────────────────────
+    // [n_x] " (x " [x₀] ") + " [n_y] " (y " [y₀] ") + " [n_z] " (z " [z₀] ") = 0"
+    const totalTopW =
+      6 * numericW +
+      3 * openParenW +
+      2 * closeParenOpW +
+      closeParenEqW;
+    let cursor = -totalTopW / 2;
+
+    const topAxisLabels: readonly string[] = ['x', 'y', 'z'];
+    const topNumerics: Text[] = new Array<Text>(6);
+    for (let axis = AXIS_X; axis <= AXIS_Z; axis++) {
+      const color = opts.axisColors[axis];
+
+      // [n_axis] numeric.
+      const nText = this.makeNumericText(this.fontSize, color);
+      nText.position.set(cursor + numericW / 2, topY, 0);
+      this.group.add(nText);
+      topNumerics[axis * 2] = nText;
+      cursor += numericW;
+
+      // " (x " separator.
+      const openSep = this.makeSeparatorText(this.fontSize);
+      openSep.text = ` (${topAxisLabels[axis]} `;
+      openSep.position.set(cursor + openParenW / 2, topY, 0);
+      openSep.sync();
+      this.group.add(openSep);
+      this.separators.push(openSep);
+      cursor += openParenW;
+
+      // [axis₀] numeric.
+      const pText = this.makeNumericText(this.fontSize, color);
+      pText.position.set(cursor + numericW / 2, topY, 0);
+      this.group.add(pText);
+      topNumerics[axis * 2 + 1] = pText;
+      cursor += numericW;
+
+      // Closing separator: ") + " between terms, ") = 0" after the last.
+      const closingSep = this.makeSeparatorText(this.fontSize);
+      const isLast = axis === AXIS_Z;
+      if (isLast) {
+        closingSep.text = ') = 0';
+        closingSep.position.set(cursor + closeParenEqW / 2, topY, 0);
+        cursor += closeParenEqW;
+      } else {
+        closingSep.text = ') + ';
+        closingSep.position.set(cursor + closeParenOpW / 2, topY, 0);
+        cursor += closeParenOpW;
+      }
+      closingSep.sync();
+      this.group.add(closingSep);
+      this.separators.push(closingSep);
+    }
+    this.topNumerics = topNumerics;
+
+    // ─── Bottom line ─────────────────────────────────────────────
+    // "n = ( " [n_x] " , " [n_y] " , " [n_z] " )"
+    const totalBottomW =
+      eqOpenW + 3 * numericW + 2 * commaW + closeParenW;
+    cursor = -totalBottomW / 2;
+
+    const eqOpen = this.makeSeparatorText(this.fontSize);
+    eqOpen.text = 'n = ( ';
+    eqOpen.position.set(cursor + eqOpenW / 2, bottomY, 0);
+    eqOpen.sync();
+    this.group.add(eqOpen);
+    this.separators.push(eqOpen);
+    cursor += eqOpenW;
+
+    const bottomNumerics: Text[] = new Array<Text>(3);
+    for (let axis = AXIS_X; axis <= AXIS_Z; axis++) {
+      const color = opts.axisColors[axis];
+      const nText = this.makeNumericText(this.fontSize, color);
+      nText.position.set(cursor + numericW / 2, bottomY, 0);
+      this.group.add(nText);
+      bottomNumerics[axis] = nText;
+      cursor += numericW;
+
+      const isLast = axis === AXIS_Z;
+      const sep = this.makeSeparatorText(this.fontSize);
+      if (isLast) {
+        sep.text = ' )';
+        sep.position.set(cursor + closeParenW / 2, bottomY, 0);
+        cursor += closeParenW;
+      } else {
+        sep.text = ' , ';
+        sep.position.set(cursor + commaW / 2, bottomY, 0);
+        cursor += commaW;
+      }
+      sep.sync();
+      this.group.add(sep);
+      this.separators.push(sep);
+    }
+    this.bottomNumerics = bottomNumerics;
+  }
+
+  private makeNumericText(fontSize: number, color: number): Text {
+    const t = new Text();
+    t.fontSize = fontSize;
+    t.color = color;
+    t.anchorX = 'center';
+    t.anchorY = 'middle';
+    t.outlineWidth = OUTLINE_WIDTH;
+    t.outlineColor = OUTLINE_COLOR;
+    return t;
+  }
+
+  private makeSeparatorText(fontSize: number): Text {
+    const t = new Text();
+    t.fontSize = fontSize;
+    t.color = SEPARATOR_COLOR;
+    t.anchorX = 'center';
+    t.anchorY = 'middle';
+    t.outlineWidth = OUTLINE_WIDTH;
+    t.outlineColor = OUTLINE_COLOR;
+    return t;
+  }
+
+  /**
+   * Update all nine numerics from the per-frame raymarch result. Throttled
+   * to ≈30 Hz via SYNC_INTERVAL_MS — mirrors EquationReadout's cadence and
+   * bounds troika SDF rebuild work during fast drags. Per-slot caching
+   * skips the .text + .sync() write when the formatted string hasn't
+   * changed (e.g. between sub-pixel slider motions that round to the
+   * same `±N.NN`).
+   */
+  setValues(point: MathVec3, normal: MathVec3): void {
+    const now = performance.now();
+    if (now - this.lastSyncMs < SYNC_INTERVAL_MS) return;
+    this.lastSyncMs = now;
+
+    const strings: TangentPlaneReadoutStrings = formatTangentPlaneReadout(
+      point,
+      normal,
+    );
+
+    // Top line: interleave [n, point] per axis to match the layout order
+    // used at construction.
+    for (let axis = AXIS_X; axis <= AXIS_Z; axis++) {
+      const nIdx = axis * 2;
+      const pIdx = axis * 2 + 1;
+      const nStr = strings.topNormals[axis];
+      const pStr = strings.topPoints[axis];
+      if (nStr !== this.topNumericCache[nIdx]) {
+        this.topNumericCache[nIdx] = nStr;
+        this.topNumerics[nIdx].text = nStr;
+        this.topNumerics[nIdx].sync();
+      }
+      if (pStr !== this.topNumericCache[pIdx]) {
+        this.topNumericCache[pIdx] = pStr;
+        this.topNumerics[pIdx].text = pStr;
+        this.topNumerics[pIdx].sync();
+      }
+    }
+
+    for (let axis = AXIS_X; axis <= AXIS_Z; axis++) {
+      const nStr = strings.bottomNormals[axis];
+      if (nStr !== this.bottomNumericCache[axis]) {
+        this.bottomNumericCache[axis] = nStr;
+        this.bottomNumerics[axis].text = nStr;
+        this.bottomNumerics[axis].sync();
+      }
+    }
+  }
+
+  // Yaw-only billboard, matching EquationReadout (#29) and Label.
+  // World-up stays world-up; head pitch and roll don't tilt the readout.
+  faceCamera(camera: THREE.Camera): void {
+    camera.getWorldPosition(this.camWorld);
+    this.group.getWorldPosition(this.groupWorld);
+    const dx = this.camWorld.x - this.groupWorld.x;
+    const dz = this.camWorld.z - this.groupWorld.z;
+    this.group.rotation.set(0, Math.atan2(dx, dz), 0);
+  }
+
+  dispose(): void {
+    for (const t of this.topNumerics) t.dispose();
+    for (const t of this.bottomNumerics) t.dispose();
+    for (const t of this.separators) t.dispose();
+  }
+}

--- a/src/exhibits/tangent-planes/formatTangentPlaneReadout.ts
+++ b/src/exhibits/tangent-planes/formatTangentPlaneReadout.ts
@@ -1,0 +1,95 @@
+import type { MathVec3 } from '@/scaffold/math/frames';
+
+// Pure formatter for the tangent-planes readout (#149). Given a
+// surface-local point and its outward unit normal, produce the nine
+// numeric-slot strings that the readout's troika-Text instances render.
+//
+// Lives in its own file so test/exhibits/tangent-planes/* can import it
+// without triggering `index.ts`'s `registerExhibit` side effect at
+// unit-test import time — same isolation pattern as
+// `directionFromAngles.ts`, `raycastSurface.ts`, `poseTangentPlaneMesh.ts`.
+//
+// Sign characters use Unicode MINUS SIGN (U+2212), matching
+// `EquationReadout.ts`'s convention so the two readouts render with the
+// same `−` glyph rather than the narrower hyphen-minus.
+
+const MINUS = '−';
+const PLUS = '+';
+
+/**
+ * Sign + 2-decimal magnitude; sign is `+` for `v >= 0`, `−` for `v < 0`.
+ * Mirrors `EquationReadout.ts:344` so quadrics and tangent-planes share
+ * the same numeric-formatting idiom.
+ */
+function formatSignedMagnitude(v: number): string {
+  const sign = v < 0 ? MINUS : PLUS;
+  return `${sign}${Math.abs(v).toFixed(2)}`;
+}
+
+/**
+ * Sign + 2-decimal magnitude with the sign of `−v` (i.e. the sign of the
+ * constant in `(x − x₀)` after expanding). The pedagogical readable form
+ * for the top-line plane equation is `(x − 0.42)` when `x₀ = +0.42`, and
+ * `(x + 0.42)` when `x₀ = −0.42`. Exact zero renders as `−0.00` —
+ * deliberate, so the equation reads as the textbook identity form
+ * `(x − x₀)` even when `x₀` is at a snap-to-zero pole.
+ */
+function formatInvertedSignedMagnitude(v: number): string {
+  const sign = v < 0 ? PLUS : MINUS;
+  return `${sign}${Math.abs(v).toFixed(2)}`;
+}
+
+export interface TangentPlaneReadoutStrings {
+  /**
+   * Top-line normal coefficients (one per axis), in math reading order
+   * `[n_x, n_y, n_z]`. Each is a `±N.NN` signed-magnitude string.
+   */
+  topNormals: readonly [string, string, string];
+  /**
+   * Top-line point-offset constants (one per axis), in math reading order
+   * `[−x₀, −y₀, −z₀]`. Each is a `±N.NN` string with the sign of the
+   * negated coordinate — so `x₀ = +0.42` yields `−0.42`, displayed inside
+   * the equation as `(x − 0.42)`.
+   */
+  topPoints: readonly [string, string, string];
+  /**
+   * Bottom-line normal-vector components, in math reading order
+   * `[n_x, n_y, n_z]`. Each is a `±N.NN` signed-magnitude string. Same
+   * source values as `topNormals`; the readout writes both because the
+   * top and bottom lines hold geometrically-independent Text instances.
+   */
+  bottomNormals: readonly [string, string, string];
+}
+
+/**
+ * Format the nine numeric strings the readout displays from the per-frame
+ * raymarch result. Pure; allocates one fresh struct per call. Allocation
+ * cost is bounded by the readout's update throttle (≈30 Hz), so the
+ * per-frame call rate stays under 30 allocations/second.
+ *
+ * The point and normal are surface-local math-frame; the readout shows
+ * raw surface-local components without any frame swap (the textbook
+ * §11.4 form is in math coordinates, not Three.js world coordinates).
+ */
+export function formatTangentPlaneReadout(
+  point: MathVec3,
+  normal: MathVec3,
+): TangentPlaneReadoutStrings {
+  return {
+    topNormals: [
+      formatSignedMagnitude(normal[0]),
+      formatSignedMagnitude(normal[1]),
+      formatSignedMagnitude(normal[2]),
+    ],
+    topPoints: [
+      formatInvertedSignedMagnitude(point[0]),
+      formatInvertedSignedMagnitude(point[1]),
+      formatInvertedSignedMagnitude(point[2]),
+    ],
+    bottomNormals: [
+      formatSignedMagnitude(normal[0]),
+      formatSignedMagnitude(normal[1]),
+      formatSignedMagnitude(normal[2]),
+    ],
+  };
+}

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -6,10 +6,16 @@ import { writeMathToWorld, type MathVec3 } from '@/scaffold/math/frames';
 import { createImplicitSurface } from '@/scaffold/render/ImplicitSurface';
 import { Slider } from '@/scaffold/ui/Slider';
 import { WorldAxes, type AxisName } from '@/scaffold/ui/WorldAxes';
-import { DEFAULT_AXIS_COLORS } from '@/scaffold/design/tokens';
+import {
+  BLUISH_GREEN,
+  DEFAULT_AXIS_COLORS,
+  SKY_BLUE,
+  VERMILLION,
+} from '@/scaffold/design/tokens';
 import { directionFromAngles } from './directionFromAngles';
 import { raycastImplicit } from './raycastSurface';
 import { createTangentPlane, type TangentPlaneHandles } from './TangentPlane';
+import { TangentPlaneReadout } from './TangentPlaneReadout';
 
 // Tangent-planes scene (#147). First sub-issue of the #121 epic — sets up
 // the v0.6 scene's surface + θ/φ point selection so #148 (tangent-plane
@@ -38,6 +44,13 @@ import { createTangentPlane, type TangentPlaneHandles } from './TangentPlane';
 const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
 const SLIDER_RACK_CENTER = new THREE.Vector3(0, 1.0, -0.7);
 const AXIS_INDICATOR_POSITION = new THREE.Vector3(0.35, 1.17, -0.7);
+
+// Tangent-plane readout (#149) sits above the slider rack, on the same
+// z-plane. y = 1.32 mirrors quadrics' EQUATION_READOUT_POSITION; clears
+// the θ slider's top (y ≈ 1.07) by ~0.25 m — enough vertical breathing
+// room for the two-line stack at fontSize 0.028 (line pitch 0.06, total
+// height ~0.06 m).
+const READOUT_POSITION = new THREE.Vector3(0, 1.32, -0.7);
 
 // Tighter than quadrics' BOUND=3.5: the unit sphere fits in [-1, 1]³ with
 // room to spare; no coefficient-driven expansion to budget for.
@@ -149,6 +162,7 @@ let thetaSlider: Slider | undefined;
 let phiSlider: Slider | undefined;
 let indicator: THREE.Mesh | undefined;
 let tangentPlane: TangentPlaneHandles | undefined;
+let tangentPlaneReadout: TangentPlaneReadout | undefined;
 let worldAxes: WorldAxes | undefined;
 let controllers: readonly THREE.Object3D[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
@@ -253,6 +267,15 @@ const tangentPlanesExhibit: Exhibit = {
     });
     group.add(tangentPlane.group);
 
+    // Live readout of the plane equation + normal (#149). Anchored above
+    // the slider rack on the same z-plane; updated each hit frame from
+    // the same raymarch result that drives the indicator + tangent plane.
+    tangentPlaneReadout = new TangentPlaneReadout({
+      axisColors: [VERMILLION, BLUISH_GREEN, SKY_BLUE],
+    });
+    tangentPlaneReadout.group.position.copy(READOUT_POSITION);
+    group.add(tangentPlaneReadout.group);
+
     // Math-frame axis indicator — same anchor as quadrics.
     worldAxes = new WorldAxes({ axisColors: AXIS_COLORS });
     worldAxes.group.position.copy(AXIS_INDICATOR_POSITION);
@@ -295,14 +318,23 @@ const tangentPlanesExhibit: Exhibit = {
       // construction-time identity.
       tangentPlane.setPose(result.point, result.normal);
       tangentPlane.setVisible(true);
+
+      // Readout consumes raw surface-local point + normal; the §11.4
+      // expanded form is in math coordinates, no frame swap needed.
+      tangentPlaneReadout?.setValues(result.point, result.normal);
     } else {
       indicator.visible = false;
       tangentPlane.setVisible(false);
+      // Freeze the readout on its last value during a miss frame —
+      // blanking would flicker on grazing rays (when v0.7+ surfaces
+      // bring real misses); for v0.6's unit sphere this branch never
+      // fires.
     }
 
     // Yaw-only billboard on the WorldAxes letter labels (X / Y / Z), so
     // they read at any user yaw. Same per-frame contract as quadrics.
     if (worldAxes && camera) worldAxes.faceCamera(camera);
+    if (tangentPlaneReadout && camera) tangentPlaneReadout.faceCamera(camera);
   },
 
   unmount() {
@@ -332,6 +364,8 @@ const tangentPlanesExhibit: Exhibit = {
     }
     tangentPlane?.dispose();
     tangentPlane = undefined;
+    tangentPlaneReadout?.dispose();
+    tangentPlaneReadout = undefined;
     thetaSlider?.dispose();
     thetaSlider = undefined;
     phiSlider?.dispose();

--- a/test/exhibits/tangent-planes/formatTangentPlaneReadout.test.ts
+++ b/test/exhibits/tangent-planes/formatTangentPlaneReadout.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { formatTangentPlaneReadout } from '../../../src/exhibits/tangent-planes/formatTangentPlaneReadout.ts';
+
+// Sign + magnitude formatter for the tangent-planes readout (#149).
+// Pure; verifies the three contracts the headset visual depends on:
+//   1. Top-line normal slot uses a leading sign of `+` for non-negative
+//      values, `−` (U+2212) for negative — matches `EquationReadout.ts`.
+//   2. Top-line point slot uses an *inverted* sign — the `±` glyph is
+//      the sign of `−x₀` so the parenthesized form `(x − x₀)` reads
+//      correctly under sign flip.
+//   3. Bottom-line normal slot is the same signed-magnitude as the top
+//      normal (independent Text instances drive the same string source).
+//
+// Guards a textbook-form regression at the unit-test level: a swapped
+// sign convention would otherwise slip through to a manual headset
+// smoke pass, where `(x + 0.42)` masquerading as `(x − x₀)` for
+// `x₀ = +0.42` would silently teach the wrong algebra.
+
+const MINUS = '−'; // U+2212
+
+describe('formatTangentPlaneReadout — top-line normals', () => {
+  it('positive normal → leading "+" sign', () => {
+    const r = formatTangentPlaneReadout([0, 0, 0], [0.71, 0.5, 0.5]);
+    expect(r.topNormals[0]).toBe('+0.71');
+    expect(r.topNormals[1]).toBe('+0.50');
+    expect(r.topNormals[2]).toBe('+0.50');
+  });
+
+  it('negative normal → leading "−" sign (U+2212)', () => {
+    const r = formatTangentPlaneReadout([0, 0, 0], [-0.71, -0.5, -0.5]);
+    expect(r.topNormals[0]).toBe(`${MINUS}0.71`);
+    expect(r.topNormals[1]).toBe(`${MINUS}0.50`);
+    expect(r.topNormals[2]).toBe(`${MINUS}0.50`);
+  });
+
+  it('zero normal → "+0.00" (sphere normals are never exactly zero, but the path is defensive)', () => {
+    const r = formatTangentPlaneReadout([0, 0, 0], [0, 0, 0]);
+    expect(r.topNormals[0]).toBe('+0.00');
+    expect(r.topNormals[1]).toBe('+0.00');
+    expect(r.topNormals[2]).toBe('+0.00');
+  });
+});
+
+describe('formatTangentPlaneReadout — top-line point offsets (inverted sign)', () => {
+  it('positive x₀ → "−|x₀|" (renders as (x − 0.42))', () => {
+    const r = formatTangentPlaneReadout([0.42, 0.5, 0.71], [0, 0, 0]);
+    expect(r.topPoints[0]).toBe(`${MINUS}0.42`);
+    expect(r.topPoints[1]).toBe(`${MINUS}0.50`);
+    expect(r.topPoints[2]).toBe(`${MINUS}0.71`);
+  });
+
+  it('negative x₀ → "+|x₀|" (renders as (x + 0.42))', () => {
+    const r = formatTangentPlaneReadout([-0.42, -0.5, -0.71], [0, 0, 0]);
+    expect(r.topPoints[0]).toBe('+0.42');
+    expect(r.topPoints[1]).toBe('+0.50');
+    expect(r.topPoints[2]).toBe('+0.71');
+  });
+
+  it('exact zero x₀ → "−0.00" (renders as (x − 0.00), the textbook identity form)', () => {
+    const r = formatTangentPlaneReadout([0, 0, 0], [1, 0, 0]);
+    expect(r.topPoints[0]).toBe(`${MINUS}0.00`);
+    expect(r.topPoints[1]).toBe(`${MINUS}0.00`);
+    expect(r.topPoints[2]).toBe(`${MINUS}0.00`);
+  });
+});
+
+describe('formatTangentPlaneReadout — bottom-line normals match top-line normals', () => {
+  it('source value parity — same signed-magnitude string per axis', () => {
+    const r = formatTangentPlaneReadout([0, 0, 0], [0.71, -0.5, 0]);
+    expect(r.bottomNormals[0]).toBe(r.topNormals[0]);
+    expect(r.bottomNormals[1]).toBe(r.topNormals[1]);
+    expect(r.bottomNormals[2]).toBe(r.topNormals[2]);
+  });
+});
+
+describe('formatTangentPlaneReadout — unit sphere identity (n̂ = p̂)', () => {
+  it('on the unit sphere the normal equals the point — readouts agree per axis', () => {
+    // A real surface point on the unit sphere: (sin θ cos φ, sin θ sin φ, cos θ)
+    // with θ = π/3, φ = π/4. Same initial pose used in tangent-planes/index.ts.
+    const x = Math.sin(Math.PI / 3) * Math.cos(Math.PI / 4);
+    const y = Math.sin(Math.PI / 3) * Math.sin(Math.PI / 4);
+    const z = Math.cos(Math.PI / 3);
+    // For x²+y²+z²=1, ∇f = 2p ⇒ unit normal = p directly.
+    const r = formatTangentPlaneReadout([x, y, z], [x, y, z]);
+    // Top-line normal coefficients are the signed point components.
+    expect(r.topNormals[0]).toBe('+0.61');
+    expect(r.topNormals[1]).toBe('+0.61');
+    expect(r.topNormals[2]).toBe('+0.50');
+    // Top-line point offsets carry the inverted sign — the equation
+    // reads `+0.61 (x − 0.61) + 0.61 (y − 0.61) + 0.50 (z − 0.50) = 0`.
+    expect(r.topPoints[0]).toBe(`${MINUS}0.61`);
+    expect(r.topPoints[1]).toBe(`${MINUS}0.61`);
+    expect(r.topPoints[2]).toBe(`${MINUS}0.50`);
+  });
+});
+
+describe('formatTangentPlaneReadout — sign flip continuity', () => {
+  it('crossing zero on x₀ flips only the parenthesized connector — magnitude unchanged', () => {
+    const positive = formatTangentPlaneReadout([0.42, 0, 0], [0, 0, 1]);
+    const negative = formatTangentPlaneReadout([-0.42, 0, 0], [0, 0, 1]);
+    expect(positive.topPoints[0]).toBe(`${MINUS}0.42`);
+    expect(negative.topPoints[0]).toBe('+0.42');
+  });
+});


### PR DESCRIPTION
Closes #149

## Summary

Third (and final) sub-issue of #121. Adds a stacked two-line readout above the slider rack:

- **Top line — §11.4 textbook expanded form:** `n_x (x − x₀) + n_y (y − y₀) + n_z (z − z₀) = 0`. Numerics are signed `±N.NN`; the parenthesized connector's sign is the sign of `−x₀` so `(x − x₀)` reads correctly under sign flips (`x₀ = +0.42` → `(x − 0.42)`, `x₀ = −0.42` → `(x + 0.42)`, `x₀ = 0` → `(x − 0.00)`, the textbook identity form).
- **Bottom line — geometric handle:** `n = ( ±N.NN , ±N.NN , ±N.NN )`.

Built as a sibling component (`TangentPlaneReadout`), **not** by extending `quadrics/EquationReadout` — different slot model, no hide-on-zero, no reflow. Pure formatter helper (`formatTangentPlaneReadout`) is unit-tested for sign + magnitude under sign flips and exact-zero edge cases. Update throttle (≈30 Hz) + yaw-only billboard mirror the quadrics readout. Numerics are colored to match the math-frame axis story (vermillion / bluish-green / sky-blue). For the unit sphere, `∇f = 2p ⇒ n̂ = p̂`, so the user sees `n = p₀` agree on first inspection — pedagogically useful and falls out without special handling.

SPEC.md updated; the live-readout out-of-scope bullet is removed.

## Test plan

- [x] `npm run build` passes (tsc + vite).
- [x] `npm test` passes — 178 tests including the new `formatTangentPlaneReadout.test.ts` (9 cases: positive / negative / zero on top normals, top point offsets, bottom normals, unit-sphere identity, and sign-flip continuity at `x₀ = 0`).
- [x] Pre-commit hooks pass (gitleaks + eslint).
- [x] **Cloudflare PR preview (in-headset smoke):**
  - [x] Numbers track the picture at the four φ snap cardinals + the equator.
  - [x] Sign of the parenthesized connector flips correctly when crossing `x₀ = 0`, `y₀ = 0`, `z₀ = 0` (slide θ through π/2 with φ = ±π/2 to hit `x₀ = 0`; etc.).
  - [x] No flicker mid-drag — throttle behaves.
  - [x] Readout legible from the user's spawn point (~2.5 m); doesn't crowd the slider rack.
  - [x] Cluster-switch + back: readout unmounts cleanly and re-mounts with fresh values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)