### PR TITLE
feat(scene): gradient-levels — register scene + k-slider sweeping f(x,y,z)=k (#163)

### DIFF
--- a/src/exhibits/gradient-levels/SPEC.md
+++ b/src/exhibits/gradient-levels/SPEC.md
@@ -1,0 +1,148 @@
+# `gradient-levels` exhibit — SPEC
+
+> Math + UX contract for the gradient + level-surfaces scene. v0.7 cuts:
+> register the third cluster member with a single k slider sweeping
+> { f(x, y, z) = k } across the canonical hyperboloid family (#163).
+> #164 adds point selection, #165 the gradient arrow, #166 the live
+> readout.
+
+## Goal
+
+An interactive WebXR scene where the learner drags a single slider — k —
+to sweep the level surface `{ f(x, y, z) = k }` of a fixed quadric `f`.
+The surface deforms continuously as k slides, traversing pedagogically
+rich poses of the family. Anchors the "level surfaces are the 3D contour
+family of f" intuition for APPM 2350 §11.6 (Directional Derivatives and
+the Gradient Vector).
+
+Sibling of `quadrics` and `tangent-planes` in the `calculus3` cluster;
+the SceneRack swaps between them at runtime.
+
+## Equation form
+
+The surface is the level set of `f(x, y, z) = x² + y² − z²` in math
+coordinates (math-X right, math-Y forward, math-Z up). The level value
+`k` is the only editable parameter; coefficients `(a, b, c) = (1, 1, −1)`
+are fixed for v0.7.
+
+Coefficient editability is **out of scope for v0.7** by deliberate
+choice (not by accident):
+
+- The §11.6 pedagogy goal is internalizing what the *level-surface
+  family* `{ f = k }` is — a continuously-parameterized family that
+  traverses a topology change as k crosses zero. That story is told by
+  one f and a k slider; varying f competes with the quadrics
+  manipulator's "morph the surface family" story.
+- Sibling scenes should differ in what they teach, not duplicate the
+  surface UI.
+
+The world-frame GLSL maps math-Z → world-Y so the negative term lands
+on `p.y²` in the shader; the family then opens vertically (along
+world-up), matching textbook §11.6 diagrams. The math-frame substitution
+(math-X = world-X, math-Y = −world-Z, math-Z = world-Y) is documented
+in the GLSL chunk in `index.ts`.
+
+## Level-surface family
+
+Three textbook poses live inside the slider's range:
+
+- `k = +1` — canonical 1-sheet hyperboloid (single connected piece,
+  opens along ±math-Z = world-up).
+- `k = 0` — double cone with apex at the origin; the family's
+  topology-transition point.
+- `k = −1` — canonical 2-sheet hyperboloid (two disconnected sheets
+  along ±math-Z).
+
+The k = 0 transition *is* the §11.6 punch line — students watch a
+single connected surface pinch to a cone and split into two sheets in
+one continuous slider motion.
+
+## k slider model
+
+Mirrors the cluster siblings' detent contract: the emitted value snaps
+inside each detent's half-width while the underlying accumulator
+integrates hand motion freely (slow drags escape snaps naturally).
+
+- Range: `k ∈ [−2, 2]`.
+- Initial value: `K_INITIAL = +0.5`. Positive (default 1-sheet
+  hyperboloid for the §11.6 pedagogy), off the cone singularity, off
+  every snap point — so the user sees immediate continuous response in
+  either drag direction on first load.
+- `snapDetent` half-width: 0.05 (matches cluster siblings).
+- Snap points: `[−1, 0, +1]` — the three textbook poses above.
+
+`K_INITIAL` is the single source of truth for the boot-time k value:
+the surface uniform `uK` is seeded with it via `extraUniforms`, and the
+slider's `initial` references the same constant. If they ever drift,
+the boot pose would visibly snap on the first `update()` tick; smoke at
+boot catches it.
+
+Slider visuals: neutral light gray base color (`0xaaaaaa`), sphere thumb
+shape — k is a scalar level value, not an axis-aligned parameter, so
+neither an axis tint nor an arrow thumb would carry meaning.
+
+## No on-screen k value (intentional v0.7-#163 deferral)
+
+The numeric value of k is not displayed in this PR. The minimum-viable
+scene the issue calls for is "register + slider"; adding worldspace
+text is scope creep against the issue title. Acknowledged that not
+seeing the number weakens the immediate learning loop (the user is
+actively dragging the parameter whose value is hidden); a follow-up
+will add a numeric k label near the slider, scheduled between #164
+and #165.
+
+## Render
+
+Minimal lambert: `uBaseColor * (0.2 + 0.8 * max(dot(n, normalize(uLightDir)), 0))`.
+No grid, no parametric grid, no cross-section glow. The visual focus
+belongs on the *family sweep* — a busy surface competes.
+
+Same `SURFACE_CENTER`, `LIGHT_DIR`, and `uBaseColor` as cluster siblings
+so the surface reads as a sibling. World-axis grid deferred. AABB
+half-extent `BOUND = 3.0` — the family is unbounded along math-Z; at
+`k = +2` the flare radius at math-Z = ±3 is `√11 ≈ 3.32` m, wider than
+`BOUND` itself, so the AABB clip cuts the surface where it is already
+on its outward flare. The crop reads as a gradual taper into the box
+wall rather than a mid-belly slice. (Smaller `BOUND` would slice the
+surface mid-flare; larger `BOUND` adds AABB-march cost without
+pedagogical payoff.)
+
+## Cone singularity (k = 0)
+
+The cone `mx² + my² − mz² = 0` has a Lipschitz-discontinuous gradient
+at the apex. Three concerns:
+
+1. **Visual at k = 0.** GPU raymarcher tests `f` at sampled points; the
+   apex contributes only if a ray passes exactly through the origin,
+   which is measure-zero in a uniform-stepped march.
+2. **Analytic gradient at the apex.** `gradF(vec3(0)) = vec3(0)`. The
+   harness's downstream `normalize(gradF(p))` would yield NaN. The
+   `gradF` GLSL chunk has an explicit
+   `if (dot(g, g) < 1e-6) g = vec3(0, 1, 0);` guard, returning a
+   deterministic up-facing world normal that reads as visually benign on
+   a cone whose apex is symmetric around the up axis. Falling back to
+   a central-difference here would also be degenerate
+   (`f(h, 0, 0) = f(−h, 0, 0) = h²`), so the shader-side guard is the
+   right fix.
+3. **CPU side (#164's concern).** Flagged here so the design tax is
+   inherited: the same NaN edge case applies in JS when the user walks
+   a point selection toward the apex. Resolution can wait until #164
+   (likely the same `dot(g, g) < eps` guard in the JS gradient).
+
+## Out of scope (v0.7 #163)
+
+- **Point selection** — point indicator + θ/φ-style sliders + CPU
+  raymarcher land in #164.
+- **Gradient arrow** — 3D arrow at the selected point, oriented along
+  ∇f. #165.
+- **Live readout** — numeric ∇f and |∇f|. #166.
+- **Numeric k value display** — separate follow-up between #164 and
+  #165.
+- **Coefficient editing** — see "Equation form" above. The `SURFACE`
+  block in `index.ts` is the single source of truth for f; adding
+  editable `(a, b, c)` would mean new uniforms + an extended SURFACE
+  block, not a structural change.
+- **Alternate f presets** — quadric is the natural family for v0.7;
+  non-quadric f presets are a v0.7-polish or v0.8+ idea.
+- **Floor** — the family extends to ±math-Z (vertically); a floor would
+  need to be hole-punched. Plain shell-bg surface is cleaner.

--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -1,0 +1,268 @@
+import * as THREE from 'three';
+import type { Exhibit, ExhibitContext } from '../../shell/Exhibit';
+import { CLUSTER_CALCULUS3 } from '../../shell/clusters';
+import { registerExhibit } from '../../shell/registry';
+import { createImplicitSurface } from '@/scaffold/render/ImplicitSurface';
+import { Slider } from '@/scaffold/ui/Slider';
+import { WorldAxes, type AxisName } from '@/scaffold/ui/WorldAxes';
+import { DEFAULT_AXIS_COLORS } from '@/scaffold/design/tokens';
+
+// Gradient + level-surfaces scene (#163, parent epic #162). Third member of
+// the calculus3 cluster, alongside quadrics and tangent-planes. The user
+// sees a single quadric level surface { f(x, y, z) = k } for the family
+// f = x² + y² − z² and a single slider that sweeps k across [-2, 2].
+//
+// Pedagogy target: APPM 2350 §11.6 (gradient + level surfaces). Stuck-point:
+// students treat level surfaces as static "snapshots" rather than as a
+// continuously-deforming family. Sweeping k traverses three textbook poses
+// — 1-sheet hyperboloid (k > 0), double cone (k = 0), 2-sheet hyperboloid
+// (k < 0) — inside one slider range, with a topology change in the middle.
+//
+// This PR establishes the worldspace footprint (surface + k slider +
+// WorldAxes); #164 adds point selection on the active surface, #165 the
+// gradient arrow, #166 the readout. f is intentionally non-editable in
+// v0.7 — the quadrics manipulator already covers surface-family morphing,
+// and this scene's story is k as a parameter, not (a, b, c). Recorded in
+// SPEC.md.
+
+// ────────────────────────────────────────────────────────────────────
+// Constants
+// ────────────────────────────────────────────────────────────────────
+
+// Match cluster siblings so SceneRack swaps don't visually relocate the
+// surface or the rack.
+const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
+const SLIDER_RACK_CENTER = new THREE.Vector3(0, 1.0, -0.7);
+const AXIS_INDICATOR_POSITION = new THREE.Vector3(0.35, 1.17, -0.7);
+
+// Family { x² + y² − z² = k } is unbounded along math-Z. At k = +2 the
+// flare radius at math-Z = ±BOUND is √(2 + BOUND²); at BOUND = 3.0 that
+// is √11 ≈ 3.32 m, wider than BOUND itself — so the AABB clips the
+// surface where it is already on its outward flare, reading as a
+// gradual taper into the box wall rather than a mid-belly slice.
+const BOUND = 3.0;
+
+// Cluster siblings' lighting + base color so the surface reads as a
+// sibling, not as a separate scene's surface.
+const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
+const BASE_COLOR = new THREE.Color(0.4, 0.7, 0.95);
+
+// Quadrics' design feel ports across the cluster.
+const SLIDER_SNAP_DETENT = 0.05;
+const GRAB_RADIUS_MULTIPLIER = 2.75;
+
+// k ∈ [-2, 2]. Wide enough to show distinct 2-sheet and 1-sheet poses
+// while keeping the slider thumb's spatial sweep mapped to a meaningful
+// family scan. Snap detents at the three textbook poses: -1 (canonical
+// 2-sheet), 0 (cone — the topology transition), +1 (canonical 1-sheet).
+const K_MIN = -2;
+const K_MAX = 2;
+const K_SNAP_POINTS: readonly number[] = [-1, 0, 1];
+
+// Initial k. Positive (default 1-sheet hyperboloid for the §11.6
+// pedagogy), off the cone singularity at zero, off every snap point so
+// the user sees immediate continuous response in either drag direction.
+// Single source of truth: referenced by the extraUniforms seed AND the
+// slider's `initial` so the boot pose agrees on first paint.
+const K_INITIAL = 0.5;
+
+// Off-axis neutral gray so the user doesn't read the slider as an
+// axis-coefficient slider (vermillion / bluish-green / sky-blue carry
+// math-X / Y / Z meaning across the cluster). k is a scalar level value,
+// no axis association.
+const SLIDER_BASE_COLOR = 0xaaaaaa;
+
+const AXIS_COLORS: Record<AxisName, number> = DEFAULT_AXIS_COLORS;
+
+// ────────────────────────────────────────────────────────────────────
+// Surface model — GLSL only.
+//
+// Math frame: math-X = world-X (right), math-Y = −world-Z (forward),
+// math-Z = world-Y (up). The cluster convention (verified against
+// quadrics/index.ts) is that the shader operates in world-frame coords;
+// the math-frame mapping happens inside the formula.
+//
+// f_math(mx, my, mz) = mx² + my² − mz² − k. Substituting mx = p.x,
+// my = −p.z, mz = p.y collapses to f = p.x² + p.z² − p.y² − uK; the sign
+// is squared away in the my term, so the only observable consequence is
+// which world-axis carries the negative term. The negative term must be
+// on p.y² (= world-Y² = math-Z²) so the hyperboloid opens vertically —
+// matching textbook §11.6 diagrams.
+//
+// No JS half in this PR. #164 introduces a CPU raymarcher for point
+// selection and brings typed `fJs` / `gradJs` with it.
+// ────────────────────────────────────────────────────────────────────
+
+const SURFACE = {
+  fImplicitGlsl: /* glsl */ `
+    float fImplicit(vec3 p) {
+      // Math-frame: math-X = world-X, math-Y = -world-Z, math-Z = world-Y.
+      // Family { x_m² + y_m² - z_m² = k } opens along math-Z (= world-Y),
+      // so the negative term is on p.y².
+      return p.x * p.x + p.z * p.z - p.y * p.y - uK;
+    }
+  `,
+  gradFGlsl: /* glsl */ `
+    vec3 gradF(vec3 p) {
+      vec3 g = vec3(2.0 * p.x, -2.0 * p.y, 2.0 * p.z);
+      // Cone apex (k = 0, p = origin) makes g = vec3(0); the harness's
+      // downstream normalize(gradF(p)) would produce NaN. Fall back to a
+      // deterministic up-facing world normal — visually benign on a cone
+      // whose apex is symmetric around the up axis. Central differences
+      // are also degenerate at the origin (f(h,0,0) = f(-h,0,0) = h²),
+      // so this shader-side guard is the right fix. The apex is
+      // measure-zero in a uniform-stepped march, so this branch fires
+      // for at most a single fragment per frame.
+      if (dot(g, g) < 1e-6) g = vec3(0.0, 1.0, 0.0);
+      return g;
+    }
+  `,
+  bound: BOUND,
+} as const;
+
+const SURFACE_UNIFORM_DECLS = /* glsl */ `
+  uniform vec3 uLightDir;
+  uniform vec3 uBaseColor;
+  uniform float uK;
+`;
+
+const SURFACE_SHADE = /* glsl */ `
+  vec3 shadeHit(vec3 pHit, vec3 n, vec3 hitWorld, vec3 rd) {
+    float lambert = max(dot(n, normalize(uLightDir)), 0.0);
+    return uBaseColor * (0.2 + 0.8 * lambert);
+  }
+`;
+
+// ────────────────────────────────────────────────────────────────────
+// Module-scoped state
+// ────────────────────────────────────────────────────────────────────
+
+// Named handles — initialized in mount, disposed inline in unmount.
+let surfaceMesh: THREE.Mesh | undefined;
+let surfaceMaterial: THREE.ShaderMaterial | undefined;
+let kSlider: Slider | undefined;
+let worldAxes: WorldAxes | undefined;
+let controllers: readonly THREE.Object3D[] = [];
+// Cached at mount; cleared at unmount. Used for the WorldAxes label
+// yaw-billboarding in update().
+let camera: THREE.Camera | undefined;
+
+// ────────────────────────────────────────────────────────────────────
+// Exhibit
+// ────────────────────────────────────────────────────────────────────
+
+const gradientLevelsExhibit: Exhibit = {
+  id: 'gradient-levels',
+  title: 'Level surfaces',
+  cluster: CLUSTER_CALCULUS3,
+
+  mount({ group, camera: cam, controllers: shellControllers }: ExhibitContext) {
+    controllers = shellControllers;
+    camera = cam;
+
+    // Ambient + directional lights matching cluster siblings.
+    group.add(new THREE.AmbientLight(0xffffff, 0.4));
+    const directional = new THREE.DirectionalLight(0xffffff, 0.8);
+    directional.position.copy(LIGHT_DIR).multiplyScalar(5);
+    group.add(directional);
+
+    // Implicit-surface mesh + ShaderMaterial via the shared harness. uK
+    // is seeded at K_INITIAL so the surface boots at the right pose
+    // even before the first update() tick.
+    const surfaceHandles = createImplicitSurface({
+      surfaceCenter: SURFACE_CENTER,
+      bound: SURFACE.bound,
+      uniforms: SURFACE_UNIFORM_DECLS,
+      fImplicit: SURFACE.fImplicitGlsl,
+      gradF: SURFACE.gradFGlsl,
+      shade: SURFACE_SHADE,
+      extraUniforms: {
+        uLightDir: { value: LIGHT_DIR.clone() },
+        uBaseColor: { value: BASE_COLOR.clone() },
+        uK: { value: K_INITIAL },
+      },
+    });
+    surfaceMesh = surfaceHandles.mesh;
+    surfaceMaterial = surfaceHandles.material;
+    group.add(surfaceHandles.mesh);
+
+    // Single k slider — no SectionTab in this PR (one section only).
+    // `initial` matches the extraUniforms.uK seed above so the boot
+    // pose is consistent across material and slider on first paint.
+    kSlider = new Slider({
+      label: 'k',
+      min: K_MIN,
+      max: K_MAX,
+      initial: K_INITIAL,
+      snapDetent: SLIDER_SNAP_DETENT,
+      snapPoints: K_SNAP_POINTS,
+      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER,
+      baseColor: SLIDER_BASE_COLOR,
+      thumbShape: 'sphere',
+    });
+    kSlider.group.position.copy(SLIDER_RACK_CENTER);
+    group.add(kSlider.group);
+
+    // Math-frame axis indicator — same anchor as cluster siblings.
+    worldAxes = new WorldAxes({ axisColors: AXIS_COLORS });
+    worldAxes.group.position.copy(AXIS_INDICATOR_POSITION);
+    group.add(worldAxes.group);
+  },
+
+  update() {
+    if (!kSlider) return;
+
+    // Slider hover + drag tick.
+    kSlider.updateHover(controllers);
+    kSlider.update();
+
+    // Push k into the surface uniform.
+    if (surfaceMaterial) {
+      surfaceMaterial.uniforms.uK.value = kSlider.value;
+    }
+
+    // Yaw-only billboard on the WorldAxes letter labels so they read at
+    // any user yaw. Same per-frame contract as cluster siblings.
+    if (worldAxes && camera) worldAxes.faceCamera(camera);
+  },
+
+  unmount() {
+    // 1. Release any active controller grabs so disposed sliders don't
+    //    leak grab references back into the shell's controller objects.
+    for (const c of controllers) {
+      kSlider?.releaseFromController(c);
+    }
+
+    // 2. Dispose named handles — geometry + material per Three.js
+    //    convention. Each resource has exactly one disposal owner.
+    if (surfaceMesh) {
+      surfaceMesh.geometry.dispose();
+      surfaceMesh = undefined;
+    }
+    if (surfaceMaterial) {
+      surfaceMaterial.dispose();
+      surfaceMaterial = undefined;
+    }
+    kSlider?.dispose();
+    kSlider = undefined;
+    worldAxes?.dispose();
+    worldAxes = undefined;
+
+    // 3. Drop external references so a re-mount starts clean. The shell
+    //    removes ctx.group and its descendants automatically.
+    controllers = [];
+    camera = undefined;
+  },
+
+  onSelectStart(controller: THREE.Object3D) {
+    if (kSlider?.tryGrab(controller)) return;
+  },
+
+  onSelectEnd(controller: THREE.Object3D) {
+    kSlider?.releaseFromController(controller);
+  },
+};
+
+registerExhibit(gradientLevelsExhibit);
+
+export default gradientLevelsExhibit;

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,10 +6,12 @@ import { bootShell } from './shell/shell';
 // Order matters: `registerExhibit` appends in import order, the shell's
 // cluster filter preserves it, and `clusterExhibits[0]` is the bare-URL
 // boot default. Quadrics stays first (cluster default + first SceneRack
-// tab); tangent-planes second (pre-warmed as a non-default sibling at
-// boot). `hello` stays last — cluster-less, filtered out of the rack.
+// tab); tangent-planes second; gradient-levels third (pre-warmed as a
+// non-default sibling at boot). `hello` stays last — cluster-less,
+// filtered out of the rack.
 import './exhibits/quadrics';
 import './exhibits/tangent-planes';
+import './exhibits/gradient-levels';
 import './exhibits/hello';
 
 bootShell();


### PR DESCRIPTION
Closes #163

## Summary

First sub-issue of #162 (gradient + level-surfaces epic). Brings up the
v0.7 gradient-levels scene as a third Exhibit in the calculus3 cluster
alongside quadrics and tangent-planes — `{ x² + y² − z² = k }` rendered
through the shared `createImplicitSurface` harness, with a single k
slider sweeping `[-2, 2]` and snap detents on the three textbook poses
(1-sheet at `k = +1`, cone at `k = 0`, 2-sheet at `k = -1`). f is
intentionally non-editable in v0.7 — quadrics already covers
surface-family morphing and this scene's story is k as a parameter.
Plan: `_private/plans/163-gradient-levels-k-slider.md` (v2, post
roundtable-plan-review). #164 / #165 / #166 hang point selection,
gradient arrow, and readout off this footprint.

Two implementation notes worth flagging on review:

- **Math-frame mapping in shader.** The GLSL `f = p.x² + p.z² − p.y² − uK`
  comes from substituting `mx = p.x, my = -p.z, mz = p.y` into the
  math-frame intent `mx² + my² − mz² − k`. The negative term lands on
  `p.y²` (= world-Y² = math-Z²) so the hyperboloid opens vertically,
  matching textbook §11.6 diagrams. If during smoke the hyperboloid
  opens horizontally toward the viewer, the substitution is wrong.
- **Cone apex (k = 0) singularity.** Analytic `gradF(vec3(0)) = vec3(0)`
  would NaN the harness's downstream `normalize(gradF(p))`. The `gradF`
  chunk has an explicit `if (dot(g, g) < 1e-6) g = vec3(0, 1, 0);`
  guard returning a deterministic up-facing world normal. Central
  differences are also degenerate at the origin, so the shader-side
  guard is the right fix; recorded in SPEC.md.

## Test plan

- [x] `npm run build` clean (tsc --noEmit + vite build) — verified locally.
- [x] `npm test` clean (178/178) — verified locally.
- [x] Headset smoke on the Cloudflare PR preview (per `CONTRIBUTING.md`):
  - [x] Boot `?exhibit=gradient-levels` — surface renders at
    `SURFACE_CENTER` as a 1-sheet hyperboloid (`k₀ = 0.5`), opening
    **vertically** along world-Y (= math-Z up). If it opens
    horizontally toward the viewer, the math-frame mapping is wrong.
  - [x] SceneRack swap across all three tabs
    (`gradient-levels → tangent-planes → quadrics → gradient-levels`):
    surfaces render at the right positions, sliders are grabbable, no
    console errors, three-tab layout reads as visually balanced
    ("Quadrics" / "Tangent planes" / "Level surfaces").
  - [x] Drag k from +2 → −2 and back. 1-sheet contracts vertically
    toward the cone as k → 0⁺; at `k = 0` the surface reads as a
    double cone with **no rendering glitch at the apex** (uniformly
    shaded apex acceptable; black/white spike means the
    `dot(g, g) < eps` fallback is wrong); below k = 0 the surface
    splits into two sheets along ±math-Z, opening apart vertically as
    k → −2. Snap detents at −1, 0, +1 fire perceptibly. Steady 72 Hz
    on Quest during continuous drag.
  - [x] AABB crop at extremes (`k = ±2`): surface flares gradually
    into the box wall, not cut mid-belly.
  - [x] Drag-release-regrab on the k slider: no visible snap between
    release and re-grab.
  - [x] URL routing: `?exhibit=gradient-levels` deep-links directly;
    bare URL still boots quadrics (registry order preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)