### PR TITLE
feat(scene): gradient-levels — gradient-vector arrow at the selected point (#165)

### DIFF
--- a/src/exhibits/gradient-levels/GradientArrow.ts
+++ b/src/exhibits/gradient-levels/GradientArrow.ts
@@ -1,0 +1,140 @@
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { YELLOW } from '@/scaffold/design/tokens';
+import type { MathVec3 } from '@/scaffold/math/frames';
+import { poseGradientArrow } from './poseGradientArrow';
+
+// Gradient-vector arrow for the gradient-levels scene (#165). A merged
+// shaft+cone mesh anchored at the user-selected surface point, oriented
+// along ∇f at that point, scaled to a fixed unit visual length. Lit
+// MeshStandardMaterial with overlay rendering — never occluded by the
+// surface, since the arrow's pedagogical role is "always-visible UI
+// element at the contact point" (the gradient direction the user is
+// actively manipulating via θ/φ), not "physical object embedded in
+// the surface body."
+//
+// Coordinate convention (locked, mirrors TangentPlane.ts): this
+// wrapper's `group.position` stays at (0, 0, 0). The full world-space
+// transform — `writeMathToWorld(pointMath) + surfaceCenter` — happens
+// inside `poseGradientArrow` and writes into the inner mesh's position.
+// Setting `group.position.copy(surfaceCenter)` would double-offset to
+// `point + 2 × surfaceCenter`.
+
+// Visual constants — v0.7 lock, tunable in headset.
+const ARROW_LENGTH = 0.40;
+const CONE_HEIGHT = 0.10;
+const SHAFT_LENGTH = ARROW_LENGTH - CONE_HEIGHT;
+const SHAFT_RADIUS = 0.018;
+const CONE_RADIUS = 0.04;
+
+// Radial segment count for the shaft + cone. 32 is high enough that
+// the silhouette reads as smooth at headset distance — at lower counts
+// (12/16) an arbitrary-axis 180° quaternion roll at the anti-parallel
+// snap point can show a visible facet rotation; at 32 the
+// hexagonal-edge artifact is too fine to perceive.
+const RADIAL_SEGMENTS = 32;
+
+export interface GradientArrowOptions {
+  /**
+   * World-space center of the surface. Passed through to
+   * poseGradientArrow on every setPose call so the helper can do the
+   * full math→world + surfaceCenter offset in one place. The wrapper
+   * group itself stays at the exhibit-local origin.
+   */
+  surfaceCenter: THREE.Vector3;
+}
+
+export interface GradientArrowHandles {
+  /**
+   * Group containing the arrow mesh. Caller adds it to the scene; the
+   * inner mesh is positioned + oriented inside this group by setPose.
+   * Initially `group.visible = false` — the first frame's setPose +
+   * setVisible(true) from the consumer's update path uncloaks it,
+   * preventing a one-frame flash at stale pose.
+   */
+  group: THREE.Group;
+  /**
+   * Drive the arrow's pose from the raymarch result. `pointMath` and
+   * `normalMath` are surface-local math-frame; the math→world routing
+   * + the surfaceCenter translation happen inside this call so the
+   * caller passes raw raymarch output.
+   */
+  setPose(pointMath: MathVec3, normalMath: MathVec3): void;
+  /** Toggles `group.visible`, gating the mesh together. */
+  setVisible(visible: boolean): void;
+  dispose(): void;
+}
+
+export function createGradientArrow(
+  opts: GradientArrowOptions,
+): GradientArrowHandles {
+  // Build merged shaft+cone geometry along +Y; tail at local origin,
+  // tip at +Y direction. Mirrors the slider's buildArrowGeometry pattern
+  // (Slider.ts:353-410) but unidirectional.
+  //
+  // Default CylinderGeometry — both end caps generated. The shaft top
+  // disc + cone base disc do land coplanar at y = SHAFT_LENGTH with
+  // overlapping inner annulus, but the overlay rendering below
+  // (`depthTest: false`) eliminates depth comparisons under this
+  // material, so the coplanar overlap can't z-fight. Bottom cap is
+  // needed — at oblique camera angles (especially k<0 where the tail
+  // faces the viewer) the tail disc closes the shaft visually.
+  const shaft = new THREE.CylinderGeometry(
+    SHAFT_RADIUS,
+    SHAFT_RADIUS,
+    SHAFT_LENGTH,
+    RADIAL_SEGMENTS,
+  );
+  // Default CylinderGeometry is centered at origin; shift so its bottom
+  // sits at y=0 (the contact point on the surface).
+  shaft.translate(0, SHAFT_LENGTH / 2, 0);
+
+  const tip = new THREE.ConeGeometry(CONE_RADIUS, CONE_HEIGHT, RADIAL_SEGMENTS);
+  // Cone base flushes against the top of the shaft; tip points +Y.
+  tip.translate(0, SHAFT_LENGTH + CONE_HEIGHT / 2, 0);
+
+  const merged = mergeGeometries([shaft, tip]);
+  // Sources have identical attribute layouts (position/normal/uv);
+  // merge can't fail in practice but the type signature requires it.
+  if (!merged) {
+    throw new Error('Failed to merge gradient-arrow geometries');
+  }
+  shaft.dispose();
+  tip.dispose();
+
+  // Overlay rendering — the arrow is a UI element ("the gradient
+  // direction at the contact point"), not a physical body embedded in
+  // the surface; render it on top regardless of depth. Eliminates k<0
+  // inward-arrow occlusion AND any z-fight at the tail/surface contact.
+  const material = new THREE.MeshStandardMaterial({
+    color: YELLOW,
+    depthTest: false,
+    depthWrite: false,
+  });
+  const mesh = new THREE.Mesh(merged, material);
+  // Within the opaque pass, draw after default-renderOrder objects.
+  // (Three.js draws the opaque list before the transparent list
+  // regardless of renderOrder; cross-pass interaction with translucent
+  // overlays is OOS for v0.7.)
+  mesh.renderOrder = 2;
+
+  const group = new THREE.Group();
+  group.visible = false;
+  group.add(mesh);
+
+  const surfaceCenter = opts.surfaceCenter;
+
+  return {
+    group,
+    setPose(pointMath, normalMath) {
+      poseGradientArrow(mesh, pointMath, normalMath, surfaceCenter);
+    },
+    setVisible(visible) {
+      group.visible = visible;
+    },
+    dispose() {
+      merged.dispose();
+      material.dispose();
+    },
+  };
+}

--- a/src/exhibits/gradient-levels/SPEC.md
+++ b/src/exhibits/gradient-levels/SPEC.md
@@ -3,8 +3,9 @@
 > Math + UX contract for the gradient + level-surfaces scene. v0.7 cuts:
 > #163 registered the third cluster member with a single k slider
 > sweeping { f(x, y, z) = k } across the canonical hyperboloid family;
-> #164 adds θ/φ point selection on the active level surface; #165 the
-> gradient arrow, #166 the live readout, #167 the numeric k label.
+> #164 added θ/φ point selection on the active level surface; #165 adds
+> the gradient arrow at the selected point; #166 the live readout, #167
+> the numeric k label.
 
 ## Goal
 
@@ -179,6 +180,48 @@ All three sliders share `SLIDER_BASE_COLOR = 0xaaaaaa` (neutral
 gray) and `thumbShape: 'sphere'`. None of θ/φ/k carries axis
 meaning — distinct from quadrics' axis-tinted coefficient sliders.
 
+## Gradient arrow (#165)
+
+A 3D arrow primitive (merged cylinder shaft + cone tip,
+`MeshStandardMaterial`, color `YELLOW = 0xf0e442` from the Wong/
+Okabe-Ito palette) anchored at the selected surface point with its
+tail on the point and its tip pointing along ∇f at that point. Total
+length 0.40 m (shaft 0.30 m + cone 0.10 m), shaft radius 0.018 m,
+cone radius 0.04 m, 32 radial segments — tunable in headset; this is
+the v0.7 lock.
+
+**Length convention: unit-length, fixed.** ∇f's *direction* is the
+§11.6 punch line; |∇f|'s magnitude story is told via the numeric
+readout (#166), not by varying-length arrows. |∇f| varies three-fold
+across the selectable surface domain for `f = x² + y² − z²` (≈ 1.94
+at the boot pose, ≈ 6 near the AABB shell at k = +2) — wide enough
+that a magnitude-proportional arrow would oscillate between
+near-invisible and dominating.
+
+**Orientation convention: ∇f as-is, no inversion.** The arrow points
+in the direction of *increasing f*. For k > 0 (1-sheet hyperboloid)
+that's outward from the math-Z axis; for k < 0 (2-sheet hyperboloid)
+that's inward, toward the cone apex. The flip is the §11.6 content,
+not a sign-flip bug — students see ∇f swing through the topology
+transition as k crosses zero.
+
+**Visibility: overlay rendering.** The arrow is constructed with
+`depthTest: false`, `depthWrite: false`, `renderOrder = 2`, so it
+draws on top of the surface regardless of camera angle. The arrow's
+pedagogical role is "always-visible UI element at the contact point"
+— students manipulating θ/φ/k need uninterrupted visual feedback,
+especially in the k < 0 inward-pointing case where physical
+depth-testing would occlude the arrow body behind the surface from
+some viewing angles.
+
+Pose drives off `result.point` + `result.normal` from the same
+per-frame raymarch that drives the indicator; positioning math (math →
+world + surfaceCenter offset) lives in `poseGradientArrow.ts` so it's
+testable without a renderer. Hides when the indicator hides (same
+`result.hit` gate). Color picked from `tokens.ts`'s `YELLOW` —
+distinct from the math-X / Y / Z axis tints (vermillion / bluish-green
+/ sky-blue) so the arrow doesn't read as carrying axis identity.
+
 ## Render
 
 Minimal lambert: `uBaseColor * (0.2 + 0.8 * max(dot(n, normalize(uLightDir)), 0))`.
@@ -222,11 +265,8 @@ at the apex. Three concerns:
    at the origin during a successful raycast. No JS-side cone-apex
    guard needed.
 
-## Out of scope (v0.7 #164 and beyond)
+## Out of scope (v0.7 beyond #165)
 
-- **Gradient arrow** — 3D arrow at the selected point, oriented along
-  ∇f. #165. Reuses the `result.point` + `result.normal` returned by
-  `raycastImplicit` in this scene's per-frame update.
 - **Live readout** — numeric ∇f and |∇f|. #166. Same source.
 - **Numeric k value display** — #167.
 - **Option B-lite (closed-form θ clamp).** Documented v0.7-polish

--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -9,6 +9,7 @@ import { raycastImplicit } from '@/scaffold/render/raycastImplicit';
 import { Slider } from '@/scaffold/ui/Slider';
 import { WorldAxes, type AxisName } from '@/scaffold/ui/WorldAxes';
 import { DEFAULT_AXIS_COLORS } from '@/scaffold/design/tokens';
+import { createGradientArrow, type GradientArrowHandles } from './GradientArrow';
 import { BOUND, fJsRaw, gradJs } from './surfaceModel';
 
 // Gradient + level-surfaces scene (#162 epic). Third member of the
@@ -24,10 +25,11 @@ import { BOUND, fJsRaw, gradJs } from './surfaceModel';
 // (k < 0) — inside one slider range, with a topology change in the middle.
 //
 // Sub-issue progression: #163 established the surface + k slider; #164
-// adds θ/φ point selection (this PR); #165 the gradient arrow; #166 the
-// readout. f is intentionally non-editable in v0.7 — the quadrics
-// manipulator already covers surface-family morphing, and this scene's
-// story is k as a parameter, not (a, b, c). Recorded in SPEC.md.
+// added θ/φ point selection; #165 the gradient arrow (this PR); #166 the
+// readout; #167 the numeric k label. f is intentionally non-editable in
+// v0.7 — the quadrics manipulator already covers surface-family
+// morphing, and this scene's story is k as a parameter, not (a, b, c).
+// Recorded in SPEC.md.
 
 // ────────────────────────────────────────────────────────────────────
 // Constants
@@ -186,6 +188,7 @@ let kSlider: Slider | undefined;
 let thetaSlider: Slider | undefined;
 let phiSlider: Slider | undefined;
 let indicator: THREE.Mesh | undefined;
+let gradientArrow: GradientArrowHandles | undefined;
 let worldAxes: WorldAxes | undefined;
 let controllers: readonly THREE.Object3D[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
@@ -301,6 +304,17 @@ const gradientLevelsExhibit: Exhibit = {
     );
     group.add(indicator);
 
+    // Gradient-vector arrow at the selected point (#165). Constructed
+    // with `group.visible = false` so the renderer can't paint a stale
+    // pose between mount and the first update tick — the first hit
+    // frame in update calls setPose then setVisible(true) to uncloak.
+    // Renders as overlay (depthTest: false, renderOrder: 2) so the
+    // §11.6 punch line stays visible regardless of camera angle, even
+    // for k<0 inward orientations where the surface body would
+    // otherwise occlude the arrow.
+    gradientArrow = createGradientArrow({ surfaceCenter: SURFACE_CENTER });
+    group.add(gradientArrow.group);
+
     // Math-frame axis indicator — same anchor as cluster siblings.
     worldAxes = new WorldAxes({ axisColors: AXIS_COLORS });
     worldAxes.group.position.copy(AXIS_INDICATOR_POSITION);
@@ -308,7 +322,7 @@ const gradientLevelsExhibit: Exhibit = {
   },
 
   update() {
-    if (!kSlider || !thetaSlider || !phiSlider || !indicator) return;
+    if (!kSlider || !thetaSlider || !phiSlider || !indicator || !gradientArrow) return;
 
     // 1. Slider hover + drag tick. Order doesn't matter across the
     //    three sliders (each tracks its own grab/hover state).
@@ -342,15 +356,21 @@ const gradientLevelsExhibit: Exhibit = {
       bound: BOUND,
     });
 
-    // 5. Indicator pose. Surface-local math → world.
+    // 5. Indicator + gradient-arrow pose. Surface-local math → world.
+    //    Arrow consumes `result.normal` (already unit-normalized by
+    //    raycastImplicit); pose is set BEFORE setVisible(true) so the
+    //    first uncloak frame paints at the correct pose, not the
+    //    stale construction-time identity.
     if (result.hit) {
       indicator.visible = true;
       writeMathToWorld(result.point, indicatorWorld);
       indicator.position.copy(indicatorWorld).add(SURFACE_CENTER);
-      // result.normal is unused in this PR; #165 can reuse the same
-      // raycast-result pattern to orient the gradient arrow.
+
+      gradientArrow.setPose(result.point, result.normal);
+      gradientArrow.setVisible(true);
     } else {
       indicator.visible = false;
+      gradientArrow.setVisible(false);
     }
 
     // 6. Yaw-only billboard on the WorldAxes letter labels so they
@@ -386,6 +406,11 @@ const gradientLevelsExhibit: Exhibit = {
       (indicator.material as THREE.Material).dispose();
       indicator = undefined;
     }
+    // Arrow disposes its merged geometry + material via its own handle;
+    // shell removes ctx.group + descendants automatically per the
+    // existing convention (mirrors tangent-planes/index.ts:340-380).
+    gradientArrow?.dispose();
+    gradientArrow = undefined;
     kSlider?.dispose();
     kSlider = undefined;
     thetaSlider?.dispose();

--- a/src/exhibits/gradient-levels/poseGradientArrow.ts
+++ b/src/exhibits/gradient-levels/poseGradientArrow.ts
@@ -1,0 +1,66 @@
+import * as THREE from 'three';
+import { writeMathToWorld, type MathVec3 } from '@/scaffold/math/frames';
+
+// Pure pose helper for the gradient-levels scene's gradient-vector
+// arrow (#165). Lives in its own file so test/exhibits/gradient-levels/*
+// can import it without triggering `index.ts`'s `registerExhibit` side
+// effect at unit-test import time — same isolation pattern as
+// `directionFromAngles.ts`, `surfaceModel.ts`, `poseTangentPlaneMesh.ts`.
+//
+// Position + orientation are pure functions of (pointMath, normalMath,
+// surfaceCenter): mutate the mesh's `position` and `quaternion` in
+// place. The math→world routing for both vectors happens here so the
+// caller (GradientArrow.ts) passes raw raymarch output without thinking
+// about the frame swap. Allocation-free per call (two module-scope
+// scratches).
+
+// CylinderGeometry's default axis is +Y. The merged shaft+cone in
+// GradientArrow.ts is built tail-at-origin, tip-along-+Y. Quaternion is
+// computed by rotating +Y to the world-frame ∇f direction.
+const ARROW_REF_AXIS = new THREE.Vector3(0, 1, 0);
+
+// Module-scope scratches — allocated once at import, mutated per-frame.
+const positionWorld = new THREE.Vector3();
+const directionWorld = new THREE.Vector3();
+
+/**
+ * Position + orient `mesh` so its tail sits at `pointMath` (in surface-
+ * local math coords) and its tip points along `normalMath`.
+ * `surfaceCenter` is the world-space center of the surface; the mesh's
+ * final world position is `writeMathToWorld(pointMath) + surfaceCenter`.
+ *
+ * Mutates the mesh's `position` and `quaternion`. Allocation-free. The
+ * helper owns the full math→world + surfaceCenter offset — DO NOT also
+ * translate the parent group by `surfaceCenter`, or the mesh will land
+ * at `point + 2 × surfaceCenter`.
+ *
+ * Edge case: when `normalMath = [0, 0, -1]` (math-Z south, world
+ * `(0, -1, 0)`), the world direction is anti-parallel to
+ * `ARROW_REF_AXIS = (0, 1, 0)` and `setFromUnitVectors` picks an
+ * arbitrary perpendicular axis for the 180° rotation. The arrow
+ * direction is well-defined; the roll about its own axis is arbitrary
+ * BUT INVISIBLE (cylinder + cone are bodies of revolution about +Y;
+ * at 32 radial segments the silhouette is fine enough that the
+ * faceted-vs-continuous gap doesn't read). Distinct from the
+ * tangent-plane mesh case, where roll IS visible at the corners.
+ *
+ * Fires at θ=0 with k<0 (math-Z+ axis hits the upper 2-sheet apex
+ * where ∇f points along math-Z−, world `(0, -1, 0)`).
+ */
+export function poseGradientArrow(
+  mesh: THREE.Object3D,
+  pointMath: MathVec3,
+  normalMath: MathVec3,
+  surfaceCenter: THREE.Vector3,
+): void {
+  writeMathToWorld(pointMath, positionWorld);
+  positionWorld.add(surfaceCenter);
+  mesh.position.copy(positionWorld);
+
+  // Defensive .normalize() — raycastImplicit already returns a unit
+  // normal (raycastImplicit.ts:172-174), but keeping the explicit
+  // normalize matches poseTangentPlaneMesh.ts and guards against
+  // future raycaster contract drift. Cost: one Math.sqrt per hit frame.
+  writeMathToWorld(normalMath, directionWorld).normalize();
+  mesh.quaternion.setFromUnitVectors(ARROW_REF_AXIS, directionWorld);
+}

--- a/test/exhibits/gradient-levels/createGradientArrow.test.ts
+++ b/test/exhibits/gradient-levels/createGradientArrow.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+import { createGradientArrow } from '../../../src/exhibits/gradient-levels/GradientArrow.ts';
+
+// Geometry-contract test for the gradient-arrow wrapper. Catches the
+// construction-side failure modes the pose-helper test can't reach
+// (wrong cone orientation, total length drift, initial-visibility
+// regression). Mirrors the test/scaffold/render/translucentRect.test.ts
+// shape — Vitest, vi.fn() spies on Three's `'dispose'` event for the
+// disposal assertion.
+
+const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
+const ARROW_LENGTH = 0.40;
+
+// The wrapper's group has exactly one child (the merged mesh); reach
+// in to inspect the geometry + material directly. `dispose()` is the
+// only public lifecycle entry point, so the handle interface
+// intentionally doesn't expose the inner mesh.
+function getMesh(handle: ReturnType<typeof createGradientArrow>): THREE.Mesh {
+  const mesh = handle.group.children[0];
+  if (!(mesh instanceof THREE.Mesh)) {
+    throw new Error('createGradientArrow: expected a Mesh as group.children[0]');
+  }
+  return mesh;
+}
+
+describe('createGradientArrow — initial state', () => {
+  it('group.visible is false at construction (no stale-pose flash)', () => {
+    const handle = createGradientArrow({ surfaceCenter: SURFACE_CENTER });
+    expect(handle.group.visible).toBe(false);
+    handle.dispose();
+  });
+});
+
+describe('createGradientArrow — geometry shape', () => {
+  it('merged geometry spans y ∈ [0, ARROW_LENGTH] (tail at origin, tip at full extent)', () => {
+    const handle = createGradientArrow({ surfaceCenter: SURFACE_CENTER });
+    const mesh = getMesh(handle);
+    mesh.geometry.computeBoundingBox();
+    const bb = mesh.geometry.boundingBox!;
+    expect(bb.min.y).toBeCloseTo(0, 4);
+    expect(bb.max.y).toBeCloseTo(ARROW_LENGTH, 4);
+    handle.dispose();
+  });
+
+  it('merged geometry is centered around the +Y axis (radial symmetry in x and z)', () => {
+    const handle = createGradientArrow({ surfaceCenter: SURFACE_CENTER });
+    const mesh = getMesh(handle);
+    mesh.geometry.computeBoundingBox();
+    const bb = mesh.geometry.boundingBox!;
+    // |min.x + max.x| ≈ 0 means the geometry is centered at x = 0.
+    expect(Math.abs(bb.min.x + bb.max.x)).toBeLessThan(1e-3);
+    expect(Math.abs(bb.min.z + bb.max.z)).toBeLessThan(1e-3);
+    handle.dispose();
+  });
+});
+
+describe('createGradientArrow — overlay material flags', () => {
+  it('mesh material has depthTest=false, depthWrite=false (overlay rendering)', () => {
+    const handle = createGradientArrow({ surfaceCenter: SURFACE_CENTER });
+    const mesh = getMesh(handle);
+    const material = mesh.material as THREE.MeshStandardMaterial;
+    expect(material.depthTest).toBe(false);
+    expect(material.depthWrite).toBe(false);
+    handle.dispose();
+  });
+
+  it('mesh.renderOrder is 2 (within the opaque pass, after default-renderOrder objects)', () => {
+    const handle = createGradientArrow({ surfaceCenter: SURFACE_CENTER });
+    const mesh = getMesh(handle);
+    expect(mesh.renderOrder).toBe(2);
+    handle.dispose();
+  });
+});
+
+describe('createGradientArrow — setVisible', () => {
+  it('setVisible(true) then setVisible(false) toggles group.visible', () => {
+    const handle = createGradientArrow({ surfaceCenter: SURFACE_CENTER });
+    handle.setVisible(true);
+    expect(handle.group.visible).toBe(true);
+    handle.setVisible(false);
+    expect(handle.group.visible).toBe(false);
+    handle.dispose();
+  });
+});
+
+describe('createGradientArrow — dispose()', () => {
+  // Three dispatches a 'dispose' event on the resource; spying on that
+  // verifies the dispose actually runs without poking at internal state.
+  it('disposes both geometry and material exactly once', () => {
+    const handle = createGradientArrow({ surfaceCenter: SURFACE_CENTER });
+    const mesh = getMesh(handle);
+    const geomSpy = vi.fn();
+    const matSpy = vi.fn();
+    mesh.geometry.addEventListener('dispose', geomSpy);
+    (mesh.material as THREE.Material).addEventListener('dispose', matSpy);
+    handle.dispose();
+    expect(geomSpy).toHaveBeenCalledTimes(1);
+    expect(matSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/exhibits/gradient-levels/poseGradientArrow.test.ts
+++ b/test/exhibits/gradient-levels/poseGradientArrow.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import * as THREE from 'three';
+import { poseGradientArrow } from '../../../src/exhibits/gradient-levels/poseGradientArrow.ts';
+
+// Unit tests for the pure math→world + orientation helper. The
+// `surfaceCenter` value matches the gradient-levels scene's
+// `SURFACE_CENTER = (0, 1.5, -4)` so position assertions read as
+// "what the user would see in headset."
+const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
+
+// CylinderGeometry's default axis (= the reference vector
+// `setFromUnitVectors` rotates from). Mirrors the constant in
+// poseGradientArrow.ts; used here only to re-apply the result
+// quaternion and verify the rotated direction.
+const REF_AXIS = new THREE.Vector3(0, 1, 0);
+
+function transformedAxis(mesh: THREE.Object3D): THREE.Vector3 {
+  return REF_AXIS.clone().applyQuaternion(mesh.quaternion);
+}
+
+describe('poseGradientArrow — math→world + position', () => {
+  it.each([
+    {
+      label: '+math-X (right)',
+      pointMath: [1, 0, 0] as const,
+      expectedWorld: [1, 1.5, -4] as const,
+    },
+    {
+      label: '+math-Y (forward)',
+      pointMath: [0, 1, 0] as const,
+      expectedWorld: [0, 1.5, -5] as const,
+    },
+    {
+      label: '+math-Z (north pole)',
+      pointMath: [0, 0, 1] as const,
+      expectedWorld: [0, 2.5, -4] as const,
+    },
+    {
+      label: '−math-Z (south pole)',
+      pointMath: [0, 0, -1] as const,
+      expectedWorld: [0, 0.5, -4] as const,
+    },
+  ])('point $label lands at the expected world position', ({ pointMath, expectedWorld }) => {
+    const mesh = new THREE.Object3D();
+    poseGradientArrow(mesh, pointMath, [0, 0, 1], SURFACE_CENTER);
+    expect(mesh.position.x).toBeCloseTo(expectedWorld[0], 6);
+    expect(mesh.position.y).toBeCloseTo(expectedWorld[1], 6);
+    expect(mesh.position.z).toBeCloseTo(expectedWorld[2], 6);
+  });
+
+  it('off-axis diagonal point lands at the math→world conversion + surfaceCenter', () => {
+    const inv = 1 / Math.sqrt(3);
+    const mesh = new THREE.Object3D();
+    poseGradientArrow(
+      mesh,
+      [inv, inv, inv],
+      [inv, inv, inv],
+      SURFACE_CENTER,
+    );
+    // math (X, Y, Z) → world (X, Z, −Y).
+    expect(mesh.position.x).toBeCloseTo(inv, 6);
+    expect(mesh.position.y).toBeCloseTo(1.5 + inv, 6);
+    expect(mesh.position.z).toBeCloseTo(-4 - inv, 6);
+  });
+});
+
+describe('poseGradientArrow — orientation (deterministic cases)', () => {
+  it('+math-Z normal rotates ref +Y to world +Y (identity rotation)', () => {
+    // Math-Z = +world-Y, parallel to ARROW_REF_AXIS = (0, 1, 0).
+    // setFromUnitVectors returns identity; rotated ref equals ref.
+    const mesh = new THREE.Object3D();
+    poseGradientArrow(mesh, [0, 0, 1], [0, 0, 1], SURFACE_CENTER);
+    const n = transformedAxis(mesh);
+    expect(n.x).toBeCloseTo(0, 6);
+    expect(n.y).toBeCloseTo(1, 6);
+    expect(n.z).toBeCloseTo(0, 6);
+  });
+
+  it('+math-X normal rotates ref +Y to world +X (perpendicular case)', () => {
+    const mesh = new THREE.Object3D();
+    poseGradientArrow(mesh, [1, 0, 0], [1, 0, 0], SURFACE_CENTER);
+    const n = transformedAxis(mesh);
+    expect(n.x).toBeCloseTo(1, 6);
+    expect(n.y).toBeCloseTo(0, 6);
+    expect(n.z).toBeCloseTo(0, 6);
+  });
+
+  it('+math-Y normal rotates ref +Y to world −Z (perpendicular case)', () => {
+    // Math-Y = −world-Z, perpendicular to ARROW_REF_AXIS.
+    const mesh = new THREE.Object3D();
+    poseGradientArrow(mesh, [0, 1, 0], [0, 1, 0], SURFACE_CENTER);
+    const n = transformedAxis(mesh);
+    expect(n.x).toBeCloseTo(0, 6);
+    expect(n.y).toBeCloseTo(0, 6);
+    expect(n.z).toBeCloseTo(-1, 6);
+  });
+
+  it('off-axis diagonal normal rotates ref +Y to the math→world conversion', () => {
+    const inv = 1 / Math.sqrt(3);
+    const mesh = new THREE.Object3D();
+    poseGradientArrow(
+      mesh,
+      [inv, inv, inv],
+      [inv, inv, inv],
+      SURFACE_CENTER,
+    );
+    const n = transformedAxis(mesh);
+    // Expected world direction = writeMathToWorld([inv,inv,inv]) = (inv, inv, -inv).
+    expect(n.x).toBeCloseTo(inv, 6);
+    expect(n.y).toBeCloseTo(inv, 6);
+    expect(n.z).toBeCloseTo(-inv, 6);
+  });
+});
+
+describe('poseGradientArrow — anti-parallel orientation (−math-Z / θ=0, k<0)', () => {
+  // The TRUE anti-parallel case for ARROW_REF_AXIS = (0, 1, 0):
+  //   normalMath [0,0,-1] → writeMathToWorld → world (0,-1,0).
+  //   dot((0,1,0), (0,-1,0)) = -1 → anti-parallel.
+  // setFromUnitVectors picks an arbitrary perpendicular axis for the 180°
+  // rotation. The rotated +Y must equal the world direction regardless of
+  // which perpendicular axis is picked; the roll about that direction is
+  // non-deterministic across Three versions (and visually invisible due
+  // to the cylinder + cone's body-of-revolution silhouette at 32 segments).
+  // We therefore assert ONLY the transformed axis direction, NOT the roll.
+  it('−math-Z normal rotates ref +Y to world (0, −1, 0) — direction only', () => {
+    const mesh = new THREE.Object3D();
+    poseGradientArrow(mesh, [0, 0, -1], [0, 0, -1], SURFACE_CENTER);
+    const n = transformedAxis(mesh);
+    expect(n.x).toBeCloseTo(0, 6);
+    expect(n.y).toBeCloseTo(-1, 6);
+    expect(n.z).toBeCloseTo(0, 6);
+  });
+
+  // Defensive: regardless of the picked perpendicular roll, the resulting
+  // quaternion must be a unit quaternion. Catches a regression where a
+  // future hand-rolled fallback returns NaN-laced components.
+  it('result quaternion is unit-length at the anti-parallel case', () => {
+    const mesh = new THREE.Object3D();
+    poseGradientArrow(mesh, [0, 0, -1], [0, 0, -1], SURFACE_CENTER);
+    const q = mesh.quaternion;
+    const len = Math.hypot(q.x, q.y, q.z, q.w);
+    expect(len).toBeCloseTo(1, 6);
+  });
+});


### PR DESCRIPTION
Closes #165

## Summary

Renders ∇f as a 3D arrow (merged cylinder shaft + cone tip, lit `MeshStandardMaterial` in Wong/Okabe-Ito `YELLOW`) anchored at the user-selected surface point. Tail on the point, tip pointing along ∇f, fixed unit length 0.40 m. Consumes the `result.normal` already returned by `raycastImplicit` — no new API surface.

Overlay rendering (`depthTest: false`, `depthWrite: false`, `renderOrder: 2`) so the §11.6 punch line — ∇f swinging perpendicular to the family as the user sweeps θ/φ/k, then flipping inward as k crosses zero into the 2-sheet region — stays visible regardless of camera angle.

Adds `poseGradientArrow.ts` (pure pose helper, mirrors `poseTangentPlaneMesh.ts`) and `GradientArrow.ts` (wrapper). Tests cover both pose math (5 cases incl. anti-parallel + unit-quaternion sanity) and geometry contract (initial visibility, bounding-box extent, overlay material flags, `setVisible` toggle, dispose-event firing).

Plan went through `/roundtable-plan-review` (Sonnet + GPT-5.5 + DeepSeek; all REVISE) → v2 closing 10 findings → Sonnet sanity-check pass → v3 closing two interaction findings between v2 closures. Plan locked at `_private/plans/165-gradient-levels-arrow.md` v3.

## Test plan

Headset smoke happens on the Cloudflare PR-preview URL (posted by `pr-preview` workflow ~1 min after push). Open `?exhibit=gradient-levels`:

- [x] Boot pose (θ=π/3, φ=π/4, k=+0.5) shows the 1-sheet hyperboloid with a yellow arrow on the indicator dot, tail-on-point, perpendicular to the surface, pointing outward.
- [x] Sweep θ from π/3 → π/2 (equator). Arrow stays perpendicular; reads as outward radially in math-XY.
- [x] Sweep φ from π/4 through 0 / π/2 / −π/2. Arrow swings around the equator; no popping or visible jumps.
- [x] Sweep k from +0.5 → +1 → +2. Surface flares outward; arrow length stays constant (unit-length lock); arrow continues perpendicular outward.
- [x] Sweep k → 0 slowly. Indicator + arrow vanish together when the raycaster's miss policy triggers near k=0.
- [x] Sweep k → −0.5 → −1 → −2. Surface re-emerges as 2-sheet hyperboloid; **arrow now points inward** (toward the cone apex). Walk around the surface to a few oblique angles and confirm the arrow stays fully visible (overlay rendering — never occluded by the surface body).
- [x] At k=−1, sweep θ to 0 (north pole snap, anti-parallel quaternion case). No perceptible roll snap or facet rotation as the arrow direction passes through the singular point.
- [x] Lean in close to the contact point and orbit. No z-fight flicker at the arrow's tail / surface interface.
- [x] Visit `?exhibit=tangent-planes` via the SceneRack. No visual regression.
- [x] Switch back to `?exhibit=gradient-levels`. Arrow re-mounts cleanly: no flash at origin, no stale pose.

Local CI gates:
- [x] `npm run build` — clean.
- [x] `npm test` — 213/213 passing (13 files), including the two new test files.
- [x] `pre-commit` — gitleaks + standard fixers all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)