### PR TITLE
feat(scene): gradient-levels — live ∇f and |∇f| readout (#166)

### DIFF
--- a/src/exhibits/gradient-levels/GradientLevelsReadout.ts
+++ b/src/exhibits/gradient-levels/GradientLevelsReadout.ts
@@ -1,0 +1,270 @@
+import * as THREE from 'three';
+import { Text } from 'troika-three-text';
+import type { MathVec3 } from '@/scaffold/math/frames';
+import {
+  formatGradientLevelsReadout,
+  type GradientLevelsReadoutStrings,
+} from './formatGradientLevelsReadout';
+
+// Live readout for the gradient-levels scene (#166). Two-line layout:
+//
+//   line 1 (top):    `∇f = ( ±N.NN , ±N.NN , ±N.NN )`
+//   line 2 (bottom): `|∇f| = N.NN`
+//
+// The top line decomposes ∇f into its math-frame components, each
+// axis-coded (vermillion = math-X, bluish-green = math-Y, sky-blue =
+// math-Z). The bottom line is the scalar magnitude, tinted YELLOW to
+// pair visually with the gradient-arrow primitive in the scene — both
+// elements describe the same gradient vector (direction = arrow,
+// magnitude = numeric); the YELLOW pairing communicates "facets of one
+// vector" rather than "the number is the arrow's rendered length"
+// (which would build the misconception #165's unit-length arrow lock
+// was designed to prevent — see SPEC.md "Readout" section).
+//
+// Sibling design choice (vs. extending `tangent-planes/TangentPlaneReadout`):
+// TangentPlaneReadout has nine slots in a specific top-line structure
+// (`±n_x (x − x₀) + ...`); this readout has four slots (3 ∇f components
+// + 1 |∇f|) in a different structure. Wrapping the troika-Text +
+// yaw-billboard idioms here keeps the surface narrow.
+//
+// Layout is computed once at construction and never reflowed. Only the
+// numeric .text values change per frame, throttled to ≈30 Hz like
+// `TangentPlaneReadout` and `EquationReadout`.
+//
+// Initial-text policy: Text instances boot empty; `group.visible = false`
+// until the first `setValues()` call populates the numerics. The boot
+// pose guarantees a first-frame hit (per SPEC.md), so under normal
+// mount the readout uncloaks within one tick; deep-link/state-restore
+// to a miss state stays hidden gracefully.
+
+export interface GradientLevelsReadoutOptions {
+  /**
+   * Diffuse colors for the three math-frame axis slots (∂f/∂x, ∂f/∂y, ∂f/∂z),
+   * in order [x, y, z]. Same convention as TangentPlaneReadout.
+   */
+  axisColors: readonly [number, number, number];
+  /**
+   * Diffuse color for the |∇f| numeric value. Locked to YELLOW
+   * (0xf0e442) at the call site in `index.ts`; constructor accepts the
+   * value so the class stays presentation-agnostic.
+   */
+  magnitudeColor: number;
+  fontSize?: number;
+}
+
+const DEFAULT_FONT_SIZE = 0.028;
+
+// Slot widths in em (multiples of fontSize). NUMERIC_SIGNED fits
+// worst-case `−6.00`; NUMERIC_UNSIGNED fits worst-case `10.39`
+// (analytic ceiling — slider-reachable max is ~8.94, see plan §2.1).
+const NUMERIC_SIGNED_EM = 2.6;
+const NUMERIC_UNSIGNED_EM = 2.0;
+// Top-line separators.
+const PREFIX_GRAD_EM = 2.8; // `∇f = ( ` — nabla glyph is wider than Latin.
+const COMMA_EM = 1.0;       // ` , `
+const CLOSE_PAREN_EM = 1.0; // ` )`
+// Bottom-line prefix — sized to match PREFIX_GRAD_EM so the equals
+// signs roughly align between the two lines.
+const PREFIX_MAG_EM = 2.8;  // `|∇f| = `
+
+// Vertical gap between the two lines. Mirrors TangentPlaneReadout.
+const LINE_PITCH = 0.06;
+
+const SEPARATOR_COLOR = 0xffffff;
+const OUTLINE_WIDTH = '8%';
+const OUTLINE_COLOR = 0x000000;
+
+// Throttle the troika `.sync()` calls to ≈30 Hz, mirroring
+// `TangentPlaneReadout` and `EquationReadout`. Bounds SDF rebuild work
+// during fast drags. Per-frame head-pose billboarding (faceCamera)
+// still runs every frame so motion smoothness is unaffected.
+const SYNC_INTERVAL_MS = 33;
+
+// Per-axis slot indices for the top-line component triple.
+const AXIS_X = 0;
+const AXIS_Z = 2;
+
+export class GradientLevelsReadout {
+  readonly group: THREE.Group;
+
+  private readonly fontSize: number;
+
+  // Top-line component numerics: [∂f/∂x, ∂f/∂y, ∂f/∂z].
+  private readonly topNumerics: readonly Text[];
+
+  // Bottom-line |∇f| numeric.
+  private readonly bottomNumeric: Text;
+
+  // Static separators. Held only for disposal; never re-written.
+  private readonly separators: Text[] = [];
+
+  // Per-slot string cache so we don't re-write Text.text + re-trigger
+  // troika .sync() when the value hasn't changed past the throttle.
+  private readonly topNumericCache: string[] = new Array(3).fill('');
+  private bottomNumericCache = '';
+
+  private lastSyncMs = 0;
+
+  // Hoisted out of `faceCamera` so per-frame billboarding does no
+  // allocation. Same convention as `TangentPlaneReadout`.
+  private readonly camWorld = new THREE.Vector3();
+  private readonly groupWorld = new THREE.Vector3();
+
+  constructor(opts: GradientLevelsReadoutOptions) {
+    this.fontSize = opts.fontSize ?? DEFAULT_FONT_SIZE;
+
+    this.group = new THREE.Group();
+    this.group.name = 'gradient-levels-readout';
+    // Stay hidden until the first setValues() populates the numerics.
+    // The first update() tick uncloaks; deep-link/state-restore to a
+    // miss state stays hidden gracefully.
+    this.group.visible = false;
+
+    const numericSignedW = NUMERIC_SIGNED_EM * this.fontSize;
+    const numericUnsignedW = NUMERIC_UNSIGNED_EM * this.fontSize;
+    const prefixGradW = PREFIX_GRAD_EM * this.fontSize;
+    const commaW = COMMA_EM * this.fontSize;
+    const closeParenW = CLOSE_PAREN_EM * this.fontSize;
+    const prefixMagW = PREFIX_MAG_EM * this.fontSize;
+
+    const topY = LINE_PITCH / 2;
+    const bottomY = -LINE_PITCH / 2;
+
+    // ─── Top line ────────────────────────────────────────────────
+    // `∇f = ( ` [n_x] ` , ` [n_y] ` , ` [n_z] ` )`
+    const totalTopW =
+      prefixGradW + 3 * numericSignedW + 2 * commaW + closeParenW;
+    let cursor = -totalTopW / 2;
+
+    const gradPrefix = this.makeSeparatorText(this.fontSize);
+    gradPrefix.text = '∇f = ( ';
+    gradPrefix.position.set(cursor + prefixGradW / 2, topY, 0);
+    gradPrefix.sync();
+    this.group.add(gradPrefix);
+    this.separators.push(gradPrefix);
+    cursor += prefixGradW;
+
+    const topNumerics: Text[] = new Array<Text>(3);
+    for (let axis = AXIS_X; axis <= AXIS_Z; axis++) {
+      const color = opts.axisColors[axis];
+
+      const nText = this.makeNumericText(this.fontSize, color);
+      nText.position.set(cursor + numericSignedW / 2, topY, 0);
+      this.group.add(nText);
+      topNumerics[axis] = nText;
+      cursor += numericSignedW;
+
+      const isLast = axis === AXIS_Z;
+      const sep = this.makeSeparatorText(this.fontSize);
+      if (isLast) {
+        sep.text = ' )';
+        sep.position.set(cursor + closeParenW / 2, topY, 0);
+        cursor += closeParenW;
+      } else {
+        sep.text = ' , ';
+        sep.position.set(cursor + commaW / 2, topY, 0);
+        cursor += commaW;
+      }
+      sep.sync();
+      this.group.add(sep);
+      this.separators.push(sep);
+    }
+    this.topNumerics = topNumerics;
+
+    // ─── Bottom line ─────────────────────────────────────────────
+    // `|∇f| = ` [mag]
+    //
+    // Both lines anchor at the same x=0 center per the layout below.
+    // Width asymmetry (~13.6 em top vs ~4.8 em bottom) is the documented
+    // open question — validates in headset smoke per plan §3.4.
+    const totalBottomW = prefixMagW + numericUnsignedW;
+    cursor = -totalBottomW / 2;
+
+    const magPrefix = this.makeSeparatorText(this.fontSize);
+    magPrefix.text = '|∇f| = ';
+    magPrefix.position.set(cursor + prefixMagW / 2, bottomY, 0);
+    magPrefix.sync();
+    this.group.add(magPrefix);
+    this.separators.push(magPrefix);
+    cursor += prefixMagW;
+
+    this.bottomNumeric = this.makeNumericText(this.fontSize, opts.magnitudeColor);
+    this.bottomNumeric.position.set(cursor + numericUnsignedW / 2, bottomY, 0);
+    this.group.add(this.bottomNumeric);
+  }
+
+  private makeNumericText(fontSize: number, color: number): Text {
+    const t = new Text();
+    t.fontSize = fontSize;
+    t.color = color;
+    t.anchorX = 'center';
+    t.anchorY = 'middle';
+    t.outlineWidth = OUTLINE_WIDTH;
+    t.outlineColor = OUTLINE_COLOR;
+    return t;
+  }
+
+  private makeSeparatorText(fontSize: number): Text {
+    const t = new Text();
+    t.fontSize = fontSize;
+    t.color = SEPARATOR_COLOR;
+    t.anchorX = 'center';
+    t.anchorY = 'middle';
+    t.outlineWidth = OUTLINE_WIDTH;
+    t.outlineColor = OUTLINE_COLOR;
+    return t;
+  }
+
+  /**
+   * Update all four numerics from the per-frame raymarch result. Throttled
+   * to ≈30 Hz via SYNC_INTERVAL_MS — mirrors TangentPlaneReadout's cadence
+   * and bounds troika SDF rebuild work during fast drags. Per-slot caching
+   * skips the .text + .sync() write when the formatted string hasn't
+   * changed.
+   *
+   * On first call, uncloaks `group.visible = true` — the readout boots
+   * hidden so it can't paint empty strings before the first hit frame.
+   */
+  setValues(gradient: MathVec3): void {
+    // First-call uncloak: before throttle gate so the readout becomes
+    // visible on the first tick regardless of throttle timing.
+    if (!this.group.visible) this.group.visible = true;
+
+    const now = performance.now();
+    if (now - this.lastSyncMs < SYNC_INTERVAL_MS) return;
+    this.lastSyncMs = now;
+
+    const strings: GradientLevelsReadoutStrings = formatGradientLevelsReadout(gradient);
+
+    for (let axis = AXIS_X; axis <= AXIS_Z; axis++) {
+      const s = strings.components[axis];
+      if (s !== this.topNumericCache[axis]) {
+        this.topNumericCache[axis] = s;
+        this.topNumerics[axis].text = s;
+        this.topNumerics[axis].sync();
+      }
+    }
+
+    if (strings.magnitude !== this.bottomNumericCache) {
+      this.bottomNumericCache = strings.magnitude;
+      this.bottomNumeric.text = strings.magnitude;
+      this.bottomNumeric.sync();
+    }
+  }
+
+  // Yaw-only billboard, matching TangentPlaneReadout / EquationReadout /
+  // Label. World-up stays world-up; head pitch and roll don't tilt.
+  faceCamera(camera: THREE.Camera): void {
+    camera.getWorldPosition(this.camWorld);
+    this.group.getWorldPosition(this.groupWorld);
+    const dx = this.camWorld.x - this.groupWorld.x;
+    const dz = this.camWorld.z - this.groupWorld.z;
+    this.group.rotation.set(0, Math.atan2(dx, dz), 0);
+  }
+
+  dispose(): void {
+    for (const t of this.topNumerics) t.dispose();
+    this.bottomNumeric.dispose();
+    for (const t of this.separators) t.dispose();
+  }
+}

--- a/src/exhibits/gradient-levels/SPEC.md
+++ b/src/exhibits/gradient-levels/SPEC.md
@@ -3,9 +3,9 @@
 > Math + UX contract for the gradient + level-surfaces scene. v0.7 cuts:
 > #163 registered the third cluster member with a single k slider
 > sweeping { f(x, y, z) = k } across the canonical hyperboloid family;
-> #164 added θ/φ point selection on the active level surface; #165 adds
-> the gradient arrow at the selected point; #166 the live readout, #167
-> the numeric k label.
+> #164 added θ/φ point selection on the active level surface; #165 added
+> the gradient arrow at the selected point; #166 adds the live ∇f / |∇f|
+> readout; #167 the numeric k label (pending).
 
 ## Goal
 
@@ -222,6 +222,68 @@ testable without a renderer. Hides when the indicator hides (same
 distinct from the math-X / Y / Z axis tints (vermillion / bluish-green
 / sky-blue) so the arrow doesn't read as carrying axis identity.
 
+## Readout (#166)
+
+Live readout of ∇f and |∇f| at the selected point, anchored above
+the slider rack. Two-line layout:
+
+- **Top line:** `∇f = ( ±N.NN , ±N.NN , ±N.NN )` — the gradient
+  decomposed into math-frame components. Each component picks up
+  the cluster's axis-color convention (vermillion / bluish-green
+  / sky-blue for math-X / Y / Z), mirroring `TangentPlaneReadout`'s
+  bottom-line normal decomposition.
+- **Bottom line:** `|∇f| = N.NN` — the scalar magnitude. Numeric
+  value tinted **YELLOW**, matching the gradient arrow.
+
+**Source.** The readout consumes the *raw* gradient `gradJs(p)` at
+the selected point, NOT `result.normal` (which is the unit normal
+from `raycastImplicit`). The arrow consumes the unit normal because
+direction is its punch line; the readout consumes the raw gradient
+because magnitude is the other half of the §11.6 story the unit-length
+arrow deliberately drops. A composition test in
+`test/exhibits/gradient-levels/formatGradientLevelsReadout.test.ts`
+pins the raw-vs-unit wiring at the unit-test level — a unit-normal
+wiring would format to `'1.00'` instead of the real |∇f|.
+
+**YELLOW color-identity decoupling.** The arrow's rendered length is
+fixed at 0.40 m regardless of |∇f| (per the unit-length lock above);
+the YELLOW pairing on the |∇f| numeric communicates "these two
+elements describe the same gradient vector" — the arrow showing
+*direction*, the readout showing *magnitude*. It does NOT communicate
+"the number equals the arrow's length." When sliding k from +0.5 to
++2, |∇f| grows from `2.00` to ~`8.94` while the arrow stays at fixed
+visual length — this is the intended decoupling, not a display bug.
+
+**Format.** Signed-magnitude `±N.NN` on top-line components (sign
+char is U+2212 MINUS for negative, `+` for non-negative including
+zero); unsigned `N.NN` on the |∇f| line (magnitude is non-negative
+by definition). `toFixed(2)` matches the cluster's 2-decimal idiom.
+
+**Anchor.** y = 1.42, z = -0.7 (same z-plane as the slider rack +
+WorldAxes indicator). Lifted from tangent-planes' y = 1.32 to
+maintain ~0.18 m bottom-to-thumb-top clearance over the now-three-row
+rack (top of θ slider thumb at y ≈ 1.21).
+
+**Cadence.** ≈30 Hz troika `.sync()` throttle on the four numerics
+to bound SDF rebuild work during fast drags; yaw-only billboard
+runs every frame so motion smoothness is unaffected. Per-slot
+string caching skips troika rewrite when the formatted string
+hasn't changed.
+
+**Miss-policy UX contract.** During raycast miss frames (k = 0
+cone, polar/equator-band rays at k ≠ 0, AABB-clip cases — all
+documented under "Miss-hide policy" above), the **displayed value
+is the last valid hit value**. The arrow and indicator hide; the
+readout freezes. Pedagogically: "the picture is paused while no
+point is selectable" rather than "the picture is broken." On
+scene mount the readout boots hidden (`group.visible = false`) and
+uncloaks on the first `setValues()` call — the boot pose guarantees
+a first-frame hit, so under normal mount the readout populates
+within one tick; deep-link / state-restore to a miss state stays
+gracefully hidden. If headset smoke surfaces that the frozen
+readout reads as a bug, a 50%-opacity dim during miss frames is
+a documented v0.7-polish follow-up.
+
 ## Render
 
 Minimal lambert: `uBaseColor * (0.2 + 0.8 * max(dot(n, normalize(uLightDir)), 0))`.
@@ -265,9 +327,8 @@ at the apex. Three concerns:
    at the origin during a successful raycast. No JS-side cone-apex
    guard needed.
 
-## Out of scope (v0.7 beyond #165)
+## Out of scope (v0.7 beyond #166)
 
-- **Live readout** — numeric ∇f and |∇f|. #166. Same source.
 - **Numeric k value display** — #167.
 - **Option B-lite (closed-form θ clamp).** Documented v0.7-polish
   follow-up if smoke shows the disappearing-indicator UX is too

--- a/src/exhibits/gradient-levels/formatGradientLevelsReadout.ts
+++ b/src/exhibits/gradient-levels/formatGradientLevelsReadout.ts
@@ -1,0 +1,56 @@
+import type { MathVec3 } from '@/scaffold/math/frames';
+import { formatSignedMagnitude } from '@/scaffold/ui/formatSignedMagnitude';
+
+// Pure formatter for the gradient-levels readout (#166). Given the raw
+// surface-local gradient ∇f at the selected point, produce the four
+// numeric-slot strings the readout's troika-Text instances render.
+//
+// Lives in its own file so test/exhibits/gradient-levels/* can import
+// without triggering `index.ts`'s `registerExhibit` side effect at
+// unit-test import time — same isolation pattern as
+// `surfaceModel.ts`, `poseGradientArrow.ts`.
+//
+// Takes a single `MathVec3 gradient` (the raw, un-normalized ∇f from
+// `gradJs(p)`) — NOT the unit normal from `raycastImplicit`'s
+// `result.normal`. The composition test in
+// `test/exhibits/gradient-levels/formatGradientLevelsReadout.test.ts`
+// pins this contract: feeding a unit normal yields magnitude '1.00'
+// instead of the real |∇f|, so the wiring failure mode is fail-loud
+// at the unit-test level.
+
+function formatUnsignedMagnitude(v: number): string {
+  // |∇f| is non-negative by definition; no sign character. Local helper —
+  // only this readout uses it. If a future scene also wants unsigned
+  // 2-decimal, extract on its third use per the repo's house rule.
+  return Math.abs(v).toFixed(2);
+}
+
+export interface GradientLevelsReadoutStrings {
+  /** Top-line ∇f components, in math reading order [∂f/∂x, ∂f/∂y, ∂f/∂z]. */
+  components: readonly [string, string, string];
+  /** Bottom-line |∇f|, unsigned 2-decimal. */
+  magnitude: string;
+}
+
+/**
+ * Format the four numeric strings the readout displays from a raw
+ * gradient vector. Pure; allocates one fresh struct per call.
+ * Allocation cost is bounded by the readout's update throttle (≈30 Hz),
+ * so the per-frame call rate stays under 30 allocations/second.
+ *
+ * The input gradient is in math-frame surface-local coords — the
+ * readout shows raw math-frame components without any frame swap.
+ */
+export function formatGradientLevelsReadout(
+  gradient: MathVec3,
+): GradientLevelsReadoutStrings {
+  const mag = Math.hypot(gradient[0], gradient[1], gradient[2]);
+  return {
+    components: [
+      formatSignedMagnitude(gradient[0]),
+      formatSignedMagnitude(gradient[1]),
+      formatSignedMagnitude(gradient[2]),
+    ],
+    magnitude: formatUnsignedMagnitude(mag),
+  };
+}

--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -8,8 +8,15 @@ import { createImplicitSurface } from '@/scaffold/render/ImplicitSurface';
 import { raycastImplicit } from '@/scaffold/render/raycastImplicit';
 import { Slider } from '@/scaffold/ui/Slider';
 import { WorldAxes, type AxisName } from '@/scaffold/ui/WorldAxes';
-import { DEFAULT_AXIS_COLORS } from '@/scaffold/design/tokens';
+import {
+  BLUISH_GREEN,
+  DEFAULT_AXIS_COLORS,
+  SKY_BLUE,
+  VERMILLION,
+  YELLOW,
+} from '@/scaffold/design/tokens';
 import { createGradientArrow, type GradientArrowHandles } from './GradientArrow';
+import { GradientLevelsReadout } from './GradientLevelsReadout';
 import { BOUND, fJsRaw, gradJs } from './surfaceModel';
 
 // Gradient + level-surfaces scene (#162 epic). Third member of the
@@ -40,6 +47,11 @@ import { BOUND, fJsRaw, gradJs } from './surfaceModel';
 const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
 const SLIDER_RACK_CENTER = new THREE.Vector3(0, 1.0, -0.7);
 const AXIS_INDICATOR_POSITION = new THREE.Vector3(0.35, 1.17, -0.7);
+
+// Live readout (#166) — anchored above the three-row slider rack. y bumped
+// to 1.42 (vs. tangent-planes' 1.32) to maintain ~0.18 m bottom-to-thumb-top
+// clearance over the taller rack (top of θ slider thumb at y ≈ 1.21).
+const READOUT_POSITION = new THREE.Vector3(0, 1.42, -0.7);
 
 // Cluster siblings' lighting + base color so the surface reads as a
 // sibling, not as a separate scene's surface.
@@ -189,6 +201,7 @@ let thetaSlider: Slider | undefined;
 let phiSlider: Slider | undefined;
 let indicator: THREE.Mesh | undefined;
 let gradientArrow: GradientArrowHandles | undefined;
+let gradientLevelsReadout: GradientLevelsReadout | undefined;
 let worldAxes: WorldAxes | undefined;
 let controllers: readonly THREE.Object3D[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
@@ -315,6 +328,22 @@ const gradientLevelsExhibit: Exhibit = {
     gradientArrow = createGradientArrow({ surfaceCenter: SURFACE_CENTER });
     group.add(gradientArrow.group);
 
+    // Live readout of ∇f components + |∇f| (#166). Anchored above the
+    // slider rack on the same z-plane. Top-line components carry the
+    // cluster's axis-color convention (vermillion/bluish-green/sky-blue
+    // for math-X/Y/Z); the |∇f| numeric is YELLOW to pair with the
+    // gradient arrow — direction (arrow) + magnitude (number) are
+    // facets of the same gradient vector. The arrow's rendered length
+    // is fixed per #165; the YELLOW pairing communicates "same vector,"
+    // not "this number is that arrow's length." See SPEC.md Readout
+    // section for the full color-identity-decoupling note.
+    gradientLevelsReadout = new GradientLevelsReadout({
+      axisColors: [VERMILLION, BLUISH_GREEN, SKY_BLUE],
+      magnitudeColor: YELLOW,
+    });
+    gradientLevelsReadout.group.position.copy(READOUT_POSITION);
+    group.add(gradientLevelsReadout.group);
+
     // Math-frame axis indicator — same anchor as cluster siblings.
     worldAxes = new WorldAxes({ axisColors: AXIS_COLORS });
     worldAxes.group.position.copy(AXIS_INDICATOR_POSITION);
@@ -322,7 +351,14 @@ const gradientLevelsExhibit: Exhibit = {
   },
 
   update() {
-    if (!kSlider || !thetaSlider || !phiSlider || !indicator || !gradientArrow) return;
+    if (
+      !kSlider ||
+      !thetaSlider ||
+      !phiSlider ||
+      !indicator ||
+      !gradientArrow ||
+      !gradientLevelsReadout
+    ) return;
 
     // 1. Slider hover + drag tick. Order doesn't matter across the
     //    three sliders (each tracks its own grab/hover state).
@@ -368,14 +404,29 @@ const gradientLevelsExhibit: Exhibit = {
 
       gradientArrow.setPose(result.point, result.normal);
       gradientArrow.setVisible(true);
+
+      // Readout consumes the RAW gradient gradJs(p), NOT the unit
+      // result.normal — direction is the arrow's job; magnitude is
+      // the readout's. The composition test in
+      // test/exhibits/gradient-levels/formatGradientLevelsReadout.test.ts
+      // pins this contract: a unit-normal wiring would format to '1.00'
+      // instead of the real |∇f|.
+      const gradAtPoint = gradJs(result.point[0], result.point[1], result.point[2]);
+      gradientLevelsReadout.setValues(gradAtPoint);
     } else {
       indicator.visible = false;
       gradientArrow.setVisible(false);
+      // Readout: freeze on last good value. Gradient-levels has real
+      // miss frames (cone at k=0, polar/equator-band rays, AABB-clip
+      // cases) — blanking each would flicker. The frozen display IS
+      // the "no point currently selectable" signal; SPEC.md Readout
+      // section documents the contract.
     }
 
     // 6. Yaw-only billboard on the WorldAxes letter labels so they
     //    read at any user yaw. Same per-frame contract as siblings.
     if (worldAxes && camera) worldAxes.faceCamera(camera);
+    if (camera) gradientLevelsReadout.faceCamera(camera);
   },
 
   unmount() {
@@ -411,6 +462,8 @@ const gradientLevelsExhibit: Exhibit = {
     // existing convention (mirrors tangent-planes/index.ts:340-380).
     gradientArrow?.dispose();
     gradientArrow = undefined;
+    gradientLevelsReadout?.dispose();
+    gradientLevelsReadout = undefined;
     kSlider?.dispose();
     kSlider = undefined;
     thetaSlider?.dispose();

--- a/src/exhibits/quadrics/EquationReadout.ts
+++ b/src/exhibits/quadrics/EquationReadout.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { Text } from 'troika-three-text';
+import { formatSignedMagnitude } from '@/scaffold/ui/formatSignedMagnitude';
 
 // Live equation readout above the slider rack (#58). Two-line layout (#89)
 // renders the full quadric with linear terms:
@@ -341,8 +342,7 @@ export class EquationReadout {
       const value = values[i];
       if (value === this.numericValues[i]) continue;
       this.numericValues[i] = value;
-      const sign = value < 0 ? '−' : '+';
-      this.numericTexts[i].text = `${sign}${Math.abs(value).toFixed(2)}`;
+      this.numericTexts[i].text = formatSignedMagnitude(value);
       this.numericTexts[i].sync();
     }
   }

--- a/src/exhibits/tangent-planes/formatTangentPlaneReadout.ts
+++ b/src/exhibits/tangent-planes/formatTangentPlaneReadout.ts
@@ -1,4 +1,5 @@
 import type { MathVec3 } from '@/scaffold/math/frames';
+import { formatSignedMagnitude } from '@/scaffold/ui/formatSignedMagnitude';
 
 // Pure formatter for the tangent-planes readout (#149). Given a
 // surface-local point and its outward unit normal, produce the nine
@@ -9,22 +10,12 @@ import type { MathVec3 } from '@/scaffold/math/frames';
 // unit-test import time — same isolation pattern as
 // `directionFromAngles.ts`, `raycastSurface.ts`, `poseTangentPlaneMesh.ts`.
 //
-// Sign characters use Unicode MINUS SIGN (U+2212), matching
-// `EquationReadout.ts`'s convention so the two readouts render with the
-// same `−` glyph rather than the narrower hyphen-minus.
+// `formatSignedMagnitude` lifted to scaffold on third use (#166); the
+// local `formatInvertedSignedMagnitude` stays here — only one call site,
+// extraction trigger hasn't fired.
 
-const MINUS = '−';
+const MINUS = '−'; // U+2212
 const PLUS = '+';
-
-/**
- * Sign + 2-decimal magnitude; sign is `+` for `v >= 0`, `−` for `v < 0`.
- * Mirrors `EquationReadout.ts:344` so quadrics and tangent-planes share
- * the same numeric-formatting idiom.
- */
-function formatSignedMagnitude(v: number): string {
-  const sign = v < 0 ? MINUS : PLUS;
-  return `${sign}${Math.abs(v).toFixed(2)}`;
-}
 
 /**
  * Sign + 2-decimal magnitude with the sign of `−v` (i.e. the sign of the

--- a/src/scaffold/ui/formatSignedMagnitude.ts
+++ b/src/scaffold/ui/formatSignedMagnitude.ts
@@ -1,0 +1,18 @@
+// Signed-magnitude formatter shared by the cluster's readout primitives
+// (quadrics/EquationReadout, tangent-planes/formatTangentPlaneReadout,
+// gradient-levels/formatGradientLevelsReadout). Sign char is U+2212
+// MINUS for negative, ASCII `+` for non-negative including zero.
+// Magnitude formatted via `.toFixed(2)`.
+//
+// Extracted on third use per the repo's "extract on third use" rule:
+// before #166, EquationReadout had the logic inlined and tangent-planes'
+// formatter had a local copy; gradient-levels' readout was the third
+// site, triggering the lift to scaffold. See _private/plans/166.
+
+const MINUS = '−'; // U+2212
+const PLUS = '+';
+
+export function formatSignedMagnitude(v: number): string {
+  const sign = v < 0 ? MINUS : PLUS;
+  return `${sign}${Math.abs(v).toFixed(2)}`;
+}

--- a/test/exhibits/gradient-levels/formatGradientLevelsReadout.test.ts
+++ b/test/exhibits/gradient-levels/formatGradientLevelsReadout.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { formatGradientLevelsReadout } from '../../../src/exhibits/gradient-levels/formatGradientLevelsReadout.ts';
+import { gradJs } from '../../../src/exhibits/gradient-levels/surfaceModel.ts';
+
+// Pure formatter coverage plus a composition test that pins the
+// raw-gradient wiring (catches `result.normal` (unit) vs `gradJs(p)`
+// (raw) regressions at the unit-test level rather than only in
+// headset smoke).
+
+const MINUS = '−'; // U+2212
+
+describe('formatGradientLevelsReadout — components', () => {
+  it('positive components → leading "+" sign', () => {
+    const r = formatGradientLevelsReadout([1.22, 0.5, 0.5]);
+    expect(r.components).toEqual(['+1.22', '+0.50', '+0.50']);
+  });
+
+  it('negative components → leading "−" sign (U+2212)', () => {
+    const r = formatGradientLevelsReadout([-1.22, -0.5, -0.5]);
+    expect(r.components).toEqual([
+      `${MINUS}1.22`,
+      `${MINUS}0.50`,
+      `${MINUS}0.50`,
+    ]);
+  });
+
+  it('zero components → "+0.00" (defensive — upstream guard prevents this from a real hit frame)', () => {
+    // raycastImplicit's `gLen === 0 → miss` branch means the formatter
+    // never receives a zero-magnitude gradient from a real hit frame.
+    // The test covers the defensive path.
+    const r = formatGradientLevelsReadout([0, 0, 0]);
+    expect(r.components).toEqual(['+0.00', '+0.00', '+0.00']);
+  });
+
+  it('mixed signs preserve per-component sign', () => {
+    const r = formatGradientLevelsReadout([1.22, 1.22, -1]);
+    expect(r.components).toEqual(['+1.22', '+1.22', `${MINUS}1.00`]);
+  });
+});
+
+describe('formatGradientLevelsReadout — magnitude', () => {
+  it('3-4-5 triangle → 5.00', () => {
+    const r = formatGradientLevelsReadout([3, 4, 0]);
+    expect(r.magnitude).toBe('5.00');
+  });
+
+  it('zero vector → 0.00 (defensive — upstream guard prevents this)', () => {
+    const r = formatGradientLevelsReadout([0, 0, 0]);
+    expect(r.magnitude).toBe('0.00');
+  });
+
+  it('boot-pose gradient at (0.612, 0.612, 0.5) on k=0.5: ∇f = (1.224, 1.224, −1)', () => {
+    // surfaceModel.gradJs(0.612, 0.612, 0.5) = (1.224, 1.224, −1)
+    // |∇f| = √(1.224² + 1.224² + 1²) = √(3.996) ≈ 1.999
+    const r = formatGradientLevelsReadout([1.224, 1.224, -1]);
+    expect(r.magnitude).toBe('2.00');
+  });
+
+  it('large-magnitude formatter smoke at |grad| = 6 (synthetic input, not a real surface point)', () => {
+    // Pure formatter test for a large input magnitude. Input
+    // `[2√3, 2√3, 2√3]` corresponds to a point at (√3, √3, −√3)
+    // where f = 3 — OUTSIDE K_MAX = 2, so NOT a slider-reachable
+    // surface point. The test exists to verify formatter output at
+    // |grad| = 6 character widths regardless of where that input
+    // would geometrically originate.
+    const c = 2 * Math.sqrt(3);
+    const r = formatGradientLevelsReadout([c, c, c]);
+    expect(r.magnitude).toBe('6.00');
+  });
+
+  it('slider-reachable max-magnitude case: k=2 at AABB top face z=3, |∇f| ≈ 8.94', () => {
+    // Actual maximum |∇f| reachable within the slider's k ∈ [-2, 2]
+    // range. At k = 2, the surface intersects the AABB top face
+    // (z = ±BOUND = ±3) where x² + y² = k + z² = 11; so
+    // (x, y, z) = (√(11/2), √(11/2), 3) is on the surface for k = 2.
+    // gradJs at that point: (2·√(11/2), 2·√(11/2), -6).
+    //   |∇f|² = 4·(11/2) + 4·(11/2) + 36 = 22 + 22 + 36 = 80.
+    //   |∇f| = √80 = 4·√5 ≈ 8.944.
+    // The "|∇f| = 2|p|" identity DOES hold for f = x² + y² − z²
+    // because squaring kills the negative sign on the z-component:
+    //   2|p| = 2·√(11/2 + 11/2 + 9) = 2·√20 = √80 ✓.
+    const p: [number, number, number] = [
+      Math.sqrt(11 / 2),
+      Math.sqrt(11 / 2),
+      3,
+    ];
+    const grad = gradJs(p[0], p[1], p[2]);
+    const r = formatGradientLevelsReadout(grad);
+    expect(r.magnitude).toBe('8.94');
+  });
+});
+
+describe('formatGradientLevelsReadout — composition with gradJs (raw vs unit wiring guard)', () => {
+  it('gradJs(boot pose) → magnitude "2.00" (fails loud if wiring uses result.normal=unit)', () => {
+    // The readout's correctness hinges on receiving the RAW gradient
+    // from gradJs(point), not the UNIT normal from raycastImplicit's
+    // result.normal. If index.ts wires the readout to result.normal
+    // accidentally, the magnitude would format to '1.00' (unit-vector
+    // length) instead of the real |∇f|. This composition test catches
+    // the regression at the unit-test level rather than only in
+    // headset smoke.
+    //
+    // Boot pose: θ = π/3, φ = π/4, k = +0.5 ⇒ surface point
+    // (0.612, 0.612, 0.5). gradJs at that point = (1.224, 1.224, -1);
+    // |∇f| ≈ 1.999 → formats as '2.00'. A unit-normal wiring would
+    // give |result.normal| = 1.00 — distinguishable here.
+    const p: [number, number, number] = [
+      Math.sin(Math.PI / 3) * Math.cos(Math.PI / 4),
+      Math.sin(Math.PI / 3) * Math.sin(Math.PI / 4),
+      Math.cos(Math.PI / 3),
+    ];
+    const grad = gradJs(p[0], p[1], p[2]);
+    const r = formatGradientLevelsReadout(grad);
+    expect(r.magnitude).toBe('2.00');
+    expect(r.magnitude).not.toBe('1.00'); // explicit anti-regression assertion
+  });
+});

--- a/test/scaffold/ui/formatSignedMagnitude.test.ts
+++ b/test/scaffold/ui/formatSignedMagnitude.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { formatSignedMagnitude } from '../../../src/scaffold/ui/formatSignedMagnitude.ts';
+
+// Three contracts shared across all cluster readouts (quadrics
+// EquationReadout, tangent-planes formatter, gradient-levels formatter).
+// Sign character is U+2212 MINUS (not hyphen-minus); zero takes `+`.
+
+const MINUS = '−'; // U+2212
+
+describe('formatSignedMagnitude', () => {
+  it('positive value → leading "+" sign', () => {
+    expect(formatSignedMagnitude(0.71)).toBe('+0.71');
+    expect(formatSignedMagnitude(1.22)).toBe('+1.22');
+    expect(formatSignedMagnitude(10)).toBe('+10.00');
+  });
+
+  it('negative value → leading "−" sign (U+2212, not hyphen-minus)', () => {
+    expect(formatSignedMagnitude(-0.71)).toBe(`${MINUS}0.71`);
+    expect(formatSignedMagnitude(-1.22)).toBe(`${MINUS}1.22`);
+  });
+
+  it('zero → "+0.00" (positive sign by convention)', () => {
+    expect(formatSignedMagnitude(0)).toBe('+0.00');
+  });
+});


### PR DESCRIPTION
Closes #166

## Summary

Final main-pedagogy item in the #162 epic: a two-line readout above the slider rack showing the gradient vector decomposed into math-frame components (top line, axis-coded vermillion/bluish-green/sky-blue) plus its scalar magnitude (bottom line, YELLOW to pair with the gradient arrow). Updates live as θ/φ/k slide; freezes on the last valid value during raycast miss frames (k=0 cone, polar/equator-band rays, AABB-clip cases).

Wires from the *raw* gradient `gradJs(result.point)` — not `result.normal` (which is the unit normal); a composition test pins this contract at the unit-test level so a regression would format `|∇f|` as `'1.00'` and fail loudly. Lifts `formatSignedMagnitude` to `src/scaffold/ui/formatSignedMagnitude.ts` on the rule's third-use trigger (EquationReadout inline + tangent-planes formatter + this PR); both prior call sites migrated to import from scaffold.

Plan went through full three-vendor roundtable (Sonnet + GPT-5.5 Pro + DeepSeek V4 Pro, all REVISE on v1; second-Sonnet sanity check on v2 PROCEED'd cleanly). The triple-convergent math error and the YELLOW-pedagogy sparring-partner blind spot are documented in v2's §0 revision summary at `_private/plans/166-gradient-levels-readout.md`.

## Test plan

Cloudflare PR preview (Quest, after the pr-preview workflow comments the URL ~1 min after push):

- [x] **Boot pose continuity.** Load `?exhibit=gradient-levels`; readout reads `∇f = (+1.22, +1.22, −1.00)` and `|∇f| = 2.00` at the boot pose (θ=π/3, φ=π/4, k=+0.5).
- [x] **Axis-color identification on components.** Each component (∂f/∂x, ∂f/∂y, ∂f/∂z) reads its cluster color matching the WorldAxes indicator labels.
- [x] **YELLOW magnitude pairing.** `|∇f|` reads visibly yellow, pairing with the gradient arrow. Drag k from +0.5 → +2: `|∇f|` grows from `2.00` to ~`8.94` while the arrow stays at fixed 0.40 m. Confirm this reads as "same vector, two facets" rather than "the number is the arrow's length" (which would be the misconception #165's unit-length lock was designed to prevent).
- [x] **Freeze-on-miss across k=0 transition.** From boot pose, drag k from +1 → 0 → −1 without moving θ. At k=0 (cone all-miss) the indicator + arrow hide; the readout freezes on the last good value. At fixed θ=π/3 (equator), k<0 frames also miss (2-sheet is in polar caps) — readout stays frozen. Confirm freeze reads as "the picture is paused while no point is selectable," not a stale display.
- [x] **Sign flip on z-component requires θ at polar cap.** Set θ to ~π/8 (polar cap) and ~7π/8 (opposite polar cap) with k = −0.5; readout shows opposite `∂f/∂z` signs (upper sheet at z > 0 vs lower sheet at z < 0).
- [x] **No regression in sibling scenes.** Switch to `quadrics` and `tangent-planes` via the SceneRack; both readouts still render correctly (verifying the scaffold extraction of `formatSignedMagnitude` didn't break either existing call site).
- [x] **Yaw billboard.** Walk around the rack (~90° yaw change); the readout follows yaw, world-up stays world-up. No tilt or roll.

Automated:

- [x] `npm test` — 226 passed (incl. 6 new tests in `formatSignedMagnitude.test.ts` + 10 new in `formatGradientLevelsReadout.test.ts`, of which one is the composition test catching raw-vs-unit wiring).
- [x] `npm run build` — `tsc --noEmit && vite build` clean.
- [x] `npm run lint` — clean.