### PR TITLE
feat(scene): gradient-levels — numeric k-value label (#167)

### DIFF
--- a/src/exhibits/gradient-levels/SPEC.md
+++ b/src/exhibits/gradient-levels/SPEC.md
@@ -4,8 +4,8 @@
 > #163 registered the third cluster member with a single k slider
 > sweeping { f(x, y, z) = k } across the canonical hyperboloid family;
 > #164 added θ/φ point selection on the active level surface; #165 added
-> the gradient arrow at the selected point; #166 adds the live ∇f / |∇f|
-> readout; #167 the numeric k label (pending).
+> the gradient arrow at the selected point; #166 added the live ∇f / |∇f|
+> readout; #167 added the numeric k label.
 
 ## Goal
 
@@ -82,17 +82,29 @@ Slider visuals: neutral light gray base color (`0xaaaaaa`), sphere thumb
 shape — k is a scalar level value, not an axis-aligned parameter, so
 neither an axis tint nor an arrow thumb would carry meaning.
 
-## No on-screen k value (intentional v0.7-#163 deferral; pending #167)
+## k-value label (#167)
 
-The numeric value of k is not displayed yet. The minimum-viable scene
-#163 called for was "register + slider"; adding worldspace text was
-scope creep against that issue title. Acknowledged that not seeing the
-number weakens the immediate learning loop (the user is actively
-dragging the parameter whose value is hidden); the follow-up is
-[#167](https://github.com/skylinetrailcomputing/geometer/issues/167),
-scheduled for v0.7 and especially load-bearing once #164 ships
-point selection — correlating "indicator vanished" with "k near 0"
-becomes a single-glance read once the value is on-screen.
+A small worldspace numeric label below the k slider displays the
+current level value as `k = N.NN`. Anchored at y = 0.70 (below the
+k slider thumb-bottom at y ≈ 0.79); centered on x = 0; same z-plane
+as the rack (z = -0.7). fontSize 0.06 matches the cluster's
+rack-label convention.
+
+There's no room *above* the k slider for the label because the φ
+slider's thumb-bottom (y ≈ 0.93) meets the k slider's thumb-top
+(y ≈ 0.93) — putting the label below is the only available rack-
+vertical slot.
+
+Format: positive values render without a leading sign (`k = 0.50`,
+`k = 0.00`); negative values prepend U+2212 MINUS (`k = −1.00`) to
+match the cluster's signed-numeric glyph convention. 2-decimal
+precision via `.toFixed(2)`, consistent with the readout (#166)
+and the EquationReadout / TangentPlaneReadout cluster idiom.
+
+Built on the `Label` primitive (`src/scaffold/ui/Label.ts`) using
+the primary line only; secondary stays empty. #170 (per-slider
+θ/φ/k labels) may rework this into a two-line shape (`k` primary +
+`0.50` secondary) once that scaffold lands.
 
 ## Point parameterization (#164)
 
@@ -327,9 +339,8 @@ at the apex. Three concerns:
    at the origin during a successful raycast. No JS-side cone-apex
    guard needed.
 
-## Out of scope (v0.7 beyond #166)
+## Out of scope (v0.7 beyond #167)
 
-- **Numeric k value display** — #167.
 - **Option B-lite (closed-form θ clamp).** Documented v0.7-polish
   follow-up if smoke shows the disappearing-indicator UX is too
   jarring. Clamp would need to account for BOUND

--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -6,6 +6,7 @@ import { writeMathToWorld } from '@/scaffold/math/frames';
 import { directionFromAngles } from '@/scaffold/math/directionFromAngles';
 import { createImplicitSurface } from '@/scaffold/render/ImplicitSurface';
 import { raycastImplicit } from '@/scaffold/render/raycastImplicit';
+import { Label } from '@/scaffold/ui/Label';
 import { Slider } from '@/scaffold/ui/Slider';
 import { WorldAxes, type AxisName } from '@/scaffold/ui/WorldAxes';
 import {
@@ -52,6 +53,15 @@ const AXIS_INDICATOR_POSITION = new THREE.Vector3(0.35, 1.17, -0.7);
 // to 1.42 (vs. tangent-planes' 1.32) to maintain ~0.18 m bottom-to-thumb-top
 // clearance over the taller rack (top of θ slider thumb at y ≈ 1.21).
 const READOUT_POSITION = new THREE.Vector3(0, 1.42, -0.7);
+
+// k-value label (#167) — anchored below the k slider. There's no room
+// for a label *above* the k slider because the φ slider sits at
+// y = 1.00 (thumb-bottom at y ≈ 0.93) and the k thumb-top is also at
+// y ≈ 0.93 (k slider at y=0.86 + ~0.07 sphere radius). Below k is the
+// only available rack-vertical slot. fontSize 0.06 matches the cluster's
+// rack-label convention (`quadrics/index.ts:82`).
+const K_LABEL_POSITION = new THREE.Vector3(0, 0.70, -0.7);
+const K_LABEL_PRIMARY_FONT_SIZE = 0.06;
 
 // Cluster siblings' lighting + base color so the surface reads as a
 // sibling, not as a separate scene's surface.
@@ -202,6 +212,7 @@ let phiSlider: Slider | undefined;
 let indicator: THREE.Mesh | undefined;
 let gradientArrow: GradientArrowHandles | undefined;
 let gradientLevelsReadout: GradientLevelsReadout | undefined;
+let kLabel: Label | undefined;
 let worldAxes: WorldAxes | undefined;
 let controllers: readonly THREE.Object3D[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
@@ -344,6 +355,17 @@ const gradientLevelsExhibit: Exhibit = {
     gradientLevelsReadout.group.position.copy(READOUT_POSITION);
     group.add(gradientLevelsReadout.group);
 
+    // k-value label (#167). Displays the current level value `k` below
+    // the k slider. The §11.6 family-sweep pedagogy is driven by k;
+    // surfacing the numeric value lets students correlate slider position
+    // with snap detents (k = -1 canonical 2-sheet, k = 0 cone, k = +1
+    // canonical 1-sheet) and with the indicator visibility transition
+    // at k = 0. Uses the Label primitive's primary line only; secondary
+    // stays empty (#170 may rework into a two-line shape later).
+    kLabel = new Label({ primaryFontSize: K_LABEL_PRIMARY_FONT_SIZE });
+    kLabel.group.position.copy(K_LABEL_POSITION);
+    group.add(kLabel.group);
+
     // Math-frame axis indicator — same anchor as cluster siblings.
     worldAxes = new WorldAxes({ axisColors: AXIS_COLORS });
     worldAxes.group.position.copy(AXIS_INDICATOR_POSITION);
@@ -357,7 +379,8 @@ const gradientLevelsExhibit: Exhibit = {
       !phiSlider ||
       !indicator ||
       !gradientArrow ||
-      !gradientLevelsReadout
+      !gradientLevelsReadout ||
+      !kLabel
     ) return;
 
     // 1. Slider hover + drag tick. Order doesn't matter across the
@@ -374,6 +397,17 @@ const gradientLevelsExhibit: Exhibit = {
       surfaceMaterial.uniforms.uK.value = kSlider.value;
     }
 
+    // 2b. k-value label (#167). Positive values render with no leading
+    //     sign per the issue spec ("k = 0.50"); negative values prepend
+    //     U+2212 MINUS to match the cluster's signed-numeric glyph
+    //     convention. Zero falls through the positive branch as "0.00"
+    //     (no leading sign), matching the textbook identity form.
+    const k = kSlider.value;
+    const kStr = k < 0
+      ? `k = −${Math.abs(k).toFixed(2)}`
+      : `k = ${k.toFixed(2)}`;
+    kLabel.setPrimary(kStr);
+
     // 3. Math-frame direction from θ/φ — mutates `dirMath` in place;
     //    no per-frame allocation.
     directionFromAngles(thetaSlider.value, phiSlider.value, dirMath);
@@ -382,8 +416,7 @@ const gradientLevelsExhibit: Exhibit = {
     //    over the current k each frame — one closure allocation per
     //    frame, well under the per-hit RaycastHit tuples raycastImplicit
     //    itself emits. Readability win over a mutable module-scope
-    //    `currentK` variable.
-    const k = kSlider.value;
+    //    `currentK` variable. `k` is the slider value pulled in step 2b.
     const result = raycastImplicit({
       f: (x, y, z) => fJsRaw(x, y, z) - k,
       gradF: gradJs,
@@ -427,6 +460,7 @@ const gradientLevelsExhibit: Exhibit = {
     //    read at any user yaw. Same per-frame contract as siblings.
     if (worldAxes && camera) worldAxes.faceCamera(camera);
     if (camera) gradientLevelsReadout.faceCamera(camera);
+    if (camera) kLabel.faceCamera(camera);
   },
 
   unmount() {
@@ -464,6 +498,8 @@ const gradientLevelsExhibit: Exhibit = {
     gradientArrow = undefined;
     gradientLevelsReadout?.dispose();
     gradientLevelsReadout = undefined;
+    kLabel?.dispose();
+    kLabel = undefined;
     kSlider?.dispose();
     kSlider = undefined;
     thetaSlider?.dispose();


### PR DESCRIPTION
Closes #167

## Summary

Small worldspace numeric label `k = N.NN` below the k slider in the gradient-levels scene. Closes the "user drags a parameter whose value is hidden" gap noted in the #163 plan's deferred-text decision; pedagogically lets students correlate slider position with snap detents (k = ±1, 0) and with the cone-miss transition at k = 0.

**Format:** positive values render without a leading sign per the issue spec (`k = 0.50`, `k = 0.00`); negatives prepend U+2212 MINUS (`k = −1.00`) to match the cluster's signed-numeric glyph convention. 2-decimal precision via `.toFixed(2)`, consistent with the readout (#166) and the EquationReadout / TangentPlaneReadout idiom.

**Position:** y = 0.70 (below the k slider thumb-bottom at y ≈ 0.79); centered on x = 0; same z-plane as the rack. There's no room *above* the k slider — the φ slider's thumb-bottom and the k slider's thumb-top meet at y ≈ 0.93, leaving only the below-rack slot.

**Built on the `Label` primitive** using the primary line only. #170 (per-slider θ/φ/k labels) may rework into a two-line shape (`k` primary + `0.50` secondary); the single-line shape here is the simplest realization of #167's spec, with a one-line note in SPEC.md acknowledging the possible future rework.

Skipped the formal plan + roundtable cadence per memory's "foundational v0.x → roundtable; narrow polish → skip" rule; #167's own issue text predicted the roundtable would PROCEED on first pass.

## Test plan

Cloudflare PR preview (Quest):

- [x] Boot pose continuity: load `?exhibit=gradient-levels`; k-label reads `k = 0.50` (the K_INITIAL boot value).
- [x] Slider drag tracking: drag k from −2 to +2; label tracks the slider value smoothly (no flicker; no rounding shimmer between detents).
- [x] Snap detent confirmation: slow drags onto the three snap points (`k = −1.00`, `k = 0.00`, `k = +1.00`) confirm clean integer poses.
- [x] Sign-flip glyph: dragging through k = 0 shows `k = 0.00` (no leading sign) and `k = −0.50` (U+2212 minus, not hyphen-minus) on the negative side.
- [x] Vertical clearance: label sits below the k slider thumb without overlapping the φ slider above or the floor below; legible from the user's spawn at ~3 m from the rack.
- [x] No regression in sibling scenes: switch to `quadrics` and `tangent-planes` via the SceneRack; both render correctly (the only shared code touched was the gradient-levels exhibit and SPEC.md).
- [x] Yaw billboard: walk around the rack; label follows yaw, world-up stays world-up.

Automated:

- [x] `npm test` — 226 passed (no new tests; format is one inline expression, visual correctness validates in headset).
- [x] `npm run build` — `tsc --noEmit && vite build` clean (caught + fixed a name-collision between step 2b's new `const k` and step 4's existing `const k` during local verification).
- [x] `npm run lint` — clean.