### PR TITLE
feat(scene): saddle-extrema — register scene + graph-surface primitive + first preset (#176)

### DIFF
--- a/src/exhibits/saddle-extrema/GraphSurface.ts
+++ b/src/exhibits/saddle-extrema/GraphSurface.ts
@@ -1,0 +1,231 @@
+import * as THREE from 'three';
+import { writeMathToWorld } from '@/scaffold/math/frames';
+
+// Meshed graph-surface primitive for the saddle / extrema scene (#176).
+// Tessellates `z = f(x, y)` over a rectangular (x, y) domain as a uniform
+// grid; vertex normals derived analytically from the supplied gradF.
+//
+// Architectural divergence from the cluster's prior three scenes
+// (quadrics, tangent-planes, gradient-levels), which all render an
+// implicit surface via the GPU raymarcher at `scaffold/render/
+// ImplicitSurface.ts`. Graph form `z = f(x, y)` doesn't fit that harness
+// — there's no GLSL `fImplicit` analogue, and the natural primitive is a
+// real BufferGeometry mesh, not a bounding cube with per-fragment
+// sign-change detection.
+//
+// Lives at the scene's path for v1 per #176. Extraction to
+// `src/scaffold/` is deferred until a second scene wants the primitive.
+//
+// Math-frame convention (X right, Y forward, Z up; see
+// `scaffold/math/frames.ts`): the (x, y) domain lives in the math-XY
+// plane and z = f(x, y) lifts vertically along math-Z. World-frame
+// mapping is JS-side per vertex via `writeGraphPointToWorld` below.
+
+/**
+ * Convert a graph-form (math-frame) point into world coordinates anchored
+ * at `surfaceCenter`. Bundles the two-step pattern `writeMathToWorld(...)
+ * + add(surfaceCenter)` so downstream consumers (#177 selected-point
+ * indicator, #179 critical-point markers, #180 quadratic overlay) don't
+ * re-derive the contract.
+ *
+ * `writeMathToWorld` itself is a pure axis remap + sign flip (no
+ * translation, per `scaffold/math/frames.ts`); the worldspace anchoring
+ * happens here.
+ */
+export function writeGraphPointToWorld(
+  x: number,
+  y: number,
+  z: number,
+  surfaceCenter: THREE.Vector3,
+  out: THREE.Vector3,
+): THREE.Vector3 {
+  writeMathToWorld([x, y, z], out);
+  return out.add(surfaceCenter);
+}
+
+export interface GraphSurfaceDomain {
+  readonly xMin: number;
+  readonly xMax: number;
+  readonly yMin: number;
+  readonly yMax: number;
+}
+
+export interface GraphSurfaceOptions {
+  /** z = f(x, y) in math-frame coords. */
+  f: (x: number, y: number) => number;
+  /**
+   * Analytic first partials: returns (f_x, f_y) at (x, y). Required (not
+   * optional) — vertex normals are derived from this. v0.8 presets all
+   * have closed-form partials; a central-difference fallback would add a
+   * code path used only by hypothetical future student-supplied-f
+   * callers.
+   */
+  gradF: (x: number, y: number) => readonly [number, number];
+  /** Rectangular (x, y) domain in math-frame coords. */
+  domain: GraphSurfaceDomain;
+  /**
+   * Grid resolution per side. Total vertices = res². Default 128.
+   * Validated: must be integer, >= 2.
+   */
+  res?: number;
+  /** World-space anchor where math-origin lifts to. Math-Z = 0 → this.y. */
+  surfaceCenter: THREE.Vector3;
+  /**
+   * Base diffuse color. The default `MeshStandardMaterial` path approximates
+   * the cluster's hand-rolled `0.2 + 0.8 × lambert` shader; if smoke shows
+   * visible parity drift (specular lobe, cooler ambient), swap to the
+   * cluster-lambert ShaderMaterial — see SPEC.md "Material parity fallback."
+   */
+  baseColor: THREE.Color;
+}
+
+export interface GraphSurfaceHandles {
+  readonly mesh: THREE.Mesh;
+  readonly material: THREE.MeshStandardMaterial;
+  dispose(): void;
+}
+
+const DEFAULT_RES = 128;
+
+// `Uint16Array` index buffers max out at 65535 vertices; tip to `Uint32Array`
+// once `res² > 65535`. `res = 128` ⇒ 16384 vertices, comfortably Uint16.
+// `res = 256` ⇒ 65536, just past the Uint16 ceiling — uses Uint32.
+const UINT16_VERTEX_CEILING = 65535;
+
+export function createGraphSurface(
+  opts: GraphSurfaceOptions,
+): GraphSurfaceHandles {
+  const res = opts.res ?? DEFAULT_RES;
+
+  // §3.1 validation. Throws at construction with a clear message rather than
+  // producing NaN geometry that would be observable only via faceting in
+  // headset smoke.
+  if (!Number.isInteger(res) || res < 2) {
+    throw new Error(
+      `createGraphSurface: res must be an integer >= 2 (got ${res})`,
+    );
+  }
+  const { xMin, xMax, yMin, yMax } = opts.domain;
+  if (
+    !Number.isFinite(xMin) ||
+    !Number.isFinite(xMax) ||
+    xMin >= xMax
+  ) {
+    throw new Error(
+      `createGraphSurface: domain.xMin (${xMin}) must be finite and < domain.xMax (${xMax})`,
+    );
+  }
+  if (
+    !Number.isFinite(yMin) ||
+    !Number.isFinite(yMax) ||
+    yMin >= yMax
+  ) {
+    throw new Error(
+      `createGraphSurface: domain.yMin (${yMin}) must be finite and < domain.yMax (${yMax})`,
+    );
+  }
+
+  const vertexCount = res * res;
+  const quadCount = (res - 1) * (res - 1);
+  const triCount = quadCount * 2;
+  const indexCount = triCount * 3;
+
+  const positions = new Float32Array(vertexCount * 3);
+  const normals = new Float32Array(vertexCount * 3);
+  // Index type selected by vertex-count ceiling. The Three.js
+  // BufferAttribute carries its own array type; the renderer reads it
+  // accordingly.
+  const indices: Uint16Array | Uint32Array =
+    vertexCount > UINT16_VERTEX_CEILING
+      ? new Uint32Array(indexCount)
+      : new Uint16Array(indexCount);
+
+  // Two scratch Vector3 objects, allocated once. Reusing a single scratch
+  // for both position and normal writes would clobber position before it's
+  // stored into the Float32Array. The Vitest suite's combined
+  // position+normal-correctness assertions catch a single-scratch mistake
+  // immediately.
+  const scratchPos = new THREE.Vector3();
+  const scratchNorm = new THREE.Vector3();
+
+  const xStep = (xMax - xMin) / (res - 1);
+  const yStep = (yMax - yMin) / (res - 1);
+
+  for (let j = 0; j < res; j++) {
+    const y = yMin + j * yStep;
+    for (let i = 0; i < res; i++) {
+      const x = xMin + i * xStep;
+      const z = opts.f(x, y);
+
+      writeGraphPointToWorld(x, y, z, opts.surfaceCenter, scratchPos);
+
+      // Math-frame normal: surface is the graph of f, i.e. the implicit
+      // surface { z − f(x, y) = 0 }, whose gradient is (−f_x, −f_y, 1).
+      // Direction-only conversion via writeMathToWorld (no surfaceCenter
+      // offset — surfaceCenter is a position, not a direction).
+      const [fx, fy] = opts.gradF(x, y);
+      writeMathToWorld([-fx, -fy, 1], scratchNorm).normalize();
+
+      const vIdx = (j * res + i) * 3;
+      positions[vIdx + 0] = scratchPos.x;
+      positions[vIdx + 1] = scratchPos.y;
+      positions[vIdx + 2] = scratchPos.z;
+      normals[vIdx + 0] = scratchNorm.x;
+      normals[vIdx + 1] = scratchNorm.y;
+      normals[vIdx + 2] = scratchNorm.z;
+    }
+  }
+
+  // Index winding: per quad (i, j) → (i+1, j) → (i, j+1) → (i+1, j+1),
+  // two triangles emitted as
+  //   [bl, br, tl]  and  [br, tr, tl]
+  // where bl = (i, j), br = (i+1, j), tl = (i, j+1), tr = (i+1, j+1).
+  // The Vitest winding-order test pins that the cross-product of the
+  // emitted triangle's edges agrees with the analytic normal at the
+  // bottom-left vertex.
+  let k = 0;
+  for (let j = 0; j < res - 1; j++) {
+    for (let i = 0; i < res - 1; i++) {
+      const bl = j * res + i;
+      const br = j * res + (i + 1);
+      const tl = (j + 1) * res + i;
+      const tr = (j + 1) * res + (i + 1);
+      indices[k++] = bl;
+      indices[k++] = br;
+      indices[k++] = tl;
+      indices[k++] = br;
+      indices[k++] = tr;
+      indices[k++] = tl;
+    }
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  geometry.setAttribute('normal', new THREE.BufferAttribute(normals, 3));
+  geometry.setIndex(new THREE.BufferAttribute(indices, 1));
+
+  // MeshStandardMaterial default. Approximates the cluster's hand-rolled
+  // lambert under the same lights; if §5.3 smoke shows visible parity
+  // drift, swap to the cluster-lambert ShaderMaterial — SPEC.md
+  // "Material parity fallback" carries the verbatim shader.
+  const material = new THREE.MeshStandardMaterial({
+    color: opts.baseColor,
+    metalness: 0,
+    roughness: 0.6,
+    side: THREE.DoubleSide,
+  });
+
+  const mesh = new THREE.Mesh(geometry, material);
+  // Per-vertex positions already bake in surfaceCenter via
+  // writeGraphPointToWorld; mesh position stays at world origin.
+  mesh.position.set(0, 0, 0);
+
+  return {
+    mesh,
+    material,
+    dispose() {
+      geometry.dispose();
+      material.dispose();
+    },
+  };
+}

--- a/src/exhibits/saddle-extrema/GraphSurface.ts
+++ b/src/exhibits/saddle-extrema/GraphSurface.ts
@@ -71,17 +71,24 @@ export interface GraphSurfaceOptions {
   /** World-space anchor where math-origin lifts to. Math-Z = 0 → this.y. */
   surfaceCenter: THREE.Vector3;
   /**
-   * Base diffuse color. The default `MeshStandardMaterial` path approximates
-   * the cluster's hand-rolled `0.2 + 0.8 × lambert` shader; if smoke shows
-   * visible parity drift (specular lobe, cooler ambient), swap to the
-   * cluster-lambert ShaderMaterial — see SPEC.md "Material parity fallback."
+   * Base diffuse color, fed to the cluster-lambert `ShaderMaterial`
+   * (see below) verbatim. Treated as linear-space RGB inside the shader
+   * — pass the same value cluster siblings pass to their raymarch
+   * harness (`new THREE.Color(0.4, 0.7, 0.95)` for v0.8 cluster sky-blue).
    */
   baseColor: THREE.Color;
+  /**
+   * World-space directional-light direction (the SAME direction the scene
+   * passes to its `DirectionalLight.position`, pre-normalization). Baked
+   * into the `uLightDir` uniform so the surface's lambert agrees with
+   * the cluster's ShaderMaterial-rendered siblings.
+   */
+  lightDir: THREE.Vector3;
 }
 
 export interface GraphSurfaceHandles {
   readonly mesh: THREE.Mesh;
-  readonly material: THREE.MeshStandardMaterial;
+  readonly material: THREE.ShaderMaterial;
   dispose(): void;
 }
 
@@ -204,14 +211,44 @@ export function createGraphSurface(
   geometry.setAttribute('normal', new THREE.BufferAttribute(normals, 3));
   geometry.setIndex(new THREE.BufferAttribute(indices, 1));
 
-  // MeshStandardMaterial default. Approximates the cluster's hand-rolled
-  // lambert under the same lights; if §5.3 smoke shows visible parity
-  // drift, swap to the cluster-lambert ShaderMaterial — SPEC.md
-  // "Material parity fallback" carries the verbatim shader.
-  const material = new THREE.MeshStandardMaterial({
-    color: opts.baseColor,
-    metalness: 0,
-    roughness: 0.6,
+  // Cluster-lambert ShaderMaterial — reproduces the implicit-surface
+  // cluster siblings' exact lighting formula
+  // (`uBaseColor * (0.2 + 0.8 * max(dot(n, L), 0))`) so the saddle reads
+  // as a visual kin during scene swaps. The v0.8 in-headset smoke
+  // confirmed that `MeshStandardMaterial({metalness:0, roughness:0.6})`
+  // under the same lights read as off-white vs. the cluster's clear
+  // light-blue — the v2 plan / SPEC.md's pre-coded fallback (this
+  // shader) is what ships.
+  //
+  // Vertex shader: `mat3(modelMatrix) * normal` (not `normalMatrix *
+  // normal`) puts vNormal in world space, matching the world-space
+  // `uLightDir` below. `normalMatrix` would put it in view space and
+  // the lambert dot would drift under head rotation. (Mesh modelMatrix
+  // is identity here — graph surface bakes world-frame positions at
+  // build time — but the explicit form survives any future
+  // repositioning, and matches `DoublePlane.ts:52`'s precedent.)
+  const material = new THREE.ShaderMaterial({
+    vertexShader: /* glsl */ `
+      varying vec3 vNormal;
+      void main() {
+        vNormal = normalize(mat3(modelMatrix) * normal);
+        gl_Position = projectionMatrix * viewMatrix * modelMatrix
+                    * vec4(position, 1.0);
+      }
+    `,
+    fragmentShader: /* glsl */ `
+      uniform vec3 uBaseColor;
+      uniform vec3 uLightDir;
+      varying vec3 vNormal;
+      void main() {
+        float lambert = max(dot(normalize(vNormal), normalize(uLightDir)), 0.0);
+        gl_FragColor = vec4(uBaseColor * (0.2 + 0.8 * lambert), 1.0);
+      }
+    `,
+    uniforms: {
+      uBaseColor: { value: opts.baseColor.clone() },
+      uLightDir: { value: opts.lightDir.clone() },
+    },
     side: THREE.DoubleSide,
   });
 

--- a/src/exhibits/saddle-extrema/SPEC.md
+++ b/src/exhibits/saddle-extrema/SPEC.md
@@ -1,0 +1,261 @@
+# `saddle-extrema` exhibit — SPEC
+
+> Math + UX contract for the saddle / extrema classification scene.
+> v0.8 cuts: #176 registers the fourth cluster member, introduces a
+> new meshed graph-surface rendering primitive, and ships one locked
+> starter preset (`z = x² − y²`). #177 adds (x, y) point selection;
+> #178 expands the preset library; #179 adds critical-point markers;
+> #180 ships the local-quadratic-approximation overlay (the §11.7–11.8
+> punch line); #181 ships the live Hessian + classification readout.
+
+## Goal
+
+An interactive WebXR scene where the learner observes a graph surface
+`z = f(x, y)` for a curated set of polynomial functions, each chosen
+to exhibit one specific critical-point archetype (saddle, min, max,
+monkey saddle, D = 0 degenerate). Pedagogy hook: APPM 2350 §11.7–11.8
+(Maximum/Minimum Values + Second Derivatives Test). Two stuck-points
+the scene is designed to encode:
+
+1. **The second-derivative test is a *local shape* judgment, not a
+   sign-checking ritual.** Mechanically computing `D = f_xx · f_yy −
+   f_xy²` and checking signs misses the underlying question: "what does
+   this surface look like in a small neighborhood?" The quadratic
+   overlay in #180 makes the local shape literal.
+2. **Degenerate critical points (D = 0) are not edge cases to memorize**
+   — they're where the local quadratic fails to determine the shape
+   and higher-order terms take over. The preset library in #178
+   includes degenerate cases (monkey saddle, `x⁴ + y⁴`) so the
+   test-failure mode reads visually rather than as a footnote.
+
+Sibling of `quadrics`, `tangent-planes`, and `gradient-levels` in the
+`calculus3` cluster; the SceneRack swaps between the four at runtime.
+
+## Equation form
+
+The surface is the **graph** `z = f(x, y)`, not the implicit
+`f(x, y, z) = k` form used by the prior three cluster scenes. The
+divergence is pedagogically honest to §11.7's framing — the
+second-derivative test operates on a function `f(x, y)` whose graph is
+a 2-surface in 3-space — and gives future flexibility for student-
+supplied `f(x, y)` (deferred to v1.x+).
+
+Math-frame convention (X right, Y forward, Z up; per
+`scaffold/math/frames.ts`): the `(x, y)` domain lives in the math-XY
+plane and `z = f(x, y)` lifts vertically along math-Z. World-frame
+mapping is JS-side per vertex via `writeGraphPointToWorld` in
+`GraphSurface.ts`.
+
+`writeMathToWorld` itself is a pure axis remap + sign flip (math
+`(x, y, z)` → world `(x, z, -y)`); no translation. Worldspace anchoring
+(`+ SURFACE_CENTER`) is the caller's responsibility — `writeGraphPointToWorld`
+bundles both steps so downstream consumers don't re-derive the
+contract.
+
+## Starter preset
+
+`f(x, y) = x² − y²` on `(x, y) ∈ [−1.5, 1.5]²`. Analytic data:
+
+- First partials: `f_x = 2x`, `f_y = −2y`.
+- Hessian: `f_xx = 2`, `f_yy = −2`, `f_xy = 0`.
+- Critical point at the origin (gradient vanishes).
+- `D = f_xx · f_yy − f_xy² = (2)(−2) − 0² = −4 < 0` ⇒ saddle.
+
+Visually the eponymous shape — math-X edges curve upward, math-Y edges
+curve downward. The §11.7 "what does it look like at the critical
+point?" question reads at a glance.
+
+### Note (forward-looking for #178)
+
+*All v0.8 preset critical points sit at the origin.* The starter
+saddle, the paraboloid (`x² + y²`), the inverted paraboloid
+(`−(x² + y²)`), the monkey saddle (`x³ − 3xy²`), and the D = 0
+degenerate min (`x⁴ + y⁴`) all have their critical point at
+`(x, y) = (0, 0)`. This is itself a useful pedagogical observation —
+critical points don't have to be "out there somewhere"; they live at
+a chosen origin so the focus can stay on the *local shape*, not the
+*location*. #179's critical-point markers will all render at the
+origin for v0.8.
+
+## Graph-surface primitive (`GraphSurface.ts`)
+
+`createGraphSurface(opts)` builds a meshed `BufferGeometry` of
+`res × res` vertices over the rectangular `(x, y)` domain, with
+analytic vertex normals derived from the supplied `gradF`.
+
+API contract (full TypeScript signatures in `GraphSurface.ts`):
+
+- `f: (x, y) => number` — function value in math-frame coords.
+- `gradF: (x, y) => readonly [number, number]` — analytic first partials
+  `(f_x, f_y)`. Required (not optional); used for vertex normals.
+- `domain: { xMin, xMax, yMin, yMax }` — math-frame `(x, y)` rectangle.
+- `res?: number` — grid resolution per side; default 128. Validated:
+  must be integer ≥ 2.
+- `surfaceCenter: THREE.Vector3` — worldspace anchor; math-origin lifts
+  to this point. Math-Z = 0 ⇒ world-Y = surfaceCenter.y.
+- `baseColor: THREE.Color` — diffuse color (cluster sky-blue for v0.8).
+
+Returns `{ mesh, material, dispose() }`. The mesh's per-vertex positions
+already bake in `surfaceCenter` (via `writeGraphPointToWorld`);
+`mesh.position` stays at world origin. `dispose()` invokes
+`geometry.dispose()` and `material.dispose()` — the exhibit's `unmount`
+calls it once.
+
+### Tessellation
+
+Uniform grid, `res = 128` for v0.8. Produces 16384 vertices and 32258
+triangles per surface — comfortably under Quest 3's per-frame triangle
+budget. Edge-to-edge tessellation distance on the starter preset at
+`[−1.5, 1.5]²` is `3.0 / 127 ≈ 23.6 mm` in world space. Adaptive
+tessellation deferred — all v0.8 presets are smooth polynomials with
+order-1 curvature across the rendered domain; uniform sampling doesn't
+waste triangles on flat regions in any concerning way.
+
+### Index buffer type
+
+Selected by vertex count: `res² > 65535` ⇒ `Uint32Array`; else
+`Uint16Array`. `res = 128` (16384 vertices) fits Uint16. `res = 256`
+(65536 vertices) tips into Uint32.
+
+### Validation
+
+`createGraphSurface` throws at construction if:
+
+- `res` is not an integer ≥ 2 (division by `res − 1` would NaN).
+- `domain.xMin >= domain.xMax` or non-finite (same for y).
+
+Validation errors surface as TypeScript exceptions with clear messages
+rather than as silent NaN geometry that would only show as faceting in
+headset smoke. The Vitest suite at
+`test/exhibits/saddle-extrema/GraphSurface.test.ts` pins all
+validation cases.
+
+### Analytic vertex normals
+
+Math-frame normal at `(x, y)`: the graph is the implicit surface
+`{ z − f(x, y) = 0 }`, whose gradient is `(−f_x, −f_y, 1)`. Normalized
+per vertex; converted to world frame via `writeMathToWorld(...)` as a
+direction (no `surfaceCenter` offset). Two scratch `Vector3` objects
+(one for position, one for normal) are allocated at builder-call time
+and reused across all `res²` iterations — reusing a single scratch
+would clobber position when computing normal in the same iteration.
+
+`computeVertexNormals()` is deliberately NOT used: it averages face
+normals over each vertex's incident triangles — accurate for arbitrary
+meshes but inferior for analytically-derived smooth surfaces.
+
+## Render
+
+`MeshStandardMaterial` with `metalness: 0`, `roughness: 0.6`,
+`side: THREE.DoubleSide`. Approximately matches the cluster's
+hand-rolled `0.2 + 0.8 × max(dot(n, L), 0)` lambert under the same
+`AmbientLight(0xffffff, 0.4)` + `DirectionalLight(0xffffff, 0.8)`
+lighting; BUT Cook-Torrance with `roughness=0.6` does produce a soft
+specular lobe, and PBR ambient injection differs from the hardcoded
+`0.2` floor.
+
+### Material parity fallback
+
+If headset smoke reveals visible parity drift (specular highlight at
+the saddle's edges; noticeably cooler or shinier than the
+implicit-surface cluster siblings during a scene swap), replace
+`MeshStandardMaterial` with a thin `ShaderMaterial` reproducing the
+cluster's exact lambert. The fallback shader (pre-coded in the #176
+plan):
+
+```glsl
+// Vertex
+varying vec3 vNormal;
+void main() {
+  // World-space normal (matches DoublePlane.ts precedent and the
+  // world-space uLightDir below). normalMatrix would put vNormal in
+  // view space, which would drift under head rotation.
+  vNormal = normalize(mat3(modelMatrix) * normal);
+  gl_Position = projectionMatrix * viewMatrix * modelMatrix
+              * vec4(position, 1.0);
+}
+
+// Fragment
+uniform vec3 uBaseColor;
+uniform vec3 uLightDir;
+varying vec3 vNormal;
+void main() {
+  float lambert = max(dot(normalize(vNormal), normalize(uLightDir)), 0.0);
+  gl_FragColor = vec4(uBaseColor * (0.2 + 0.8 * lambert), 1.0);
+}
+```
+
+The fallback is a one-line ctor swap inside `GraphSurface.ts`. Decision
+rule for smoke: "if any specular highlight is visible at the saddle's
+edges → swap before merge."
+
+## Domain framing + spatial-footprint
+
+The cluster's `BOUND = 3.0` is the **AABB half-extent**. Sibling
+raymarched surfaces live inside a BoxGeometry of side `2 × BOUND = 6 m`,
+spanning world-X `[-3, 3]`, world-Y `[-1.5, 4.5]` (centered on
+`SURFACE_CENTER.y = 1.5`), world-Z `[-7, -1]` (centered on
+`SURFACE_CENTER.z = -4`).
+
+The starter saddle on `[−1.5, 1.5]²` uses **half** the cluster's
+per-axis x/y extent (3 m × 3 m, vs. the cluster's 6 m × 6 m). The
+saddle's z-range `[−2.25, 2.25]` is inside the cluster's half-extent;
+the bottom corner sits at world-Y `= -0.75` (below `SURFACE_CENTER.y`
+by 2.25 m). The cluster doesn't render a floor and gradient-levels'
+family extends arbitrarily along ±math-Z too, so visually consistent
+with cluster convention.
+
+`[−1.5, 1.5]²` is a v0.8-starter lock; iterate in-headset if it reads
+too small. Future presets in #178 carry per-preset domains in the
+preset record.
+
+## Camera framing
+
+**Inherited from the shell's XR spawn camera** (world-origin, ~1.6 m
+head height, looking down −world-Z). No per-exhibit camera mutation.
+The cluster's `SURFACE_CENTER = (0, 1.5, −4)` anchor was chosen
+specifically so cluster surfaces sit at a comfortable viewing position
+from the spawn with no per-exhibit framing logic.
+
+Visibility check for the starter saddle:
+
+- Surface center 4 m forward of spawn.
+- Surface extends ±1.5 m in world-X (horizontal) and from world-Y
+  `−0.75` to `3.75` (full vertical extent 4.5 m).
+- Horizontal angular extent: `2 × atan(1.5 / 4) ≈ 41°`.
+- Vertical angular extent: from `atan((-0.75 - 1.6) / 4) ≈ −30°`
+  (bottom corner below eye level) to `atan((3.75 - 1.6) / 4) ≈ 28°`
+  (top corner above eye level), total ~58°.
+- Quest 3 FOV: ~96°×96° per eye. Saddle fits well within FOV.
+
+## Out of scope (v0.8 beyond #176)
+
+- **Point selection (#177).** Two (x, y) sliders walking the domain
+  + selected-point indicator on the surface. Per-slider variable +
+  value labels reusing the #170 scaffold. Introduces the
+  `SLIDER_RACK_CENTER` constant (deliberately deferred from #176 per
+  the v1 roundtable's GPT #4 finding — scope creep otherwise).
+- **Preset library (#178).** Four additional presets (paraboloid,
+  inverted paraboloid, monkey saddle, `x⁴ + y⁴`); preset-selector UI
+  (mirror the manipulator's `Preset` scaffold primitive); preset-record
+  interface extended with `hessF` (second partials for #181's readout).
+- **Critical-point markers (#179).** Small visual markers at the
+  analytically-known critical points (all at origin for v0.8 presets).
+- **Quadratic overlay (#180).** Always-on, translucent second-order
+  Taylor approximation rendered as a second graph surface hugging the
+  main one at the selected point. Reuses `GraphSurface` and
+  `writeGraphPointToWorld`. The §11.7–11.8 punch line.
+- **Hessian + classification readout (#181).** Live 2×2 Hessian,
+  `D = f_xx · f_yy − f_xy²`, classification verdict
+  (min / max / saddle / inconclusive).
+- **`GraphSurface` extraction to `src/scaffold/`.** Deferred until a
+  second scene wants the primitive (likely v1.x). The overlay in #180
+  is a same-scene consumer; doesn't count for the extract-on-second-
+  consumer rule.
+- **Numerical critical-point solver.** Preset-supplied analytical
+  critical points only.
+- **User-supplied `f(x, y)`.** Strong long-term motivator for the
+  primitive's design; input UX is its own scope (v1.x+).
+- **Runtime `f` / `gradF` non-finite-value validation.** v0.8 presets
+  are all polynomials; sampling validation is over-engineering against
+  a deferred risk.

--- a/src/exhibits/saddle-extrema/SPEC.md
+++ b/src/exhibits/saddle-extrema/SPEC.md
@@ -146,30 +146,20 @@ meshes but inferior for analytically-derived smooth surfaces.
 
 ## Render
 
-`MeshStandardMaterial` with `metalness: 0`, `roughness: 0.6`,
-`side: THREE.DoubleSide`. Approximately matches the cluster's
-hand-rolled `0.2 + 0.8 × max(dot(n, L), 0)` lambert under the same
-`AmbientLight(0xffffff, 0.4)` + `DirectionalLight(0xffffff, 0.8)`
-lighting; BUT Cook-Torrance with `roughness=0.6` does produce a soft
-specular lobe, and PBR ambient injection differs from the hardcoded
-`0.2` floor.
-
-### Material parity fallback
-
-If headset smoke reveals visible parity drift (specular highlight at
-the saddle's edges; noticeably cooler or shinier than the
-implicit-surface cluster siblings during a scene swap), replace
-`MeshStandardMaterial` with a thin `ShaderMaterial` reproducing the
-cluster's exact lambert. The fallback shader (pre-coded in the #176
-plan):
+Custom **`ShaderMaterial`** reproducing the cluster's exact lighting
+formula `uBaseColor * (0.2 + 0.8 × max(dot(n, L), 0))` under the
+scene's `AmbientLight(0xffffff, 0.4)` + `DirectionalLight(0xffffff,
+0.8)` (the directional light is decorative — `ShaderMaterial` doesn't
+auto-bind scene lights; the world-space `uLightDir` uniform drives the
+lambert directly). Vertex shader uses `mat3(modelMatrix) * normal`
+(not `normalMatrix * normal`) to keep the normal in world space,
+matching the world-space `uLightDir` and the cluster's `DoublePlane.ts:52`
+precedent.
 
 ```glsl
 // Vertex
 varying vec3 vNormal;
 void main() {
-  // World-space normal (matches DoublePlane.ts precedent and the
-  // world-space uLightDir below). normalMatrix would put vNormal in
-  // view space, which would drift under head rotation.
   vNormal = normalize(mat3(modelMatrix) * normal);
   gl_Position = projectionMatrix * viewMatrix * modelMatrix
               * vec4(position, 1.0);
@@ -185,9 +175,23 @@ void main() {
 }
 ```
 
-The fallback is a one-line ctor swap inside `GraphSurface.ts`. Decision
-rule for smoke: "if any specular highlight is visible at the saddle's
-edges → swap before merge."
+### Material history (why ShaderMaterial, not MeshStandardMaterial)
+
+The v1/v2 plan initially specified `MeshStandardMaterial({metalness: 0,
+roughness: 0.6})` as the default with the ShaderMaterial above as a
+"if smoke trips, swap to this" fallback (Sonnet #2 + DeepSeek #2 from
+the v1 roundtable both flagged the parity risk). **In-headset smoke on
+PR #182 confirmed the trip:** the saddle read as visibly off-white
+under PBR's Cook-Torrance BRDF + PBR ambient injection, while the
+cluster siblings (raymarched via `ImplicitSurface.ts`'s hand-rolled
+lambert) read as a clear light blue. The plan's pre-coded fallback is
+what ships in #176.
+
+The shader is identical in math to what the cluster's raymarched
+siblings use in their per-fragment `shadeHit(...)` — the only
+difference is that here it runs at the vertex-interpolated normal
+stage rather than at per-fragment ray-march hit points. Visual parity
+across the cluster is the design goal.
 
 ## Domain framing + spatial-footprint
 

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -1,0 +1,149 @@
+import * as THREE from 'three';
+import type { Exhibit, ExhibitContext } from '../../shell/Exhibit';
+import { CLUSTER_CALCULUS3 } from '../../shell/clusters';
+import { registerExhibit } from '../../shell/registry';
+import { DEFAULT_AXIS_COLORS } from '@/scaffold/design/tokens';
+import { WorldAxes } from '@/scaffold/ui/WorldAxes';
+import {
+  createGraphSurface,
+  type GraphSurfaceDomain,
+  type GraphSurfaceHandles,
+} from './GraphSurface';
+
+// Saddle / extrema scene (#175 epic, #176 foundation). Fourth and final
+// member of the calculus3 cluster, alongside quadrics, tangent-planes,
+// and gradient-levels.
+//
+// Pedagogy target: APPM 2350 §11.7–11.8 (Maximum/Minimum Values + Second
+// Derivatives Test). Stuck-point: students mechanically compute D =
+// f_xx·f_yy − f_xy² without seeing that they're asking "what does this
+// surface look like in a small neighborhood?" The quadratic-overlay
+// punch line lands in #180; this PR establishes the substrate — meshed
+// graph surface for z = f(x, y) — that #177 (point selection), #178
+// (preset library), #179 (critical-point markers), #180 (overlay), and
+// #181 (Hessian readout) attach to.
+//
+// Architectural divergence from the prior three cluster scenes: those
+// render an implicit surface via the GPU raymarcher. Saddle-extrema
+// renders a graph form z = f(x, y) — a meshed BufferGeometry, not a
+// raymarched bounding cube. See GraphSurface.ts for the primitive.
+
+// ────────────────────────────────────────────────────────────────────
+// Constants — cluster-shared anchors carry verbatim from siblings so
+// SceneRack swaps don't visually relocate the surface.
+// ────────────────────────────────────────────────────────────────────
+
+const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
+const AXIS_INDICATOR_POSITION = new THREE.Vector3(0.35, 1.17, -0.7);
+const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
+const BASE_COLOR = new THREE.Color(0.4, 0.7, 0.95);
+
+// ────────────────────────────────────────────────────────────────────
+// Starter preset — z = x² − y² on [-1.5, 1.5]². Sole preset for #176.
+// The `id` and `label` fields exist now to pre-pave #178's preset-
+// selector UI (which will mirror the manipulator's `Preset` primitive);
+// #176 has only one preset and never reads them.
+//
+// `hessF` (second partials for #181's Hessian readout) is intentionally
+// absent from this interface — added in #178 alongside the preset
+// library, because no #176-scope consumer needs second partials.
+// Implementer note: do not try to "complete" the interface in this PR.
+// ────────────────────────────────────────────────────────────────────
+
+interface SaddleExtremaPreset {
+  readonly id: string;
+  readonly label: string;
+  readonly f: (x: number, y: number) => number;
+  readonly gradF: (x: number, y: number) => readonly [number, number];
+  readonly domain: GraphSurfaceDomain;
+  readonly res?: number;
+}
+
+const STARTER_PRESET: SaddleExtremaPreset = {
+  id: 'saddle',
+  label: 'Saddle (x² − y²)',
+  f: (x, y) => x * x - y * y,
+  gradF: (x, y) => [2 * x, -2 * y],
+  domain: { xMin: -1.5, xMax: 1.5, yMin: -1.5, yMax: 1.5 },
+};
+
+// ────────────────────────────────────────────────────────────────────
+// Module-scoped state — named handles initialized in mount, disposed
+// inline in unmount. No `controllers` or `SLIDER_RACK_CENTER` capture
+// in #176 — no consumer until #177's sliders arrive (TS strict-mode
+// `noUnusedLocals` would also reject dead capture).
+// ────────────────────────────────────────────────────────────────────
+
+let graphSurface: GraphSurfaceHandles | undefined;
+let worldAxes: WorldAxes | undefined;
+let camera: THREE.Camera | undefined;
+
+// ────────────────────────────────────────────────────────────────────
+// Exhibit
+// ────────────────────────────────────────────────────────────────────
+
+const saddleExtremaExhibit: Exhibit = {
+  id: 'saddle-extrema',
+  title: 'Critical points',
+  cluster: CLUSTER_CALCULUS3,
+
+  mount({ group, camera: cam }: ExhibitContext) {
+    camera = cam;
+
+    // Ambient + directional lights matching cluster siblings. The graph
+    // surface uses MeshStandardMaterial under these lights to approximate
+    // the cluster's hand-rolled lambert; SPEC.md "Material parity fallback"
+    // documents the ShaderMaterial swap if smoke shows divergence.
+    group.add(new THREE.AmbientLight(0xffffff, 0.4));
+    const directional = new THREE.DirectionalLight(0xffffff, 0.8);
+    directional.position.copy(LIGHT_DIR).multiplyScalar(5);
+    group.add(directional);
+
+    graphSurface = createGraphSurface({
+      f: STARTER_PRESET.f,
+      gradF: STARTER_PRESET.gradF,
+      domain: STARTER_PRESET.domain,
+      res: STARTER_PRESET.res ?? 128,
+      surfaceCenter: SURFACE_CENTER,
+      baseColor: BASE_COLOR.clone(),
+    });
+    group.add(graphSurface.mesh);
+
+    worldAxes = new WorldAxes({ axisColors: DEFAULT_AXIS_COLORS });
+    worldAxes.group.position.copy(AXIS_INDICATOR_POSITION);
+    group.add(worldAxes.group);
+  },
+
+  update() {
+    // No sliders or per-frame uniforms in #176. Keep WorldAxes labels
+    // billboarded so they read at any user yaw — same per-frame contract
+    // as cluster siblings.
+    if (worldAxes && camera) worldAxes.faceCamera(camera);
+  },
+
+  unmount() {
+    // No controller grabs to release in #176 (no sliders yet); #177 will
+    // walk the (x, y) sliders here.
+
+    graphSurface?.dispose();
+    graphSurface = undefined;
+    worldAxes?.dispose();
+    worldAxes = undefined;
+
+    // Drop external references so a re-mount starts clean. The shell
+    // removes ctx.group + descendants automatically.
+    camera = undefined;
+  },
+
+  onSelectStart() {
+    // No interactive elements in #176; #177 introduces (x, y) sliders.
+  },
+
+  onSelectEnd() {
+    // Symmetric — no grabs to release.
+  },
+};
+
+registerExhibit(saddleExtremaExhibit);
+
+export default saddleExtremaExhibit;

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -106,6 +106,7 @@ const saddleExtremaExhibit: Exhibit = {
       res: STARTER_PRESET.res ?? 128,
       surfaceCenter: SURFACE_CENTER,
       baseColor: BASE_COLOR.clone(),
+      lightDir: LIGHT_DIR.clone(),
     });
     group.add(graphSurface.mesh);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,12 +6,13 @@ import { bootShell } from './shell/shell';
 // Order matters: `registerExhibit` appends in import order, the shell's
 // cluster filter preserves it, and `clusterExhibits[0]` is the bare-URL
 // boot default. Quadrics stays first (cluster default + first SceneRack
-// tab); tangent-planes second; gradient-levels third (pre-warmed as a
-// non-default sibling at boot). `hello` stays last — cluster-less,
-// filtered out of the rack.
+// tab); tangent-planes second; gradient-levels third; saddle-extrema
+// fourth (pre-warmed as non-default siblings at boot). `hello` stays
+// last — cluster-less, filtered out of the rack.
 import './exhibits/quadrics';
 import './exhibits/tangent-planes';
 import './exhibits/gradient-levels';
+import './exhibits/saddle-extrema';
 import './exhibits/hello';
 
 bootShell();

--- a/test/exhibits/saddle-extrema/GraphSurface.test.ts
+++ b/test/exhibits/saddle-extrema/GraphSurface.test.ts
@@ -24,6 +24,7 @@ function makeSurface(overrides: Partial<{
   res: number;
   surfaceCenter: THREE.Vector3;
   baseColor: THREE.Color;
+  lightDir: THREE.Vector3;
 }> = {}) {
   return createGraphSurface({
     f: STARTER_F,
@@ -32,6 +33,7 @@ function makeSurface(overrides: Partial<{
     res: 3,
     surfaceCenter: new THREE.Vector3(0, 1.5, -4),
     baseColor: new THREE.Color(0.4, 0.7, 0.95),
+    lightDir: new THREE.Vector3(0.4, 0.8, 0.5).normalize(),
     ...overrides,
   });
 }

--- a/test/exhibits/saddle-extrema/GraphSurface.test.ts
+++ b/test/exhibits/saddle-extrema/GraphSurface.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+import {
+  createGraphSurface,
+  writeGraphPointToWorld,
+} from '@/exhibits/saddle-extrema/GraphSurface';
+
+// Vitest coverage for the meshed graph-surface primitive (#176; GPT #1 from
+// the v1 roundtable). The primitive is a pure helper carrying the highest
+// math-risk surface in the v0.8 saddle-extrema PR: grid indexing, math-frame
+// mapping, and analytic vertex normals. Scope is the pure helper only —
+// scene-registration / mount / unmount plumbing is exercised by the shell's
+// boot-time pre-warm cycle, not here.
+
+const STARTER_F = (x: number, y: number) => x * x - y * y;
+const STARTER_GRAD_F = (x: number, y: number) =>
+  [2 * x, -2 * y] as const;
+const STARTER_DOMAIN = { xMin: -1.5, xMax: 1.5, yMin: -1.5, yMax: 1.5 };
+
+function makeSurface(overrides: Partial<{
+  f: (x: number, y: number) => number;
+  gradF: (x: number, y: number) => readonly [number, number];
+  domain: { xMin: number; xMax: number; yMin: number; yMax: number };
+  res: number;
+  surfaceCenter: THREE.Vector3;
+  baseColor: THREE.Color;
+}> = {}) {
+  return createGraphSurface({
+    f: STARTER_F,
+    gradF: STARTER_GRAD_F,
+    domain: STARTER_DOMAIN,
+    res: 3,
+    surfaceCenter: new THREE.Vector3(0, 1.5, -4),
+    baseColor: new THREE.Color(0.4, 0.7, 0.95),
+    ...overrides,
+  });
+}
+
+describe('writeGraphPointToWorld', () => {
+  it('remaps math (x, y, z) to world (x, z, -y) then adds surfaceCenter', () => {
+    const out = new THREE.Vector3();
+    writeGraphPointToWorld(1, 2, 3, new THREE.Vector3(0, 1.5, -4), out);
+    // math (1, 2, 3) -> world (1, 3, -2), then + (0, 1.5, -4) -> (1, 4.5, -6).
+    expect(out.x).toBeCloseTo(1);
+    expect(out.y).toBeCloseTo(4.5);
+    expect(out.z).toBeCloseTo(-6);
+  });
+
+  it('math-origin lifts to the surfaceCenter', () => {
+    const out = new THREE.Vector3();
+    writeGraphPointToWorld(0, 0, 0, new THREE.Vector3(0, 1.5, -4), out);
+    expect(out.x).toBeCloseTo(0);
+    expect(out.y).toBeCloseTo(1.5);
+    expect(out.z).toBeCloseTo(-4);
+  });
+});
+
+describe('createGraphSurface — geometry shape', () => {
+  it('emits res² vertices (positions and normals)', () => {
+    const { mesh } = makeSurface({ res: 3 });
+    const position = mesh.geometry.getAttribute('position');
+    const normal = mesh.geometry.getAttribute('normal');
+    expect(position.count).toBe(9);
+    expect(normal.count).toBe(9);
+  });
+
+  it('emits (res-1)² × 2 triangles', () => {
+    const { mesh } = makeSurface({ res: 3 });
+    const index = mesh.geometry.getIndex();
+    expect(index).not.toBeNull();
+    // 2² quads × 2 triangles × 3 indices = 24 index entries.
+    expect(index!.count).toBe(24);
+  });
+
+  it('uses Uint16Array indices when res² ≤ 65535', () => {
+    const { mesh } = makeSurface({ res: 3 });
+    const index = mesh.geometry.getIndex()!;
+    expect(index.array).toBeInstanceOf(Uint16Array);
+  });
+
+  it('uses Uint32Array indices when res² > 65535', () => {
+    // res = 256 ⇒ res² = 65536 > 65535; tips into Uint32.
+    const { mesh, dispose } = makeSurface({ res: 256 });
+    const index = mesh.geometry.getIndex()!;
+    try {
+      expect(index.array).toBeInstanceOf(Uint32Array);
+    } finally {
+      dispose();
+    }
+  });
+});
+
+describe('createGraphSurface — math-frame mapping (sample positions)', () => {
+  // Uses res = 3 with domain [-1, 1]² and surfaceCenter (0, 1.5, -4) so
+  // sample vertices land at predictable world coords:
+  //   (i, j) = (1, 1): math (0, 0, 0)   → world (0, 1.5, -4)
+  //   (i, j) = (0, 0): math (-1, -1, 0) → world (-1, 1.5, -3)
+  //   (i, j) = (2, 0): math (1, -1, 0)  → world (1, 1.5, -3)
+  //   (i, j) = (0, 2): math (-1, 1, 0)  → world (-1, 1.5, -5)
+  // A flipped math-frame mapping (e.g. math-Y → +world-Z instead of
+  // -world-Z) would shift the corners; the test fails immediately.
+
+  function makeFlatSurface() {
+    return makeSurface({
+      f: () => 0,
+      gradF: () => [0, 0] as const,
+      domain: { xMin: -1, xMax: 1, yMin: -1, yMax: 1 },
+      res: 3,
+      surfaceCenter: new THREE.Vector3(0, 1.5, -4),
+    });
+  }
+
+  it('center vertex (1, 1) lifts to the surfaceCenter', () => {
+    const { mesh } = makeFlatSurface();
+    const p = mesh.geometry.getAttribute('position');
+    const idx = 1 * 3 + 1; // (j, i) = (1, 1)
+    expect(p.getX(idx)).toBeCloseTo(0);
+    expect(p.getY(idx)).toBeCloseTo(1.5);
+    expect(p.getZ(idx)).toBeCloseTo(-4);
+  });
+
+  it('corner (0, 0) sits at world (-1, 1.5, -3)', () => {
+    const { mesh } = makeFlatSurface();
+    const p = mesh.geometry.getAttribute('position');
+    const idx = 0; // (j, i) = (0, 0)
+    expect(p.getX(idx)).toBeCloseTo(-1);
+    expect(p.getY(idx)).toBeCloseTo(1.5);
+    expect(p.getZ(idx)).toBeCloseTo(-3);
+  });
+
+  it('corner (2, 0) sits at world (1, 1.5, -3)', () => {
+    const { mesh } = makeFlatSurface();
+    const p = mesh.geometry.getAttribute('position');
+    const idx = 2; // (j, i) = (0, 2)
+    expect(p.getX(idx)).toBeCloseTo(1);
+    expect(p.getY(idx)).toBeCloseTo(1.5);
+    expect(p.getZ(idx)).toBeCloseTo(-3);
+  });
+
+  it('corner (0, 2) sits at world (-1, 1.5, -5)', () => {
+    const { mesh } = makeFlatSurface();
+    const p = mesh.geometry.getAttribute('position');
+    const idx = 2 * 3 + 0; // (j, i) = (2, 0)
+    expect(p.getX(idx)).toBeCloseTo(-1);
+    expect(p.getY(idx)).toBeCloseTo(1.5);
+    expect(p.getZ(idx)).toBeCloseTo(-5);
+  });
+
+  it('saddle z = x² − y² lifts math-X edges up and math-Y edges down', () => {
+    const { mesh } = makeSurface({
+      domain: { xMin: -1, xMax: 1, yMin: -1, yMax: 1 },
+      res: 3,
+    });
+    const p = mesh.geometry.getAttribute('position');
+    // (i=2, j=1): math (1, 0, 1) → world (1, 2.5, -4) — up by 1 from
+    // surfaceCenter.y because math-Z = 1.
+    expect(p.getY(1 * 3 + 2)).toBeCloseTo(2.5);
+    // (i=1, j=2): math (0, 1, -1) → world (0, 0.5, -5) — down by 1 from
+    // surfaceCenter.y because math-Z = -1.
+    expect(p.getY(2 * 3 + 1)).toBeCloseTo(0.5);
+  });
+});
+
+describe('createGraphSurface — analytic normals', () => {
+  // Math-frame normal for z = f(x, y): n_math = normalize(-f_x, -f_y, 1).
+  // For z = x² − y², f_x = 2x, f_y = -2y, so n_math = normalize(-2x, 2y, 1).
+  // World mapping: math (a, b, c) → world (a, c, -b).
+  // So at (x, y), n_world = normalize(-2x, 1, -2y) (before normalization).
+
+  it('saddle origin normal points straight up in world coords', () => {
+    const { mesh } = makeSurface({
+      domain: { xMin: -1, xMax: 1, yMin: -1, yMax: 1 },
+      res: 3,
+    });
+    const n = mesh.geometry.getAttribute('normal');
+    const idx = 1 * 3 + 1; // center vertex (i=1, j=1)
+    expect(n.getX(idx)).toBeCloseTo(0);
+    expect(n.getY(idx)).toBeCloseTo(1);
+    expect(n.getZ(idx)).toBeCloseTo(0);
+  });
+
+  it('saddle off-center normal tilts correctly in world coords', () => {
+    const { mesh } = makeSurface({
+      domain: { xMin: -1, xMax: 1, yMin: -1, yMax: 1 },
+      res: 3,
+    });
+    const n = mesh.geometry.getAttribute('normal');
+    // (i=2, j=1): (x, y) = (1, 0); math-normal (-2, 0, 1) → world (-2, 1, 0)
+    // normalized → (-0.8944, 0.4472, 0).
+    const idx = 1 * 3 + 2;
+    const len = Math.sqrt(5);
+    expect(n.getX(idx)).toBeCloseTo(-2 / len);
+    expect(n.getY(idx)).toBeCloseTo(1 / len);
+    expect(n.getZ(idx)).toBeCloseTo(0);
+  });
+
+  it('saddle off-center normal in math-Y tilts toward +world-Z', () => {
+    const { mesh } = makeSurface({
+      domain: { xMin: -1, xMax: 1, yMin: -1, yMax: 1 },
+      res: 3,
+    });
+    const n = mesh.geometry.getAttribute('normal');
+    // (i=1, j=2): (x, y) = (0, 1); math-normal (0, 2, 1) → world (0, 1, -2)
+    // normalized → (0, 0.4472, -0.8944). Math-Y = +1 maps to world-Z = -1,
+    // so the normal's −math-Y² direction (negative tilt of f) shows up as
+    // world-Z = -2 component.
+    const idx = 2 * 3 + 1;
+    const len = Math.sqrt(5);
+    expect(n.getX(idx)).toBeCloseTo(0);
+    expect(n.getY(idx)).toBeCloseTo(1 / len);
+    expect(n.getZ(idx)).toBeCloseTo(-2 / len);
+  });
+
+  it('every emitted normal is unit-length', () => {
+    const { mesh } = makeSurface({ res: 5 });
+    const n = mesh.geometry.getAttribute('normal');
+    for (let i = 0; i < n.count; i++) {
+      const mag = Math.sqrt(
+        n.getX(i) ** 2 + n.getY(i) ** 2 + n.getZ(i) ** 2,
+      );
+      expect(mag).toBeCloseTo(1);
+    }
+  });
+});
+
+describe('createGraphSurface — index winding', () => {
+  // For a flat surface with up-facing normal, the cross product of two
+  // edges of each emitted triangle (taken in winding order) should also
+  // point up (positive world-Y). A flipped-winding bug would show as a
+  // negative-Y cross product.
+
+  it('triangle winding agrees with up-facing analytic normal on a flat surface', () => {
+    const { mesh } = makeSurface({
+      f: () => 0,
+      gradF: () => [0, 0] as const,
+      domain: { xMin: -1, xMax: 1, yMin: -1, yMax: 1 },
+      res: 3,
+    });
+    const p = mesh.geometry.getAttribute('position');
+    const idx = mesh.geometry.getIndex()!;
+
+    // First triangle: bl → br → tl. Edges (br - bl) and (tl - bl).
+    const i0 = idx.getX(0);
+    const i1 = idx.getX(1);
+    const i2 = idx.getX(2);
+
+    const e1 = new THREE.Vector3(
+      p.getX(i1) - p.getX(i0),
+      p.getY(i1) - p.getY(i0),
+      p.getZ(i1) - p.getZ(i0),
+    );
+    const e2 = new THREE.Vector3(
+      p.getX(i2) - p.getX(i0),
+      p.getY(i2) - p.getY(i0),
+      p.getZ(i2) - p.getZ(i0),
+    );
+    const cross = new THREE.Vector3().crossVectors(e1, e2);
+    expect(cross.y).toBeGreaterThan(0);
+  });
+});
+
+describe('createGraphSurface — validation', () => {
+  it('throws when res is non-integer', () => {
+    expect(() => makeSurface({ res: 1.5 })).toThrow(/res must be an integer/);
+  });
+
+  it('throws when res < 2', () => {
+    expect(() => makeSurface({ res: 1 })).toThrow(/res must be an integer/);
+    expect(() => makeSurface({ res: 0 })).toThrow(/res must be an integer/);
+    expect(() => makeSurface({ res: -2 })).toThrow(/res must be an integer/);
+  });
+
+  it('throws when xMin >= xMax', () => {
+    expect(() =>
+      makeSurface({ domain: { xMin: 1, xMax: 1, yMin: -1, yMax: 1 } }),
+    ).toThrow(/domain\.xMin/);
+    expect(() =>
+      makeSurface({ domain: { xMin: 2, xMax: 1, yMin: -1, yMax: 1 } }),
+    ).toThrow(/domain\.xMin/);
+  });
+
+  it('throws when yMin >= yMax', () => {
+    expect(() =>
+      makeSurface({ domain: { xMin: -1, xMax: 1, yMin: 0, yMax: 0 } }),
+    ).toThrow(/domain\.yMin/);
+  });
+
+  it('throws on non-finite domain bounds', () => {
+    expect(() =>
+      makeSurface({ domain: { xMin: NaN, xMax: 1, yMin: -1, yMax: 1 } }),
+    ).toThrow(/domain\.xMin/);
+    expect(() =>
+      makeSurface({
+        domain: { xMin: -1, xMax: 1, yMin: -Infinity, yMax: 1 },
+      }),
+    ).toThrow(/domain\.yMin/);
+  });
+});
+
+describe('createGraphSurface — dispose', () => {
+  it('disposes both geometry and material', () => {
+    const handles = makeSurface({ res: 3 });
+    const geomSpy = vi.spyOn(handles.mesh.geometry, 'dispose');
+    const matSpy = vi.spyOn(handles.material, 'dispose');
+    handles.dispose();
+    expect(geomSpy).toHaveBeenCalledTimes(1);
+    expect(matSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #176

## Summary

First sub-issue of #175 (saddle / extrema scene epic). Registers the **fourth and final** scene of the v1.0 `calculus3` cluster, and introduces a new **meshed graph-surface rendering primitive** — architectural divergence from the cluster's prior three raymarched implicit-surface scenes, since graph form `z = f(x, y)` doesn't fit the `ImplicitSurface` harness and meshed `BufferGeometry` is the natural primitive.

Ships with one locked starter preset: `z = x² − y²` on `(x, y) ∈ [−1.5, 1.5]²` — critical point at origin, Hessian `[[2,0],[0,−2]]`, `D = −4` ⇒ saddle. Foundation for #177 (point selection), #178 (preset library), #179 (critical-point markers), #180 (quadratic overlay — the §11.7–11.8 punch line), #181 (Hessian + classification readout).

Plan went through `/roundtable-plan-review` per the validated v0.x foundational-work cadence (Sonnet + GPT-5.5 Pro + DeepSeek V4 Pro). v1 → v2 closed 14 findings (3 convergent + 11 singletons); focused second-Sonnet closure pass confirmed gaps closed and caught two v2-introduced gaps (HIGH normal-space mismatch in fallback ShaderMaterial, LOW bookkeeping in camera-framing FOV calc), both fixed inline before implementation.

## Test plan

**Automated (already green locally):**

- [ ] `npx vitest run` — 263 tests pass (22 new in `test/exhibits/saddle-extrema/GraphSurface.test.ts` covering vertex/index counts, index-buffer-type selection by `res² > 65535`, math-frame mapping sample positions, analytic normals, triangle winding, validation throws, dispose).
- [ ] `npx tsc --noEmit` — clean.
- [ ] `npm run build` — clean.
- [ ] Pre-commit hooks (gitleaks + standard fixers + eslint) — passed.

**Headset smoke on Cloudflare PR preview** (per the project convention — see `CLAUDE.md` "Headset smoke-testing"). Walk through these in the Quest browser at the preview URL once the `pr-preview` workflow comments it:

- [ ] **Boot at `?exhibit=saddle-extrema`.** Saddle renders at `SURFACE_CENTER = (0, 1.5, -4)` as the eponymous `z = x² − y²` shape — math-X edges curve upward (world-Y rising), math-Y edges curve downward. WorldAxes indicator at its anchor on the right, letter labels readable. If the saddle's curve directions are swapped, the math-frame mapping is wrong — abort and re-derive.
- [ ] **Cluster swap.** Tap the SceneRack: `saddle-extrema → gradient-levels → tangent-planes → quadrics → saddle-extrema`. All four surfaces render; 4-tab rack reads as visually balanced (`Quadrics` / `Tangent planes` / `Level surfaces` / `Critical points` — 8/14/14/15 chars). When in quadrics, the 4-tab rack does NOT collide with quadrics' SectionTab column at x = -0.44 (column sits cleanly between the 2nd and 3rd tabs). No console errors. Pre-warm passed at boot.
- [ ] **Tab reach.** Leftmost (Quadrics at x = -0.74) and rightmost (Critical points at x = -0.14) tabs both comfortably reachable from spawn.
- [ ] **Surface shading + lambert-fallback decision.** Walk around the saddle (head-rotation only). Surface is doubly-shaded; vertex normals smooth (no faceted banding). **Lambert fallback check:** swap between `saddle-extrema` and `gradient-levels` — the saddle's surface tint, ambient floor, and highlight character must match the implicit-surface sibling within visible tolerance. **If any specular highlight is visible at the saddle's edges, or the saddle reads as visibly cooler/shinier than the sibling, swap `MeshStandardMaterial` for the pre-coded `ShaderMaterial` fallback documented in `SPEC.md` "Material parity fallback" before merge.**
- [ ] **URL routing.** Reload with `?exhibit=saddle-extrema` (deep link); reload without `?exhibit` (quadrics still the cluster default).
- [ ] **Disposal regression check.** Capture `renderer.info.memory.geometries` + `renderer.info.programs.length` baseline; swap between all four scenes 5 times each; re-capture. Counts at end must equal baseline ± 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)