### PR TITLE
feat(scene): saddle-extrema — (x, y) point-selection sliders walking the domain (#177)

### DIFF
--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -2,10 +2,17 @@ import * as THREE from 'three';
 import type { Exhibit, ExhibitContext } from '../../shell/Exhibit';
 import { CLUSTER_CALCULUS3 } from '../../shell/clusters';
 import { registerExhibit } from '../../shell/registry';
-import { DEFAULT_AXIS_COLORS } from '@/scaffold/design/tokens';
+import {
+  BLUISH_GREEN,
+  DEFAULT_AXIS_COLORS,
+  VERMILLION,
+} from '@/scaffold/design/tokens';
+import { Label } from '@/scaffold/ui/Label';
+import { Slider } from '@/scaffold/ui/Slider';
 import { WorldAxes } from '@/scaffold/ui/WorldAxes';
 import {
   createGraphSurface,
+  writeGraphPointToWorld,
   type GraphSurfaceDomain,
   type GraphSurfaceHandles,
 } from './GraphSurface';
@@ -38,6 +45,54 @@ const AXIS_INDICATOR_POSITION = new THREE.Vector3(0.35, 1.17, -0.7);
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
 const BASE_COLOR = new THREE.Color(0.4, 0.7, 0.95);
 
+// Slider rack — two-row symmetric straddle around SLIDER_RACK_CENTER. The
+// 3-row top-heavy pattern from gradient-levels (θ/φ/k at [center+pitch,
+// center, center-pitch]) doesn't carry over cleanly to a 2-row rack; the
+// straddle layout reads as balanced.
+const SLIDER_RACK_CENTER = new THREE.Vector3(0, 1.0, -0.7);
+const SLIDER_ROW_PITCH = 0.14;
+const X_SLIDER_Y = SLIDER_RACK_CENTER.y + SLIDER_ROW_PITCH / 2;
+const Y_SLIDER_Y = SLIDER_RACK_CENTER.y - SLIDER_ROW_PITCH / 2;
+
+// Slider design feel — quadric-tuned constants, ported from cluster
+// siblings. Snap detents at [0] only: slider-canonical origin, not
+// critical-point-aware (the coincidence that v0.8 preset critical points
+// sit at the origin makes origin-snap LAND on the critical point, but the
+// snap mechanism is preset-independent). Critical-point-aware snap is
+// deferred to #179.
+const SLIDER_SNAP_DETENT = 0.05;
+const GRAB_RADIUS_MULTIPLIER = 2.75;
+const SLIDER_SNAP_POINTS: readonly number[] = [0];
+
+// Initial pose — off origin-snap, off endpoints, off both axes,
+// non-equal — so first-frame drag responds in any direction.
+const X_INITIAL = 0.5;
+const Y_INITIAL = 0.3;
+
+// Per-slider variable + value label layout — verbatim from gradient-levels'
+// #170 layout. Right-anchored so worst-case secondary text "−1.50" stays
+// clear of the slider thumb at any value.
+const SLIDER_LABEL_X_OFFSET = -0.20;
+const SLIDER_LABEL_PRIMARY_FONT_SIZE = 0.05;
+const SLIDER_LABEL_SECONDARY_FONT_SIZE = 0.035;
+const SLIDER_LABEL_LINE_GAP = 0.008;
+
+// Indicator — verbatim port from cluster siblings for visual consistency.
+const INDICATOR_RADIUS = 0.04;
+const INDICATOR_COLOR = 0xdddddd;
+
+// Cluster glyph convention for negative-magnitude formatting.
+const SLIDER_VALUE_MINUS = '−'; // U+2212
+
+// Local linear-decimal formatter for the per-slider value labels.
+// Identical in shape to gradient-levels' local helper (#170 history);
+// this scene becomes consumer #2 — extract-on-third-use rule honored, so
+// kept local rather than extracted to scaffold/ui.
+function formatLinearDecimal(v: number): string {
+  if (v < 0) return `${SLIDER_VALUE_MINUS}${Math.abs(v).toFixed(2)}`;
+  return v.toFixed(2);
+}
+
 // ────────────────────────────────────────────────────────────────────
 // Starter preset — z = x² − y² on [-1.5, 1.5]². Sole preset for #176.
 // The `id` and `label` fields exist now to pre-pave #178's preset-
@@ -69,14 +124,23 @@ const STARTER_PRESET: SaddleExtremaPreset = {
 
 // ────────────────────────────────────────────────────────────────────
 // Module-scoped state — named handles initialized in mount, disposed
-// inline in unmount. No `controllers` or `SLIDER_RACK_CENTER` capture
-// in #176 — no consumer until #177's sliders arrive (TS strict-mode
-// `noUnusedLocals` would also reject dead capture).
+// inline in unmount.
 // ────────────────────────────────────────────────────────────────────
 
 let graphSurface: GraphSurfaceHandles | undefined;
 let worldAxes: WorldAxes | undefined;
+let xSlider: Slider | undefined;
+let ySlider: Slider | undefined;
+let xLabel: Label | undefined;
+let yLabel: Label | undefined;
+let indicator: THREE.Mesh | undefined;
 let camera: THREE.Camera | undefined;
+let controllers: readonly THREE.Object3D[] = [];
+
+// Persistent scratch — allocated once at module scope, mutated each
+// frame in update(). One per-frame allocation hot path #177 introduces
+// is the indicator-position write; this scratch keeps it allocation-free.
+const indicatorWorld = new THREE.Vector3();
 
 // ────────────────────────────────────────────────────────────────────
 // Exhibit
@@ -87,13 +151,15 @@ const saddleExtremaExhibit: Exhibit = {
   title: 'Critical points',
   cluster: CLUSTER_CALCULUS3,
 
-  mount({ group, camera: cam }: ExhibitContext) {
+  mount({ group, camera: cam, controllers: shellControllers }: ExhibitContext) {
     camera = cam;
+    controllers = shellControllers;
 
-    // Ambient + directional lights matching cluster siblings. The graph
-    // surface uses MeshStandardMaterial under these lights to approximate
-    // the cluster's hand-rolled lambert; SPEC.md "Material parity fallback"
-    // documents the ShaderMaterial swap if smoke shows divergence.
+    // Ambient + directional lights match cluster siblings. The graph
+    // surface uses a custom ShaderMaterial reproducing the cluster's
+    // lambert formula; the DirectionalLight here is decorative for the
+    // surface (ShaderMaterial doesn't auto-bind scene lights) but lights
+    // accessory geometry (indicator).
     group.add(new THREE.AmbientLight(0xffffff, 0.4));
     const directional = new THREE.DirectionalLight(0xffffff, 0.8);
     directional.position.copy(LIGHT_DIR).multiplyScalar(5);
@@ -110,38 +176,183 @@ const saddleExtremaExhibit: Exhibit = {
     });
     group.add(graphSurface.mesh);
 
+    // x slider — vermillion (math-X axis tint). Honest pickup since
+    // x IS the math-X axis value, not a derived parameter. Mirrors
+    // the quadrics manipulator's (a, b, c) coefficient-slider color
+    // convention.
+    xSlider = new Slider({
+      label: 'x',
+      min: STARTER_PRESET.domain.xMin,
+      max: STARTER_PRESET.domain.xMax,
+      initial: X_INITIAL,
+      snapDetent: SLIDER_SNAP_DETENT,
+      snapPoints: SLIDER_SNAP_POINTS,
+      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER,
+      baseColor: VERMILLION,
+      thumbShape: 'sphere',
+    });
+    xSlider.group.position.set(
+      SLIDER_RACK_CENTER.x,
+      X_SLIDER_Y,
+      SLIDER_RACK_CENTER.z,
+    );
+    group.add(xSlider.group);
+
+    // y slider — bluish-green (math-Y axis tint).
+    ySlider = new Slider({
+      label: 'y',
+      min: STARTER_PRESET.domain.yMin,
+      max: STARTER_PRESET.domain.yMax,
+      initial: Y_INITIAL,
+      snapDetent: SLIDER_SNAP_DETENT,
+      snapPoints: SLIDER_SNAP_POINTS,
+      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER,
+      baseColor: BLUISH_GREEN,
+      thumbShape: 'sphere',
+    });
+    ySlider.group.position.set(
+      SLIDER_RACK_CENTER.x,
+      Y_SLIDER_Y,
+      SLIDER_RACK_CENTER.z,
+    );
+    group.add(ySlider.group);
+
+    // Per-slider labels — primary = variable name (set once at mount),
+    // secondary = live value (per-frame in update()).
+    xLabel = new Label({
+      primaryFontSize: SLIDER_LABEL_PRIMARY_FONT_SIZE,
+      secondaryFontSize: SLIDER_LABEL_SECONDARY_FONT_SIZE,
+      lineGap: SLIDER_LABEL_LINE_GAP,
+      anchorX: 'right',
+    });
+    xLabel.setPrimary('x');
+    xLabel.group.position.set(
+      SLIDER_RACK_CENTER.x + SLIDER_LABEL_X_OFFSET,
+      X_SLIDER_Y,
+      SLIDER_RACK_CENTER.z,
+    );
+    group.add(xLabel.group);
+
+    yLabel = new Label({
+      primaryFontSize: SLIDER_LABEL_PRIMARY_FONT_SIZE,
+      secondaryFontSize: SLIDER_LABEL_SECONDARY_FONT_SIZE,
+      lineGap: SLIDER_LABEL_LINE_GAP,
+      anchorX: 'right',
+    });
+    yLabel.setPrimary('y');
+    yLabel.group.position.set(
+      SLIDER_RACK_CENTER.x + SLIDER_LABEL_X_OFFSET,
+      Y_SLIDER_Y,
+      SLIDER_RACK_CENTER.z,
+    );
+    group.add(yLabel.group);
+
+    // Indicator — sphere at the selected point. Position seeded at the
+    // boot pose so the first paint shows the correct location even
+    // before update() runs.
+    indicator = new THREE.Mesh(
+      new THREE.SphereGeometry(INDICATOR_RADIUS, 16, 12),
+      new THREE.MeshStandardMaterial({ color: INDICATOR_COLOR }),
+    );
+    writeGraphPointToWorld(
+      X_INITIAL,
+      Y_INITIAL,
+      STARTER_PRESET.f(X_INITIAL, Y_INITIAL),
+      SURFACE_CENTER,
+      indicatorWorld,
+    );
+    indicator.position.copy(indicatorWorld);
+    group.add(indicator);
+
     worldAxes = new WorldAxes({ axisColors: DEFAULT_AXIS_COLORS });
     worldAxes.group.position.copy(AXIS_INDICATOR_POSITION);
     group.add(worldAxes.group);
   },
 
   update() {
-    // No sliders or per-frame uniforms in #176. Keep WorldAxes labels
-    // billboarded so they read at any user yaw — same per-frame contract
-    // as cluster siblings.
+    if (xSlider && ySlider) {
+      // 1. Slider hover + drag tick. Order between the two sliders
+      //    doesn't matter — each tracks its own grab/hover state.
+      xSlider.updateHover(controllers);
+      ySlider.updateHover(controllers);
+      xSlider.update();
+      ySlider.update();
+
+      const x = xSlider.value;
+      const y = ySlider.value;
+      const z = STARTER_PRESET.f(x, y);
+
+      // 2. Indicator pose. writeGraphPointToWorld reuses the same
+      //    math-frame mapping as the surface mesh, so indicator and
+      //    surface can't drift.
+      if (indicator) {
+        writeGraphPointToWorld(x, y, z, SURFACE_CENTER, indicatorWorld);
+        indicator.position.copy(indicatorWorld);
+      }
+
+      // 3. Per-slider value labels — linear-decimal format (Cartesian
+      //    coords, not angles).
+      if (xLabel && camera) {
+        xLabel.setSecondary(formatLinearDecimal(x));
+        xLabel.faceCamera(camera);
+      }
+      if (yLabel && camera) {
+        yLabel.setSecondary(formatLinearDecimal(y));
+        yLabel.faceCamera(camera);
+      }
+    }
+
+    // Yaw-only billboard on the WorldAxes letter labels so they read at
+    // any user yaw. Same per-frame contract as cluster siblings.
     if (worldAxes && camera) worldAxes.faceCamera(camera);
   },
 
   unmount() {
-    // No controller grabs to release in #176 (no sliders yet); #177 will
-    // walk the (x, y) sliders here.
+    // 1. Release any active controller grabs so disposed sliders don't
+    //    leak grab references back into the shell's controller objects.
+    for (const c of controllers) {
+      xSlider?.releaseFromController(c);
+      ySlider?.releaseFromController(c);
+    }
 
+    // 2. Dispose named handles — each resource has exactly one disposal
+    //    owner. The shell removes ctx.group + descendants automatically
+    //    after unmount() returns, so no scene.remove() calls here.
     graphSurface?.dispose();
     graphSurface = undefined;
     worldAxes?.dispose();
     worldAxes = undefined;
+    xSlider?.dispose();
+    xSlider = undefined;
+    ySlider?.dispose();
+    ySlider = undefined;
+    xLabel?.dispose();
+    xLabel = undefined;
+    yLabel?.dispose();
+    yLabel = undefined;
+    if (indicator) {
+      indicator.geometry.dispose();
+      (indicator.material as THREE.Material).dispose();
+      indicator = undefined;
+    }
 
-    // Drop external references so a re-mount starts clean. The shell
-    // removes ctx.group + descendants automatically.
+    // 3. Drop external references so a re-mount starts clean.
+    controllers = [];
     camera = undefined;
   },
 
-  onSelectStart() {
-    // No interactive elements in #176; #177 introduces (x, y) sliders.
+  onSelectStart(controller: THREE.Object3D) {
+    // Try sliders in rack reading order (x first, y second); first hit
+    // wins. Rack-first-refusal arbitration happens upstream in the
+    // shell — by the time this fires, SceneRack didn't consume the
+    // event.
+    if (xSlider?.tryGrab(controller)) return;
+    ySlider?.tryGrab(controller);
   },
 
-  onSelectEnd() {
-    // Symmetric — no grabs to release.
+  onSelectEnd(controller: THREE.Object3D) {
+    xSlider?.releaseFromController(controller);
+    ySlider?.releaseFromController(controller);
   },
 };
 


### PR DESCRIPTION
Closes #177

## Summary

Adds two sliders (`x`, `y`) to the saddle-extrema scene that walk a selected-point indicator across the active graph surface. Reuses the `Slider` + `Label` scaffold and the `writeGraphPointToWorld` helper shipped in #176, so the indicator's math-frame mapping is byte-identical to the surface mesh's vertex mapping (no drift risk).

Foundation for downstream sub-issues: #179 (critical-point markers next to the indicator), #180 (quadratic overlay AT the selected point), #181 (Hessian + classification readout AT the selected point).

**Key design decisions:**

- Slider colors **vermillion (x) + bluish-green (y)** — axis-tinted since these are literal math-axis values, mirroring quadrics' coefficient-slider convention (departure from gradient-levels' all-gray rack, whose θ/φ are derived parameters).
- Rack layout: symmetric two-row straddle around `SLIDER_RACK_CENTER.y = 1.0` (x at 1.07, y at 0.93).
- Snap detents `[0]` per slider — slider-canonical origin, NOT critical-point-aware (the v0.8 origin-coincidence doesn't establish a critical-point mechanism; #179 owns that).
- No miss policy: graph form `z = f(x, y)` is single-valued, so the indicator is always on the surface. Substantially simpler than gradient-levels' raycast-and-hide handling.

## Test plan

**Automated (green locally):**
- [ ] `npx vitest run` — 263 pass (no new tests; same posture as the cluster-sibling #164 precedent).
- [ ] `npx tsc --noEmit` — clean.
- [ ] `npm run build` — clean.
- [ ] Pre-commit hooks — passed.

**Headset smoke on Cloudflare PR preview:**
- [ ] **Boot at `?exhibit=saddle-extrema`.** Two sliders visible — top: x at world-y 1.07, vermillion tint; bottom: y at world-y 0.93, bluish-green tint. Labels read `x` / `y` (primary) and `0.50` / `0.30` (secondary). Indicator sphere visible on the saddle surface near `(0.5, 0.3, 0.16)` math ⇒ world `(0.5, 1.66, -3.7)` approx.
- [ ] **Drag x slider.** Indicator slides along math-X across the surface; label updates live. At extremes (`−1.50` / `1.50`), indicator visits the saddle's "up" edges (z = x² − y² rises with x²).
- [ ] **Drag y slider.** Indicator slides along math-Y. At extremes, indicator visits the saddle's "down" edges (z falls with y²) — confirms math-Y forward orientation is correct (moves toward/away from user AND vertically).
- [ ] **Origin snap.** Drag x and y both through 0 — both sliders snap perceptibly; indicator lands at the saddle's center (math origin, world `(0, 1.5, -4)`).
- [ ] **Slider colors read as honest axis indicators** (not as competing tints against the cluster sky-blue surface). If they clash visually, the fallback is one-line: swap both to `0xaaaaaa` neutral gray.
- [ ] **Cluster swap** (saddle-extrema ↔ gradient-levels ↔ tangent-planes ↔ quadrics). Sliders re-mount cleanly; pre-warm passes; no console errors; surface tint still matches the cluster's clear light-blue (no regression on #176's lambert ShaderMaterial).
- [ ] **Drag-release-regrab.** Release a slider mid-drag and re-grab — no visible snap-jump between release and re-grab (split rawValue/currentValue contract).
- [ ] **Disposal regression check.** Capture `renderer.info.memory.geometries` + `renderer.info.programs.length` baseline; swap between all four scenes 5 times each; re-capture. Counts at end equal baseline ± 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)