### PR TITLE
feat(scene): saddle-extrema — preset library (#178)

### DIFF
--- a/src/exhibits/saddle-extrema/SPEC.md
+++ b/src/exhibits/saddle-extrema/SPEC.md
@@ -4,9 +4,11 @@
 > v0.8 cuts: #176 registers the fourth cluster member, introduces a
 > new meshed graph-surface rendering primitive, and ships one locked
 > starter preset (`z = x² − y²`). #177 adds (x, y) point selection;
-> #178 expands the preset library; #179 adds critical-point markers;
-> #180 ships the local-quadratic-approximation overlay (the §11.7–11.8
-> punch line); #181 ships the live Hessian + classification readout.
+> #178 expands the preset library to five archetypes + adds `hessF`
+> to the preset record + ships the preset-selector UI; #179 adds
+> critical-point markers; #180 ships the local-quadratic-approximation
+> overlay (the §11.7–11.8 punch line); #181 ships the live Hessian +
+> classification readout.
 
 ## Goal
 
@@ -52,30 +54,116 @@ mapping is JS-side per vertex via `writeGraphPointToWorld` in
 bundles both steps so downstream consumers don't re-derive the
 contract.
 
-## Starter preset
+## Preset library (#178)
 
-`f(x, y) = x² − y²` on `(x, y) ∈ [−1.5, 1.5]²`. Analytic data:
+Five curated presets, one per critical-point archetype. The student
+steps through them deliberately — each preset replaces the active
+`f`, `gradF`, `hessF`, and `(x, y)` domain — so the lesson focuses on
+one archetype at a time rather than a single function mixing several.
+The boot pose is the saddle (the #176 starter; also visually the most
+recognizable archetype).
 
-- First partials: `f_x = 2x`, `f_y = −2y`.
-- Hessian: `f_xx = 2`, `f_yy = −2`, `f_xy = 0`.
-- Critical point at the origin (gradient vanishes).
-- `D = f_xx · f_yy − f_xy² = (2)(−2) − 0² = −4 < 0` ⇒ saddle.
+Reading order in the preset row matches the array order in
+`presets.ts` — paraboloid → inv-paraboloid → saddle → monkey saddle →
+quartic — which is also the pedagogical sequence: simplest classical
+cases first, then the eponymous saddle, then the degenerate
+counterexamples that drive the §11.7–11.8 stuck-point.
 
-Visually the eponymous shape — math-X edges curve upward, math-Y edges
-curve downward. The §11.7 "what does it look like at the critical
-point?" question reads at a glance.
+| `id`              | Function            | Domain          | `D` at origin   | Classification |
+|-------------------|---------------------|-----------------|-----------------|----------------|
+| `paraboloid`      | `x² + y²`           | `[-1.2, 1.2]²`  | `4` (> 0)       | Local min      |
+| `inv-paraboloid`  | `−(x² + y²)`        | `[-1.2, 1.2]²`  | `4` (> 0)       | Local max      |
+| `saddle`          | `x² − y²`           | `[-1.5, 1.5]²`  | `−4` (< 0)      | Saddle         |
+| `monkey-saddle`   | `x³ − 3xy²`         | `[-1.2, 1.2]²`  | `0`             | Inconclusive (degenerate; cubic terms determine local shape) |
+| `quartic-min`     | `x⁴ + y⁴`           | `[-1, 1]²`      | `0`             | Inconclusive (test failure — surface is still a local min)   |
 
-### Note (forward-looking for #178)
+Analytic data on each preset:
 
-*All v0.8 preset critical points sit at the origin.* The starter
-saddle, the paraboloid (`x² + y²`), the inverted paraboloid
-(`−(x² + y²)`), the monkey saddle (`x³ − 3xy²`), and the D = 0
-degenerate min (`x⁴ + y⁴`) all have their critical point at
-`(x, y) = (0, 0)`. This is itself a useful pedagogical observation —
-critical points don't have to be "out there somewhere"; they live at
-a chosen origin so the focus can stay on the *local shape*, not the
-*location*. #179's critical-point markers will all render at the
-origin for v0.8.
+- `f(x, y)` — function value in math-frame coords.
+- `gradF(x, y) → [f_x, f_y]` — first partials. Required (vertex normals on the graph-surface primitive read from this).
+- `hessF(x, y) → [f_xx, f_xy, f_yy]` — symmetric Hessian, three distinct entries. Stored on the preset for #181's classification readout (`D = f_xx · f_yy − f_xy²`); not consumed by #178 itself.
+- `domain: { xMin, xMax, yMin, yMax }` — per-preset rectangle, sized so the rendered surface fits the cluster envelope.
+
+### Why per-preset domains?
+
+The cluster's vertical envelope is roughly world-Y `[−0.75, 3.75]`
+(4.5 m, centered on `SURFACE_CENTER.y = 1.5`, see "Domain framing"
+below). A shared `[−1.5, 1.5]²` doesn't work across the set:
+
+- Paraboloid / inv-paraboloid at `(±1.5, ±1.5)` evaluates to `±4.5` —
+  top corner extends to world-Y = 6, well above the cluster envelope.
+- Monkey saddle at corner `(1.5, 1.5)` evaluates to `−6.75` — bottom
+  corner at world-Y ≈ −5.25, far below the cluster floor.
+- Quartic at corner `(1.5, 1.5)` evaluates to `10.125` — top corner at
+  world-Y ≈ 11.6, completely out of FOV from spawn.
+
+Smaller domains for higher-degree presets keep the surface within the
+viewing volume without sacrificing the critical-point neighborhood (every
+preset's critical point sits at the origin, well inside its domain).
+
+### Pedagogical observation — all critical points at origin
+
+*All v0.8 preset critical points sit at the origin.* Critical points
+don't have to be "out there somewhere"; they live at a chosen origin
+so the focus stays on the *local shape*, not the *location*. #179's
+critical-point markers will all render at the origin for v0.8.
+Origin-snap on the (x, y) sliders (`snapPoints = [0]`) coincides with
+the critical point for every preset — slider-canonical, not
+critical-point-aware (the snap mechanism doesn't know about presets).
+
+## Preset-selector UI (#178)
+
+Five `TapButton` instances in a single horizontal row above the slider
+rack, at `y = 1.30`, centered on `x = 0` with `0.13 m` horizontal pitch
+(span 0.52 m; columns at `[-0.26, -0.13, 0, 0.13, 0.26]`). Always
+visible — five archetypes is small enough to live on screen at all
+times (the quadrics manipulator's 8-preset rack needed an
+expand/collapse chevron; here that machinery would be friction without
+payoff).
+
+Button visuals mirror the manipulator's `Preset` primitive
+(`src/scaffold/ui/Preset.ts`) — cool-blue base, label below the
+button, smaller font than `SectionTab` — **plus** sticky-active
+emissive. Saddle-extrema's preset is a persistent mode (the surface IS
+the preset's `f`); the manipulator's `Preset` deliberately omits
+`activeEmissive` because its presets are one-shot snap-to-pose
+affordances. Different semantic → different visual contract.
+
+`Preset` (the scaffold class) couples its API to quadrics-coefficient
+`values: PresetValues = [number, number, number, number]`, so this
+scene uses `TapButton` directly rather than the `Preset` subclass.
+Generalizing `Preset` to a typed payload would touch the manipulator
+for one new consumer and the rule-of-three threshold hasn't been
+crossed (scaffold's `Preset` is consumer #1; saddle-extrema is
+consumer #2). Defer scaffold extraction to consumer #3.
+
+### Apply-preset semantics
+
+When a preset button activates:
+
+1. Press flash fires (TapButton-internal feedback).
+2. Previous active preset's button → inactive; new preset's button → active.
+3. Old `graphSurface.mesh` removed from the exhibit group, then disposed.
+4. New `graphSurface` constructed with the new preset's `f` / `gradF` /
+   `domain`, added to the group.
+5. `xSlider.setRange(...)` and `ySlider.setRange(...)` update slider
+   domains; current values clamp into the new range and re-apply snap.
+6. Indicator + labels pick up the new active preset's `f` on the next
+   `update()` tick via the `PRESETS[activePresetIndex]` lookup.
+
+No tween between preset surfaces. The active `f` changes
+fundamentally between presets (different polynomial families,
+different domains), so a coefficient-tween — what the manipulator does
+between its presets — is meaningless here. Instant swap also matches
+the lesson: each preset shows one archetype.
+
+Slider values carry over across preset switches (clamped into the new
+domain). A student comparing min vs. saddle at the same `(x, y)` point
+sees the local-shape difference; forcing reset to `(0, 0)` on each
+switch would hide that pedagogy.
+
+Tapping the already-active preset is a press-flash-only no-op (no
+surface rebuild).
 
 ## Graph-surface primitive (`GraphSurface.ts`)
 
@@ -201,17 +289,19 @@ spanning world-X `[-3, 3]`, world-Y `[-1.5, 4.5]` (centered on
 `SURFACE_CENTER.y = 1.5`), world-Z `[-7, -1]` (centered on
 `SURFACE_CENTER.z = -4`).
 
-The starter saddle on `[−1.5, 1.5]²` uses **half** the cluster's
-per-axis x/y extent (3 m × 3 m, vs. the cluster's 6 m × 6 m). The
-saddle's z-range `[−2.25, 2.25]` is inside the cluster's half-extent;
-the bottom corner sits at world-Y `= -0.75` (below `SURFACE_CENTER.y`
-by 2.25 m). The cluster doesn't render a floor and gradient-levels'
-family extends arbitrarily along ±math-Z too, so visually consistent
-with cluster convention.
+Each preset's `domain` (see "Preset library" above) sizes the rendered
+surface to fit comfortably inside the cluster envelope. The starter
+saddle on `[−1.5, 1.5]²` uses **half** the cluster's per-axis x/y
+extent (3 m × 3 m, vs. the cluster's 6 m × 6 m). The saddle's z-range
+`[−2.25, 2.25]` is inside the cluster's half-extent; the bottom corner
+sits at world-Y `= -0.75` (below `SURFACE_CENTER.y` by 2.25 m). The
+cluster doesn't render a floor and gradient-levels' family extends
+arbitrarily along ±math-Z too, so visually consistent with cluster
+convention.
 
-`[−1.5, 1.5]²` is a v0.8-starter lock; iterate in-headset if it reads
-too small. Future presets in #178 carry per-preset domains in the
-preset record.
+Per-preset domains are tabulated in the "Preset library" section
+above and are revisited in-headset; iterate if any preset reads too
+small or too tall.
 
 ## Camera framing
 
@@ -232,17 +322,8 @@ Visibility check for the starter saddle:
   (top corner above eye level), total ~58°.
 - Quest 3 FOV: ~96°×96° per eye. Saddle fits well within FOV.
 
-## Out of scope (v0.8 beyond #176)
+## Out of scope (v0.8 beyond #178)
 
-- **Point selection (#177).** Two (x, y) sliders walking the domain
-  + selected-point indicator on the surface. Per-slider variable +
-  value labels reusing the #170 scaffold. Introduces the
-  `SLIDER_RACK_CENTER` constant (deliberately deferred from #176 per
-  the v1 roundtable's GPT #4 finding — scope creep otherwise).
-- **Preset library (#178).** Four additional presets (paraboloid,
-  inverted paraboloid, monkey saddle, `x⁴ + y⁴`); preset-selector UI
-  (mirror the manipulator's `Preset` scaffold primitive); preset-record
-  interface extended with `hessF` (second partials for #181's readout).
 - **Critical-point markers (#179).** Small visual markers at the
   analytically-known critical points (all at origin for v0.8 presets).
 - **Quadratic overlay (#180).** Always-on, translucent second-order

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -9,26 +9,29 @@ import {
 } from '@/scaffold/design/tokens';
 import { Label } from '@/scaffold/ui/Label';
 import { Slider } from '@/scaffold/ui/Slider';
+import {
+  TapButton,
+  type TapButtonVisuals,
+} from '@/scaffold/ui/TapButton';
 import { WorldAxes } from '@/scaffold/ui/WorldAxes';
 import {
   createGraphSurface,
   writeGraphPointToWorld,
-  type GraphSurfaceDomain,
   type GraphSurfaceHandles,
 } from './GraphSurface';
+import { DEFAULT_PRESET_INDEX, PRESETS } from './presets';
 
-// Saddle / extrema scene (#175 epic, #176 foundation). Fourth and final
-// member of the calculus3 cluster, alongside quadrics, tangent-planes,
-// and gradient-levels.
+// Saddle / extrema scene (#175 epic). Fourth and final member of the
+// calculus3 cluster, alongside quadrics, tangent-planes, and gradient-levels.
 //
 // Pedagogy target: APPM 2350 §11.7–11.8 (Maximum/Minimum Values + Second
 // Derivatives Test). Stuck-point: students mechanically compute D =
 // f_xx·f_yy − f_xy² without seeing that they're asking "what does this
 // surface look like in a small neighborhood?" The quadratic-overlay
-// punch line lands in #180; this PR establishes the substrate — meshed
-// graph surface for z = f(x, y) — that #177 (point selection), #178
-// (preset library), #179 (critical-point markers), #180 (overlay), and
-// #181 (Hessian readout) attach to.
+// punch line lands in #180; #178 ships the curated preset library
+// (paraboloid / inv-paraboloid / saddle / monkey saddle / x⁴+y⁴) so the
+// student steps through each archetype deliberately rather than
+// encountering them mixed in one surface.
 //
 // Architectural divergence from the prior three cluster scenes: those
 // render an implicit surface via the GPU raymarcher. Saddle-extrema
@@ -84,6 +87,37 @@ const INDICATOR_COLOR = 0xdddddd;
 // Cluster glyph convention for negative-magnitude formatting.
 const SLIDER_VALUE_MINUS = '−'; // U+2212
 
+// Preset row (#178). Five buttons in a single horizontal row above the
+// slider rack, centered on x = 0. Always-visible — five archetypes is
+// small enough to live on screen at all times (the quadrics manipulator's
+// 8-preset rack needed an expand/collapse chevron; here that machinery
+// would be friction without payoff). The y level clears the top slider's
+// grab sphere (≈ 0.07 m radius) with ~0.16 m of clear air.
+const PRESET_ROW_Y = 1.30;
+const PRESET_HORIZONTAL_PITCH = 0.13;
+// 5 columns centered on x = 0 ⇒ leftmost col at -2 × pitch.
+const PRESET_ROW_START_X = -2 * PRESET_HORIZONTAL_PITCH;
+const PRESET_RES = 128;
+
+// Mirror the manipulator's `Preset` visual identity (cool blue base,
+// label below the button) plus a sticky-active emissive — saddle-extrema's
+// preset is a persistent mode (the surface IS the preset's f), where the
+// manipulator's preset is a one-shot snap-to-pose. Sticky-active reads as
+// "this is the current archetype"; press flash layers on top as tap
+// feedback. Pattern echoes SectionTab (#57): press + active + hover, all
+// three managed by the shared TapButton base.
+const PRESET_BUTTON_VISUALS: TapButtonVisuals = {
+  groupNamePrefix: 'preset',
+  buttonRadius: 0.02,
+  baseColor: 0x44aabb,
+  hoverEmissive: 0x224455,
+  activeEmissive: 0x66ccdd,
+  pressEmissive: 0x88ddff,
+  labelFontSize: 0.022,
+  labelOffsetY: -0.025,
+  labelAnchorY: 'top',
+};
+
 // Local linear-decimal formatter for the per-slider value labels.
 // Identical in shape to gradient-levels' local helper (#170 history);
 // this scene becomes consumer #2 — extract-on-third-use rule honored, so
@@ -94,39 +128,12 @@ function formatLinearDecimal(v: number): string {
 }
 
 // ────────────────────────────────────────────────────────────────────
-// Starter preset — z = x² − y² on [-1.5, 1.5]². Sole preset for #176.
-// The `id` and `label` fields exist now to pre-pave #178's preset-
-// selector UI (which will mirror the manipulator's `Preset` primitive);
-// #176 has only one preset and never reads them.
-//
-// `hessF` (second partials for #181's Hessian readout) is intentionally
-// absent from this interface — added in #178 alongside the preset
-// library, because no #176-scope consumer needs second partials.
-// Implementer note: do not try to "complete" the interface in this PR.
-// ────────────────────────────────────────────────────────────────────
-
-interface SaddleExtremaPreset {
-  readonly id: string;
-  readonly label: string;
-  readonly f: (x: number, y: number) => number;
-  readonly gradF: (x: number, y: number) => readonly [number, number];
-  readonly domain: GraphSurfaceDomain;
-  readonly res?: number;
-}
-
-const STARTER_PRESET: SaddleExtremaPreset = {
-  id: 'saddle',
-  label: 'Saddle (x² − y²)',
-  f: (x, y) => x * x - y * y,
-  gradF: (x, y) => [2 * x, -2 * y],
-  domain: { xMin: -1.5, xMax: 1.5, yMin: -1.5, yMax: 1.5 },
-};
-
-// ────────────────────────────────────────────────────────────────────
 // Module-scoped state — named handles initialized in mount, disposed
-// inline in unmount.
+// inline in unmount. `exhibitGroup` is captured at mount so applyPreset
+// (called from onSelectStart) can swap the graphSurface mesh in/out.
 // ────────────────────────────────────────────────────────────────────
 
+let exhibitGroup: THREE.Group | undefined;
 let graphSurface: GraphSurfaceHandles | undefined;
 let worldAxes: WorldAxes | undefined;
 let xSlider: Slider | undefined;
@@ -134,6 +141,8 @@ let ySlider: Slider | undefined;
 let xLabel: Label | undefined;
 let yLabel: Label | undefined;
 let indicator: THREE.Mesh | undefined;
+let presetButtons: TapButton[] = [];
+let activePresetIndex = DEFAULT_PRESET_INDEX;
 let camera: THREE.Camera | undefined;
 let controllers: readonly THREE.Object3D[] = [];
 
@@ -152,8 +161,11 @@ const saddleExtremaExhibit: Exhibit = {
   cluster: CLUSTER_CALCULUS3,
 
   mount({ group, camera: cam, controllers: shellControllers }: ExhibitContext) {
+    exhibitGroup = group;
     camera = cam;
     controllers = shellControllers;
+    activePresetIndex = DEFAULT_PRESET_INDEX;
+    const initialPreset = PRESETS[activePresetIndex];
 
     // Ambient + directional lights match cluster siblings. The graph
     // surface uses a custom ShaderMaterial reproducing the cluster's
@@ -166,10 +178,10 @@ const saddleExtremaExhibit: Exhibit = {
     group.add(directional);
 
     graphSurface = createGraphSurface({
-      f: STARTER_PRESET.f,
-      gradF: STARTER_PRESET.gradF,
-      domain: STARTER_PRESET.domain,
-      res: STARTER_PRESET.res ?? 128,
+      f: initialPreset.f,
+      gradF: initialPreset.gradF,
+      domain: initialPreset.domain,
+      res: initialPreset.res ?? PRESET_RES,
       surfaceCenter: SURFACE_CENTER,
       baseColor: BASE_COLOR.clone(),
       lightDir: LIGHT_DIR.clone(),
@@ -182,8 +194,8 @@ const saddleExtremaExhibit: Exhibit = {
     // convention.
     xSlider = new Slider({
       label: 'x',
-      min: STARTER_PRESET.domain.xMin,
-      max: STARTER_PRESET.domain.xMax,
+      min: initialPreset.domain.xMin,
+      max: initialPreset.domain.xMax,
       initial: X_INITIAL,
       snapDetent: SLIDER_SNAP_DETENT,
       snapPoints: SLIDER_SNAP_POINTS,
@@ -201,8 +213,8 @@ const saddleExtremaExhibit: Exhibit = {
     // y slider — bluish-green (math-Y axis tint).
     ySlider = new Slider({
       label: 'y',
-      min: STARTER_PRESET.domain.yMin,
-      max: STARTER_PRESET.domain.yMax,
+      min: initialPreset.domain.yMin,
+      max: initialPreset.domain.yMax,
       initial: Y_INITIAL,
       snapDetent: SLIDER_SNAP_DETENT,
       snapPoints: SLIDER_SNAP_POINTS,
@@ -257,7 +269,7 @@ const saddleExtremaExhibit: Exhibit = {
     writeGraphPointToWorld(
       X_INITIAL,
       Y_INITIAL,
-      STARTER_PRESET.f(X_INITIAL, Y_INITIAL),
+      initialPreset.f(X_INITIAL, Y_INITIAL),
       SURFACE_CENTER,
       indicatorWorld,
     );
@@ -267,9 +279,30 @@ const saddleExtremaExhibit: Exhibit = {
     worldAxes = new WorldAxes({ axisColors: DEFAULT_AXIS_COLORS });
     worldAxes.group.position.copy(AXIS_INDICATOR_POSITION);
     group.add(worldAxes.group);
+
+    // Preset row (#178) — five archetypes left → right, mirroring the
+    // PRESETS array order. The starter (saddle, DEFAULT_PRESET_INDEX) is
+    // marked sticky-active so the user reads which archetype is current.
+    presetButtons = PRESETS.map((preset, i) => {
+      const btn = new TapButton({
+        name: preset.label,
+        grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER,
+        visuals: PRESET_BUTTON_VISUALS,
+      });
+      btn.group.position.set(
+        PRESET_ROW_START_X + i * PRESET_HORIZONTAL_PITCH,
+        PRESET_ROW_Y,
+        SLIDER_RACK_CENTER.z,
+      );
+      group.add(btn.group);
+      return btn;
+    });
+    presetButtons[activePresetIndex]?.setActive(true);
   },
 
   update() {
+    const activePreset = PRESETS[activePresetIndex];
+
     if (xSlider && ySlider) {
       // 1. Slider hover + drag tick. Order between the two sliders
       //    doesn't matter — each tracks its own grab/hover state.
@@ -280,7 +313,7 @@ const saddleExtremaExhibit: Exhibit = {
 
       const x = xSlider.value;
       const y = ySlider.value;
-      const z = STARTER_PRESET.f(x, y);
+      const z = activePreset.f(x, y);
 
       // 2. Indicator pose. writeGraphPointToWorld reuses the same
       //    math-frame mapping as the surface mesh, so indicator and
@@ -300,6 +333,15 @@ const saddleExtremaExhibit: Exhibit = {
         yLabel.setSecondary(formatLinearDecimal(y));
         yLabel.faceCamera(camera);
       }
+    }
+
+    // 4. Preset-button hover + press-flash tick. Faces the camera so
+    //    labels stay readable at any user yaw, mirroring the slider-
+    //    label and worldAxes billboarding contract.
+    for (const btn of presetButtons) {
+      btn.updateHover(controllers);
+      btn.update();
+      if (camera) btn.faceCamera(camera);
     }
 
     // Yaw-only billboard on the WorldAxes letter labels so they read at
@@ -330,6 +372,8 @@ const saddleExtremaExhibit: Exhibit = {
     xLabel = undefined;
     yLabel?.dispose();
     yLabel = undefined;
+    for (const btn of presetButtons) btn.dispose();
+    presetButtons = [];
     if (indicator) {
       indicator.geometry.dispose();
       (indicator.material as THREE.Material).dispose();
@@ -339,15 +383,22 @@ const saddleExtremaExhibit: Exhibit = {
     // 3. Drop external references so a re-mount starts clean.
     controllers = [];
     camera = undefined;
+    exhibitGroup = undefined;
+    activePresetIndex = DEFAULT_PRESET_INDEX;
   },
 
   onSelectStart(controller: THREE.Object3D) {
-    // Try sliders in rack reading order (x first, y second); first hit
-    // wins. Rack-first-refusal arbitration happens upstream in the
-    // shell — by the time this fires, SceneRack didn't consume the
-    // event.
+    // Sliders first (warm drag affordance), then the preset row. Spatially
+    // disjoint regions, but explicit ordering keeps first-hit-wins
+    // well-defined regardless of layout.
     if (xSlider?.tryGrab(controller)) return;
-    ySlider?.tryGrab(controller);
+    if (ySlider?.tryGrab(controller)) return;
+    for (let i = 0; i < presetButtons.length; i++) {
+      if (presetButtons[i].tryActivate(controller)) {
+        applyPreset(i);
+        return;
+      }
+    }
   },
 
   onSelectEnd(controller: THREE.Object3D) {
@@ -355,6 +406,54 @@ const saddleExtremaExhibit: Exhibit = {
     ySlider?.releaseFromController(controller);
   },
 };
+
+// ────────────────────────────────────────────────────────────────────
+// Preset application (#178).
+//
+// Switching presets rebuilds the graph-surface mesh outright — unlike the
+// quadrics manipulator's preset tweens, here the active `f` changes
+// fundamentally between presets (different polynomial families,
+// different domains), so a coefficient-tween is meaningless. Instant
+// swap also matches the lesson: "this preset shows ONE archetype."
+//
+// Slider values carry across the switch (clamped into the new domain via
+// setRange). Rationale: a student comparing min vs. saddle at the same
+// (x, y) point sees the local-shape difference. Forcing reset to (0, 0)
+// every switch would hide that pedagogy.
+// ────────────────────────────────────────────────────────────────────
+
+function applyPreset(idx: number): void {
+  if (idx === activePresetIndex) return; // press flash already fired; no rebuild
+  presetButtons[activePresetIndex]?.setActive(false);
+  presetButtons[idx]?.setActive(true);
+  activePresetIndex = idx;
+
+  const preset = PRESETS[idx];
+  if (graphSurface && exhibitGroup) {
+    // Remove from the parent group BEFORE dispose — otherwise the disposed
+    // mesh leaks as a child of `exhibitGroup` until unmount sweeps the
+    // group. Sequencing matters.
+    exhibitGroup.remove(graphSurface.mesh);
+    graphSurface.dispose();
+    graphSurface = undefined;
+  }
+  graphSurface = createGraphSurface({
+    f: preset.f,
+    gradF: preset.gradF,
+    domain: preset.domain,
+    res: preset.res ?? PRESET_RES,
+    surfaceCenter: SURFACE_CENTER,
+    baseColor: BASE_COLOR.clone(),
+    lightDir: LIGHT_DIR.clone(),
+  });
+  exhibitGroup?.add(graphSurface.mesh);
+
+  // Slider domains follow the preset. setRange clamps the current value
+  // into the new range and re-applies snap; the indicator picks up the
+  // (possibly clamped) value via the next update() tick.
+  xSlider?.setRange(preset.domain.xMin, preset.domain.xMax);
+  ySlider?.setRange(preset.domain.yMin, preset.domain.yMax);
+}
 
 registerExhibit(saddleExtremaExhibit);
 

--- a/src/exhibits/saddle-extrema/presets.ts
+++ b/src/exhibits/saddle-extrema/presets.ts
@@ -1,0 +1,95 @@
+import type { GraphSurfaceDomain } from './GraphSurface';
+
+// Saddle / extrema scene preset library (#178). Each preset focuses the
+// lesson on one specific critical-point archetype so the student can step
+// through them deliberately rather than encountering them mixed in a single
+// surface. All v0.8 critical points sit at the origin (cluster-shared
+// observation in SPEC.md), so the indicator at the slider-origin pose lands
+// on the critical point for every preset.
+//
+// Per-preset `domain` sized so the surface fits the cluster's vertical
+// envelope (world-Y ≈ [-0.75, 3.75], per SPEC.md "Domain framing"). The
+// shared `[-1.5, 1.5]²` from the #176 starter doesn't carry to quartics or
+// cubics — `x⁴+y⁴` evaluates to 10.125 at (1.5, 1.5), well past the
+// cluster top.
+
+/**
+ * Symmetric 2×2 Hessian entries. Returns `[f_xx, f_xy, f_yy]`; `f_yx`
+ * equals `f_xy` and is left implicit. Consumed by #181's classification
+ * readout via `D = f_xx · f_yy − f_xy²`.
+ */
+export type Hessian = readonly [number, number, number];
+
+export interface SaddleExtremaPreset {
+  readonly id: string;
+  readonly label: string;
+  /** `z = f(x, y)` in math-frame coords. */
+  readonly f: (x: number, y: number) => number;
+  /** Analytic first partials `(f_x, f_y)`. Required — feeds vertex normals. */
+  readonly gradF: (x: number, y: number) => readonly [number, number];
+  /** Analytic Hessian entries `(f_xx, f_xy, f_yy)`. Stored on the preset for
+   *  #181's classification readout; not consumed by #178. */
+  readonly hessF: (x: number, y: number) => Hessian;
+  /** Per-preset (x, y) window. Picked so the surface fits the cluster envelope. */
+  readonly domain: GraphSurfaceDomain;
+  /** Optional grid resolution per side. Defaults to 128 at the call site. */
+  readonly res?: number;
+}
+
+export const PRESETS: readonly SaddleExtremaPreset[] = [
+  // 1. Local min — z = x² + y². Paraboloid; classic D > 0 + f_xx > 0 ⇒ min.
+  {
+    id: 'paraboloid',
+    label: 'Min (x² + y²)',
+    f: (x, y) => x * x + y * y,
+    gradF: (x, y) => [2 * x, 2 * y],
+    hessF: () => [2, 0, 2],
+    domain: { xMin: -1.2, xMax: 1.2, yMin: -1.2, yMax: 1.2 },
+  },
+  // 2. Local max — z = −(x² + y²). Inverted paraboloid; D > 0 + f_xx < 0 ⇒ max.
+  {
+    id: 'inv-paraboloid',
+    label: 'Max (−x² − y²)',
+    f: (x, y) => -(x * x + y * y),
+    gradF: (x, y) => [-2 * x, -2 * y],
+    hessF: () => [-2, 0, -2],
+    domain: { xMin: -1.2, xMax: 1.2, yMin: -1.2, yMax: 1.2 },
+  },
+  // 3. Saddle — z = x² − y². The #176 starter; D < 0 ⇒ saddle.
+  {
+    id: 'saddle',
+    label: 'Saddle (x² − y²)',
+    f: (x, y) => x * x - y * y,
+    gradF: (x, y) => [2 * x, -2 * y],
+    hessF: () => [2, 0, -2],
+    domain: { xMin: -1.5, xMax: 1.5, yMin: -1.5, yMax: 1.5 },
+  },
+  // 4. Monkey saddle — z = x³ − 3xy². Degenerate critical point at origin
+  //    (Hessian vanishes identically there ⇒ D = 0). Three "valleys"
+  //    radiate outward; the second-derivative test is silent and the local
+  //    shape is determined by the cubic terms.
+  {
+    id: 'monkey-saddle',
+    label: 'Monkey (x³−3xy²)',
+    f: (x, y) => x * x * x - 3 * x * y * y,
+    gradF: (x, y) => [3 * x * x - 3 * y * y, -6 * x * y],
+    hessF: (x, y) => [6 * x, -6 * y, -6 * x],
+    domain: { xMin: -1.2, xMax: 1.2, yMin: -1.2, yMax: 1.2 },
+  },
+  // 5. D = 0 degenerate that's still a min — z = x⁴ + y⁴. Hessian vanishes
+  //    at origin (f_xx = f_xy = f_yy = 0) ⇒ D = 0 inconclusive — yet the
+  //    surface is unambiguously a local minimum. The §11.7–11.8 punch-line
+  //    counterexample: "the test isn't always sufficient." Quartic grows
+  //    quickly; smallest domain in the set.
+  {
+    id: 'quartic-min',
+    label: 'Min (x⁴ + y⁴)',
+    f: (x, y) => x ** 4 + y ** 4,
+    gradF: (x, y) => [4 * x ** 3, 4 * y ** 3],
+    hessF: (x, y) => [12 * x * x, 0, 12 * y * y],
+    domain: { xMin: -1, xMax: 1, yMin: -1, yMax: 1 },
+  },
+];
+
+/** Index of the saddle preset — the #176 starter; boot pose for #178. */
+export const DEFAULT_PRESET_INDEX = 2;

--- a/src/scaffold/ui/Slider.ts
+++ b/src/scaffold/ui/Slider.ts
@@ -210,6 +210,32 @@ export class Slider {
   }
 
   /**
+   * Update the slider's value range. The raw and emitted values are
+   * clamped into the new range; the visible thumb position re-syncs to
+   * the clamped value, with snap re-applied. Used by scenes whose domain
+   * shifts at runtime — e.g., saddle-extrema's per-preset (x, y)
+   * windows (#178). `snapDetent` and `snapPoints` are unchanged; callers
+   * are responsible for keeping snap points inside the new range.
+   * Throws if `min >= max` or either bound is non-finite.
+   */
+  setRange(min: number, max: number): void {
+    if (!Number.isFinite(min) || !Number.isFinite(max) || !(min < max)) {
+      throw new Error(
+        `Slider.setRange: min (${min}) must be finite and < max (${max})`,
+      );
+    }
+    this.opts.min = min;
+    this.opts.max = max;
+    this.rawValue = clamp(this.rawValue, min, max);
+    this.currentValue = applySnap(
+      this.rawValue,
+      this.opts.snapPoints,
+      this.opts.snapDetent,
+    );
+    this.syncThumbPosition();
+  }
+
+  /**
    * Test whether `controller`'s forward ray hits the thumb. On hit, attach
    * the grab to that controller and pulse haptics. Returns whether grabbed.
    */

--- a/test/exhibits/saddle-extrema/presets.test.ts
+++ b/test/exhibits/saddle-extrema/presets.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_PRESET_INDEX,
+  PRESETS,
+  type SaddleExtremaPreset,
+} from '@/exhibits/saddle-extrema/presets';
+
+// Vitest coverage for the saddle-extrema preset library (#178). Scope:
+// math correctness of f, gradF, and hessF on each preset, plus the
+// per-archetype classification reading at the critical point. The
+// presets feed downstream consumers (#179 markers, #180 quadratic
+// overlay, #181 classification readout) — analytic-derivative bugs would
+// surface as silent misalignment between the surface mesh (vertex
+// normals from gradF) and the indicator / overlays.
+
+// Central-difference step for the finite-difference cross-check. Small
+// enough to keep truncation error <1e-5 on smooth polynomials; large
+// enough to keep roundoff noise comfortable.
+const FD_STEP = 1e-4;
+
+function gradFD(
+  f: (x: number, y: number) => number,
+  x: number,
+  y: number,
+): [number, number] {
+  return [
+    (f(x + FD_STEP, y) - f(x - FD_STEP, y)) / (2 * FD_STEP),
+    (f(x, y + FD_STEP) - f(x, y - FD_STEP)) / (2 * FD_STEP),
+  ];
+}
+
+function hessFD(
+  f: (x: number, y: number) => number,
+  x: number,
+  y: number,
+): [number, number, number] {
+  // Standard second-order central differences for f_xx, f_xy, f_yy.
+  const fxx =
+    (f(x + FD_STEP, y) - 2 * f(x, y) + f(x - FD_STEP, y)) / (FD_STEP * FD_STEP);
+  const fyy =
+    (f(x, y + FD_STEP) - 2 * f(x, y) + f(x, y - FD_STEP)) / (FD_STEP * FD_STEP);
+  const fxy =
+    (f(x + FD_STEP, y + FD_STEP)
+      - f(x + FD_STEP, y - FD_STEP)
+      - f(x - FD_STEP, y + FD_STEP)
+      + f(x - FD_STEP, y - FD_STEP)) / (4 * FD_STEP * FD_STEP);
+  return [fxx, fxy, fyy];
+}
+
+function presetById(id: string): SaddleExtremaPreset {
+  const p = PRESETS.find((preset) => preset.id === id);
+  if (!p) throw new Error(`preset not found: ${id}`);
+  return p;
+}
+
+describe('PRESETS — library shape', () => {
+  it('contains exactly five archetypes in the canonical order', () => {
+    expect(PRESETS.map((p) => p.id)).toEqual([
+      'paraboloid',
+      'inv-paraboloid',
+      'saddle',
+      'monkey-saddle',
+      'quartic-min',
+    ]);
+  });
+
+  it('DEFAULT_PRESET_INDEX points at the saddle (#176 starter)', () => {
+    expect(PRESETS[DEFAULT_PRESET_INDEX].id).toBe('saddle');
+  });
+
+  it('every preset has a finite, well-ordered (x, y) domain', () => {
+    for (const p of PRESETS) {
+      expect(Number.isFinite(p.domain.xMin)).toBe(true);
+      expect(Number.isFinite(p.domain.xMax)).toBe(true);
+      expect(Number.isFinite(p.domain.yMin)).toBe(true);
+      expect(Number.isFinite(p.domain.yMax)).toBe(true);
+      expect(p.domain.xMin).toBeLessThan(p.domain.xMax);
+      expect(p.domain.yMin).toBeLessThan(p.domain.yMax);
+      // Every v0.8 preset's critical point sits at the origin —
+      // confirm origin is inside the domain.
+      expect(p.domain.xMin).toBeLessThanOrEqual(0);
+      expect(p.domain.xMax).toBeGreaterThanOrEqual(0);
+      expect(p.domain.yMin).toBeLessThanOrEqual(0);
+      expect(p.domain.yMax).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe('PRESETS — critical point at origin', () => {
+  it('gradF vanishes at the origin for every preset', () => {
+    for (const p of PRESETS) {
+      const [fx, fy] = p.gradF(0, 0);
+      expect(fx).toBeCloseTo(0);
+      expect(fy).toBeCloseTo(0);
+    }
+  });
+});
+
+describe('PRESETS — analytic derivatives agree with finite differences', () => {
+  // Sample at a generic non-origin, non-axis point inside every domain.
+  // (0.3, 0.2) sits inside the quartic preset's [-1, 1]² (the tightest
+  // domain in the set) with room to spare.
+  const x = 0.3;
+  const y = 0.2;
+
+  it('gradF matches finite-difference gradient at a sample point', () => {
+    for (const p of PRESETS) {
+      const [fx, fy] = p.gradF(x, y);
+      const [fxNum, fyNum] = gradFD(p.f, x, y);
+      expect(fx).toBeCloseTo(fxNum, 4);
+      expect(fy).toBeCloseTo(fyNum, 4);
+    }
+  });
+
+  it('hessF matches finite-difference Hessian at a sample point', () => {
+    for (const p of PRESETS) {
+      const [fxx, fxy, fyy] = p.hessF(x, y);
+      const [fxxNum, fxyNum, fyyNum] = hessFD(p.f, x, y);
+      // FD second derivatives accumulate more roundoff; loosen the
+      // tolerance via toBeCloseTo precision 3 (≈ ±5e-4).
+      expect(fxx).toBeCloseTo(fxxNum, 3);
+      expect(fxy).toBeCloseTo(fxyNum, 3);
+      expect(fyy).toBeCloseTo(fyyNum, 3);
+    }
+  });
+});
+
+describe('PRESETS — per-archetype Hessian at origin', () => {
+  it('paraboloid (x²+y²): f_xx = f_yy = 2, f_xy = 0', () => {
+    const [fxx, fxy, fyy] = presetById('paraboloid').hessF(0, 0);
+    expect(fxx).toBe(2);
+    expect(fxy).toBe(0);
+    expect(fyy).toBe(2);
+  });
+
+  it('inv-paraboloid (−x²−y²): f_xx = f_yy = -2, f_xy = 0', () => {
+    const [fxx, fxy, fyy] = presetById('inv-paraboloid').hessF(0, 0);
+    expect(fxx).toBe(-2);
+    expect(fxy).toBe(0);
+    expect(fyy).toBe(-2);
+  });
+
+  it('saddle (x²−y²): f_xx = 2, f_yy = -2, f_xy = 0', () => {
+    const [fxx, fxy, fyy] = presetById('saddle').hessF(0, 0);
+    expect(fxx).toBe(2);
+    expect(fxy).toBe(0);
+    expect(fyy).toBe(-2);
+  });
+
+  it('monkey saddle (x³−3xy²): Hessian vanishes at origin', () => {
+    const [fxx, fxy, fyy] = presetById('monkey-saddle').hessF(0, 0);
+    // toBeCloseTo (rather than toBe) so −0 from `-6 * 0` matches +0 — the
+    // pedagogically meaningful claim is that the entries are zero, not
+    // their IEEE 754 sign.
+    expect(fxx).toBeCloseTo(0);
+    expect(fxy).toBeCloseTo(0);
+    expect(fyy).toBeCloseTo(0);
+  });
+
+  it('quartic min (x⁴+y⁴): Hessian vanishes at origin', () => {
+    const [fxx, fxy, fyy] = presetById('quartic-min').hessF(0, 0);
+    expect(fxx).toBeCloseTo(0);
+    expect(fxy).toBeCloseTo(0);
+    expect(fyy).toBeCloseTo(0);
+  });
+});
+
+describe('PRESETS — second-derivative test reading at origin', () => {
+  // D = f_xx · f_yy − f_xy². The four archetype outcomes the preset
+  // library is designed to demonstrate:
+  //   D > 0 + f_xx > 0 ⇒ local min
+  //   D > 0 + f_xx < 0 ⇒ local max
+  //   D < 0            ⇒ saddle
+  //   D = 0            ⇒ inconclusive (test failure: monkey saddle + quartic)
+
+  function discriminantAtOrigin(p: SaddleExtremaPreset): number {
+    const [fxx, fxy, fyy] = p.hessF(0, 0);
+    return fxx * fyy - fxy * fxy;
+  }
+
+  it('paraboloid: D > 0 and f_xx > 0 ⇒ local min', () => {
+    const p = presetById('paraboloid');
+    expect(discriminantAtOrigin(p)).toBeGreaterThan(0);
+    expect(p.hessF(0, 0)[0]).toBeGreaterThan(0);
+  });
+
+  it('inv-paraboloid: D > 0 and f_xx < 0 ⇒ local max', () => {
+    const p = presetById('inv-paraboloid');
+    expect(discriminantAtOrigin(p)).toBeGreaterThan(0);
+    expect(p.hessF(0, 0)[0]).toBeLessThan(0);
+  });
+
+  it('saddle: D < 0 ⇒ saddle', () => {
+    expect(discriminantAtOrigin(presetById('saddle'))).toBeLessThan(0);
+  });
+
+  it('monkey saddle: D = 0 ⇒ test inconclusive', () => {
+    expect(discriminantAtOrigin(presetById('monkey-saddle'))).toBeCloseTo(0);
+  });
+
+  it('quartic min: D = 0 ⇒ test inconclusive (the §11.7 punch-line counterexample)', () => {
+    expect(discriminantAtOrigin(presetById('quartic-min'))).toBeCloseTo(0);
+  });
+});

--- a/test/scaffold/ui/Slider.test.ts
+++ b/test/scaffold/ui/Slider.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { Slider } from '@/scaffold/ui/Slider';
+
+// Vitest coverage for `Slider.setRange` (#178). Other Slider behavior —
+// drag-tick accumulation, snap-detent escape, ray-grab — is exercised
+// indirectly via per-scene mount/unmount; setRange is new module-level
+// state mutation that benefits from direct coverage.
+
+function makeSlider(overrides: Partial<{
+  min: number;
+  max: number;
+  initial: number;
+  snapDetent: number;
+  snapPoints: readonly number[];
+}> = {}) {
+  return new Slider({
+    label: 'test',
+    min: -1.5,
+    max: 1.5,
+    initial: 1.0,
+    snapDetent: 0.05,
+    snapPoints: [0],
+    grabRadiusMultiplier: 2.75,
+    ...overrides,
+  });
+}
+
+describe('Slider.setRange', () => {
+  it('updates min and max so subsequent setValue clamps to the new bounds', () => {
+    const slider = makeSlider({ initial: 0 });
+    slider.setRange(-1, 1);
+    slider.setValue(2);
+    expect(slider.value).toBe(1);
+    slider.setValue(-2);
+    expect(slider.value).toBe(-1);
+  });
+
+  it('clamps the current value into the new range when it falls outside', () => {
+    // initial = 1.4, range [-1.5, 1.5]. Shrink to [-1.2, 1.2] — 1.4 clamps to 1.2.
+    const slider = makeSlider({ initial: 1.4 });
+    expect(slider.value).toBeCloseTo(1.4);
+    slider.setRange(-1.2, 1.2);
+    expect(slider.value).toBeCloseTo(1.2);
+  });
+
+  it('leaves the current value untouched when it is inside the new range', () => {
+    const slider = makeSlider({ initial: 0.5 });
+    slider.setRange(-1.2, 1.2);
+    expect(slider.value).toBeCloseTo(0.5);
+  });
+
+  it('re-applies snap to the clamped value', () => {
+    // Park inside the [0]-snap detent (|v| < 0.05), then expand the range —
+    // the value should stay snapped to 0 after re-snap.
+    const slider = makeSlider({ initial: 0.02 });
+    expect(slider.value).toBe(0);
+    slider.setRange(-2, 2);
+    expect(slider.value).toBe(0);
+  });
+
+  it('throws when min >= max', () => {
+    const slider = makeSlider();
+    expect(() => slider.setRange(1, 1)).toThrow(/Slider\.setRange/);
+    expect(() => slider.setRange(2, 1)).toThrow(/Slider\.setRange/);
+  });
+
+  it('throws on non-finite bounds', () => {
+    const slider = makeSlider();
+    expect(() => slider.setRange(NaN, 1)).toThrow(/Slider\.setRange/);
+    expect(() => slider.setRange(-1, Infinity)).toThrow(/Slider\.setRange/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds the curated 5-preset library to the saddle-extrema scene: paraboloid (local min), inverted paraboloid (local max), saddle, monkey saddle, and `x⁴+y⁴` (the D=0 degenerate min). Each preset carries analytic `f`, `gradF`, and `hessF` plus a per-preset (x, y) `domain` sized to the cluster envelope.
- Adds the preset-selector UI — a row of five `TapButton`s above the slider rack, mirroring the manipulator's `Preset` cool-blue visual identity but with sticky-active (the preset here is a persistent mode, not a one-shot snap-to-pose).
- Adds `Slider.setRange(min, max)` so per-preset domain switches clamp current values into the new range cleanly.

## Test plan

- [x] `npx vitest run` — 285 tests passing (16 new for `presets.ts`, 6 new for `Slider.setRange`).
- [x] `npx tsc --noEmit` clean.
- [x] `npm run build` clean.
- [x] `npm run lint` clean.
- [x] **Headset smoke on Cloudflare PR preview:** the [memory rule](`feedback_headset_smoke_on_cloudflare_pr`) says to point the Quest at the preview URL, not `npm run dev`. Spot-checks:
  - All 5 preset buttons visible above the slider rack on entry; saddle button reads as sticky-active on boot.
  - Tapping a non-saddle preset → surface visibly swaps to the new `f`; tapped preset's emissive becomes sticky-active; previous preset returns to idle.
  - Slider thumbs clamp to new domain when switching to a preset with a smaller range (e.g., saddle [-1.5, 1.5] → quartic [-1, 1]).
  - Tapping the already-active preset is a press-flash-only no-op (no surface flicker).
  - Indicator stays on the surface across all preset switches; per-slider value labels update correctly.

Closes #178 (third sub-issue of #175).

🤖 Generated with [Claude Code](https://claude.com/claude-code)