### PR TITLE
feat(scene): saddle-extrema — live Hessian + D + classification readout (#181)

### DIFF
--- a/src/exhibits/saddle-extrema/SPEC.md
+++ b/src/exhibits/saddle-extrema/SPEC.md
@@ -5,10 +5,10 @@
 > new meshed graph-surface rendering primitive, and ships one locked
 > starter preset (`z = x² − y²`). #177 adds (x, y) point selection;
 > #178 expands the preset library to five archetypes + adds `hessF`
-> to the preset record + ships the preset-selector UI; #179 adds
-> critical-point markers; #180 ships the local-quadratic-approximation
-> overlay (the §11.7–11.8 punch line); #181 ships the live Hessian +
-> classification readout.
+> to the preset record + ships the preset-selector UI; #181 ships the
+> live Hessian + classification readout; #179 adds critical-point
+> markers; #180 ships the local-quadratic-approximation overlay (the
+> §11.7–11.8 punch line).
 
 ## Goal
 
@@ -322,7 +322,69 @@ Visibility check for the starter saddle:
   (top corner above eye level), total ~58°.
 - Quest 3 FOV: ~96°×96° per eye. Saddle fits well within FOV.
 
-## Out of scope (v0.8 beyond #178)
+## Classification readout (#181)
+
+Live three-line readout above the preset row (`READOUT_POSITION = (0,
+1.50, -0.7)`) showing the symmetric Hessian entries, the
+discriminant, and the second-derivative-test verdict at the
+slider-selected `(x, y)`:
+
+```
+line 1 (top): f_xx = ±N.NN   f_xy = ±N.NN   f_yy = ±N.NN
+line 2 (mid): D = ±N.NN
+line 3 (bot): <verdict>
+```
+
+Verdict is one of `local min` / `local max` / `saddle` /
+`inconclusive`. Branches per §11.7–11.8:
+
+- `D > 0` and `f_xx > 0` ⇒ local min.
+- `D > 0` and `f_xx < 0` ⇒ local max.
+- `D < 0` ⇒ saddle.
+- `|D| < ε` (default `1e-9`) ⇒ inconclusive (test failure; higher-
+  order terms determine the shape).
+
+`f_xx` and `f_yy` are tinted with the cluster's math-X / math-Y axis
+colors (vermillion / bluish-green) to reinforce "pure-x² / pure-y²
+term"; the cross term `f_xy` stays white to read as "neither pure
+axis." `D` and the verdict use YELLOW — the same accent the
+gradient-levels readout (#166) uses for `|∇f|`.
+
+### Always-on at any (x, y) (not just critical points)
+
+Strictly the second-derivative test classifies *critical* points —
+at a non-critical point the linear term dominates and "local min /
+saddle / ..." isn't a well-formed claim about the surface there.
+The readout displays the Hessian-based verdict at whatever `(x, y)`
+the sliders select anyway, mirroring the always-on local-quadratic
+overlay's (#180) approach: this is "what *would* the local shape be
+IF this were a critical point." The interpretation that the verdict
+only *applies* at a critical point is a SPEC-level claim, not a
+runtime gate on the display.
+
+Pedagogical payoff: the student steps `(x, y)` toward the origin on
+the monkey saddle preset and watches `D` cross zero as the local
+shape transitions — visualizing the test's failure mode rather than
+memorizing it as a footnote. Pure formatting + classification logic
+lives in `formatSaddleExtremaReadout.ts`, covered by
+`test/exhibits/saddle-extrema/formatSaddleExtremaReadout.test.ts`.
+
+### Layout sizing
+
+Slot widths are sized to worst-case preset values within the
+slider-reachable domains:
+
+- Hessian entries: `NUMERIC_ENTRY_EM = 3.2` fits `−12.00` (quartic
+  at domain corner `(1, 1)`: `f_xx = 12`).
+- D: `NUMERIC_D_EM = 4.2` fits `−103.68` (monkey saddle at domain
+  corner `(1.2, 1.2)`: `D = -36·(x² + y²) ≈ -103.68`).
+
+`SYNC_INTERVAL_MS = 33` throttles troika-Text `.sync()` calls to
+≈30 Hz, mirroring `GradientLevelsReadout` / `TangentPlaneReadout`.
+Per-slot string caching skips the write entirely when the formatted
+string hasn't changed.
+
+## Out of scope (v0.8 beyond #181)
 
 - **Critical-point markers (#179).** Small visual markers at the
   analytically-known critical points (all at origin for v0.8 presets).
@@ -330,9 +392,6 @@ Visibility check for the starter saddle:
   Taylor approximation rendered as a second graph surface hugging the
   main one at the selected point. Reuses `GraphSurface` and
   `writeGraphPointToWorld`. The §11.7–11.8 punch line.
-- **Hessian + classification readout (#181).** Live 2×2 Hessian,
-  `D = f_xx · f_yy − f_xy²`, classification verdict
-  (min / max / saddle / inconclusive).
 - **`GraphSurface` extraction to `src/scaffold/`.** Deferred until a
   second scene wants the primitive (likely v1.x). The overlay in #180
   is a same-scene consumer; doesn't count for the extract-on-second-

--- a/src/exhibits/saddle-extrema/SaddleExtremaReadout.ts
+++ b/src/exhibits/saddle-extrema/SaddleExtremaReadout.ts
@@ -1,0 +1,295 @@
+import * as THREE from 'three';
+import { Text } from 'troika-three-text';
+import {
+  formatSaddleExtremaReadout,
+  type SaddleExtremaReadoutStrings,
+} from './formatSaddleExtremaReadout';
+import type { Hessian } from './presets';
+
+// Live classification readout for the saddle-extrema scene (#181).
+// Three-line layout:
+//
+//   line 1 (top): `f_xx = ±N.NN   f_xy = ±N.NN   f_yy = ±N.NN`
+//   line 2 (mid): `D = ±N.NN`
+//   line 3 (bot): `<verdict>`
+//
+// The top line spells out the three symmetric-Hessian entries; the
+// diagonal entries are tinted with the cluster's math-X / math-Y axis
+// colors (vermillion / bluish-green) to reinforce "f_xx is the pure-x²
+// term, f_yy is the pure-y² term," while the off-diagonal f_xy stays
+// white to read as "neither pure axis — it's the mix." Line 2's `D`
+// and line 3's verdict are YELLOW accents, matching the cluster's
+// "interpretive numeric" convention from gradient-levels (#166).
+//
+// Per-entry prefixes (`f_xx = `, etc.) are kept literal here rather
+// than unicode subscripts — Unicode lacks a subscript-`y`, so the
+// `fₓₓ / fᵧᵧ` form would be asymmetric (`fₓₓ / f_yy`). The literal
+// underscore form reads consistently across all three.
+//
+// Sibling design choice (vs. extending `GradientLevelsReadout`):
+// GradientLevelsReadout has 4 slots in a 2-line layout (3 components +
+// 1 magnitude); this readout has 5 slots in a 3-line layout (3 H
+// entries + D + verdict). The slot wiring, line layout, and per-slot
+// label-vs-value treatment all differ enough that wrapping the
+// troika-Text + yaw-billboard idioms here keeps the surface narrow,
+// matching the rationale gradient-levels' readout used to justify
+// not extending tangent-planes'.
+//
+// Layout is computed once at construction; only numeric .text values
+// (and the verdict string) change per frame, throttled to ≈30 Hz like
+// `GradientLevelsReadout` / `TangentPlaneReadout`.
+//
+// Initial-text policy: Text instances boot empty; `group.visible =
+// false` until the first `setValues()` call populates the slots. The
+// saddle-extrema scene's boot pose hits valid Hessian data on the
+// first tick, so the readout uncloaks within one frame.
+
+export interface SaddleExtremaReadoutOptions {
+  /**
+   * Diffuse color for the f_xx entry (math-X axis tint at the call
+   * site). Constructor accepts the value so the class stays
+   * presentation-agnostic.
+   */
+  fxxColor: number;
+  /**
+   * Diffuse color for the f_xy cross-term entry. White at the call
+   * site — no single axis association.
+   */
+  fxyColor: number;
+  /**
+   * Diffuse color for the f_yy entry (math-Y axis tint at the call
+   * site).
+   */
+  fyyColor: number;
+  /** Diffuse color for the D value and verdict text (YELLOW accent). */
+  accentColor: number;
+  fontSize?: number;
+}
+
+const DEFAULT_FONT_SIZE = 0.028;
+
+// Slot widths in em (multiples of fontSize). NUMERIC_ENTRY_EM fits
+// worst-case `−12.00` (monkey saddle / quartic at domain corners);
+// NUMERIC_D_EM fits worst-case `−103.68` (monkey saddle at corner
+// `(1.2, 1.2)`: D = 36·(x² + y²) ≈ 103.68 with sign from sliders).
+const NUMERIC_ENTRY_EM = 3.2;
+const NUMERIC_D_EM = 4.2;
+
+// Top-line per-entry prefix `f_xx = ` (and `f_xy = `, `f_yy = `).
+const PREFIX_ENTRY_EM = 3.5;
+// Between adjacent entry pairs on the top line.
+const TOP_ENTRY_GAP_EM = 1.2;
+// `D = ` on the middle line.
+const PREFIX_D_EM = 2.0;
+
+// Vertical pitch — same as gradient-levels for visual consistency
+// across the cluster's readouts. Three lines ⇒ ±LINE_PITCH around mid.
+const LINE_PITCH = 0.06;
+
+const SEPARATOR_COLOR = 0xffffff;
+const OUTLINE_WIDTH = '8%';
+const OUTLINE_COLOR = 0x000000;
+
+// Throttle troika `.sync()` calls. Bounds SDF rebuild work during fast
+// slider drags. Per-frame head-pose billboarding (faceCamera) still
+// runs every frame so motion smoothness is unaffected.
+const SYNC_INTERVAL_MS = 33;
+
+// Entry-slot index range — `for i = ENTRY_XX; i <= ENTRY_YY` covers
+// [f_xx, f_xy, f_yy] in math reading order. The middle index (f_xy)
+// has no symbolic name; the loop body indexes the per-slot arrays
+// directly.
+const ENTRY_XX = 0;
+const ENTRY_YY = 2;
+
+export class SaddleExtremaReadout {
+  readonly group: THREE.Group;
+
+  private readonly fontSize: number;
+
+  // Top-line entry numerics: [f_xx, f_xy, f_yy].
+  private readonly entryNumerics: readonly Text[];
+
+  // Middle-line D numeric.
+  private readonly dNumeric: Text;
+
+  // Bottom-line verdict text.
+  private readonly verdictText: Text;
+
+  // Static prefixes / separators. Held for disposal; never re-written.
+  private readonly separators: Text[] = [];
+
+  // Per-slot string cache so .text + .sync() doesn't fire when the
+  // formatted string hasn't changed across the throttle gate.
+  private readonly entryCache: string[] = new Array(3).fill('');
+  private dCache = '';
+  private verdictCache = '';
+
+  private lastSyncMs = 0;
+
+  // Hoisted scratch for per-frame yaw billboarding — no allocation.
+  private readonly camWorld = new THREE.Vector3();
+  private readonly groupWorld = new THREE.Vector3();
+
+  constructor(opts: SaddleExtremaReadoutOptions) {
+    this.fontSize = opts.fontSize ?? DEFAULT_FONT_SIZE;
+
+    this.group = new THREE.Group();
+    this.group.name = 'saddle-extrema-readout';
+    // Hidden until first setValues() populates the numerics. Avoids
+    // painting empty strings on the first frame between mount and
+    // first update().
+    this.group.visible = false;
+
+    const numericEntryW = NUMERIC_ENTRY_EM * this.fontSize;
+    const numericDW = NUMERIC_D_EM * this.fontSize;
+    const prefixEntryW = PREFIX_ENTRY_EM * this.fontSize;
+    const prefixDW = PREFIX_D_EM * this.fontSize;
+    const topGapW = TOP_ENTRY_GAP_EM * this.fontSize;
+
+    const topY = LINE_PITCH;
+    const midY = 0;
+    const bottomY = -LINE_PITCH;
+
+    // ─── Top line ──────────────────────────────────────────────────
+    // `f_xx = ` [n_xx] `   f_xy = ` [n_xy] `   f_yy = ` [n_yy]
+    const totalTopW =
+      3 * prefixEntryW + 3 * numericEntryW + 2 * topGapW;
+    let cursor = -totalTopW / 2;
+
+    const entryColors: readonly [number, number, number] = [
+      opts.fxxColor,
+      opts.fxyColor,
+      opts.fyyColor,
+    ];
+    const entryPrefixes: readonly [string, string, string] = [
+      'f_xx = ',
+      'f_xy = ',
+      'f_yy = ',
+    ];
+
+    const entryNumerics: Text[] = new Array<Text>(3);
+    for (let i = ENTRY_XX; i <= ENTRY_YY; i++) {
+      const prefix = this.makeSeparatorText(this.fontSize);
+      prefix.text = entryPrefixes[i];
+      prefix.position.set(cursor + prefixEntryW / 2, topY, 0);
+      prefix.sync();
+      this.group.add(prefix);
+      this.separators.push(prefix);
+      cursor += prefixEntryW;
+
+      const nText = this.makeNumericText(this.fontSize, entryColors[i]);
+      nText.position.set(cursor + numericEntryW / 2, topY, 0);
+      this.group.add(nText);
+      entryNumerics[i] = nText;
+      cursor += numericEntryW;
+
+      if (i !== ENTRY_YY) cursor += topGapW;
+    }
+    this.entryNumerics = entryNumerics;
+
+    // ─── Middle line ───────────────────────────────────────────────
+    // `D = ` [d]
+    const totalMidW = prefixDW + numericDW;
+    cursor = -totalMidW / 2;
+
+    const dPrefix = this.makeSeparatorText(this.fontSize);
+    dPrefix.text = 'D = ';
+    dPrefix.position.set(cursor + prefixDW / 2, midY, 0);
+    dPrefix.sync();
+    this.group.add(dPrefix);
+    this.separators.push(dPrefix);
+    cursor += prefixDW;
+
+    this.dNumeric = this.makeNumericText(this.fontSize, opts.accentColor);
+    this.dNumeric.position.set(cursor + numericDW / 2, midY, 0);
+    this.group.add(this.dNumeric);
+
+    // ─── Bottom line ───────────────────────────────────────────────
+    // verdict (single centered text slot). Anchored at x = 0 with
+    // `anchorX: 'center'` so it stays centered as the verdict-text
+    // length changes — 'saddle' (6 chars) ↔ 'inconclusive' (12 chars).
+    this.verdictText = this.makeNumericText(this.fontSize, opts.accentColor);
+    this.verdictText.position.set(0, bottomY, 0);
+    this.group.add(this.verdictText);
+  }
+
+  private makeNumericText(fontSize: number, color: number): Text {
+    const t = new Text();
+    t.fontSize = fontSize;
+    t.color = color;
+    t.anchorX = 'center';
+    t.anchorY = 'middle';
+    t.outlineWidth = OUTLINE_WIDTH;
+    t.outlineColor = OUTLINE_COLOR;
+    return t;
+  }
+
+  private makeSeparatorText(fontSize: number): Text {
+    const t = new Text();
+    t.fontSize = fontSize;
+    t.color = SEPARATOR_COLOR;
+    t.anchorX = 'center';
+    t.anchorY = 'middle';
+    t.outlineWidth = OUTLINE_WIDTH;
+    t.outlineColor = OUTLINE_COLOR;
+    return t;
+  }
+
+  /**
+   * Update all five slots from the per-frame Hessian. Throttled to
+   * ≈30 Hz via SYNC_INTERVAL_MS, with per-slot caching so unchanged
+   * strings don't re-trigger troika's `.sync()`.
+   *
+   * On first call, uncloaks `group.visible = true` — the readout
+   * boots hidden so empty-string frames never paint.
+   */
+  setValues(hessian: Hessian): void {
+    if (!this.group.visible) this.group.visible = true;
+
+    const now = performance.now();
+    if (now - this.lastSyncMs < SYNC_INTERVAL_MS) return;
+    this.lastSyncMs = now;
+
+    const s: SaddleExtremaReadoutStrings = formatSaddleExtremaReadout(hessian);
+
+    for (let i = ENTRY_XX; i <= ENTRY_YY; i++) {
+      const entry = s.hessianEntries[i];
+      if (entry !== this.entryCache[i]) {
+        this.entryCache[i] = entry;
+        this.entryNumerics[i].text = entry;
+        this.entryNumerics[i].sync();
+      }
+    }
+
+    if (s.determinant !== this.dCache) {
+      this.dCache = s.determinant;
+      this.dNumeric.text = s.determinant;
+      this.dNumeric.sync();
+    }
+
+    if (s.verdict !== this.verdictCache) {
+      this.verdictCache = s.verdict;
+      this.verdictText.text = s.verdict;
+      this.verdictText.sync();
+    }
+  }
+
+  // Yaw-only billboard. World-up stays world-up; head pitch/roll don't
+  // tilt the readout. Mirrors GradientLevelsReadout / TangentPlaneReadout
+  // / Label.
+  faceCamera(camera: THREE.Camera): void {
+    camera.getWorldPosition(this.camWorld);
+    this.group.getWorldPosition(this.groupWorld);
+    const dx = this.camWorld.x - this.groupWorld.x;
+    const dz = this.camWorld.z - this.groupWorld.z;
+    this.group.rotation.set(0, Math.atan2(dx, dz), 0);
+  }
+
+  dispose(): void {
+    for (const t of this.entryNumerics) t.dispose();
+    this.dNumeric.dispose();
+    this.verdictText.dispose();
+    for (const t of this.separators) t.dispose();
+  }
+}

--- a/src/exhibits/saddle-extrema/formatSaddleExtremaReadout.ts
+++ b/src/exhibits/saddle-extrema/formatSaddleExtremaReadout.ts
@@ -1,0 +1,101 @@
+import { formatSignedMagnitude } from '@/scaffold/ui/formatSignedMagnitude';
+import type { Hessian } from './presets';
+
+// Pure formatter for the saddle-extrema classification readout (#181).
+// Given the symmetric Hessian entries `(f_xx, f_xy, f_yy)` at the
+// selected point, produce the strings the readout's troika-Text slots
+// render plus the classification verdict from the second-derivative
+// test.
+//
+// Sibling of `gradient-levels/formatGradientLevelsReadout.ts` —
+// lives in its own file so `test/exhibits/saddle-extrema/*` can import
+// without triggering `index.ts`'s `registerExhibit` side effect at
+// unit-test import time. Same isolation pattern as `GraphSurface.ts` and
+// the gradient-levels formatters.
+//
+// Strictly, the second-derivative test classifies *critical* points;
+// at a non-critical point the linear term dominates and the verdict
+// "local min / saddle / ..." isn't a well-formed claim about the
+// surface there. The readout displays the Hessian-based verdict at
+// whatever (x, y) is selected anyway — pedagogically this is "what
+// *would* the local shape be IF this were a critical point," and
+// it parallels the always-on local-quadratic overlay (#180) which
+// renders the second-order Taylor approximation regardless of
+// criticality. The interpretation that the verdict only *applies* at
+// a critical point belongs in the SPEC, not in this formatter.
+
+/** Inconclusive band for the second-derivative test. */
+const DEFAULT_INCONCLUSIVE_EPS = 1e-9;
+
+/**
+ * Classification verdict from the second-derivative test (§11.7–11.8).
+ * Lowercase phrasing matches the cluster's tone (verdict reads as a
+ * text label, not a heading).
+ */
+export type SaddleExtremaVerdict =
+  | 'local min'
+  | 'local max'
+  | 'saddle'
+  | 'inconclusive';
+
+export interface SaddleExtremaReadoutStrings {
+  /** Hessian entries [f_xx, f_xy, f_yy], each signed-magnitude 2-decimal. */
+  readonly hessianEntries: readonly [string, string, string];
+  /** `D = f_xx · f_yy − f_xy²`, signed-magnitude 2-decimal. */
+  readonly determinant: string;
+  /** Classification verdict text — drives the bottom-line readout slot. */
+  readonly verdict: SaddleExtremaVerdict;
+}
+
+/**
+ * Classify the critical-point archetype from a 2×2 symmetric Hessian.
+ *
+ * - `D > 0` and `f_xx > 0` ⇒ local min.
+ * - `D > 0` and `f_xx < 0` ⇒ local max.
+ * - `D < 0` ⇒ saddle.
+ * - `|D| < eps` ⇒ inconclusive (second-derivative test fails;
+ *   higher-order terms determine the local shape — the §11.7–11.8
+ *   stuck-point that the preset library's monkey saddle and `x⁴+y⁴`
+ *   were chosen to surface).
+ *
+ * Edge case `D > 0` with `f_xx === 0`: impossible — if `f_xx = 0` then
+ * `D = -f_xy² ≤ 0`, contradicting `D > 0`. The branch is unreachable
+ * and intentionally not coded for.
+ */
+export function classifySaddleExtrema(
+  hessian: Hessian,
+  eps: number = DEFAULT_INCONCLUSIVE_EPS,
+): SaddleExtremaVerdict {
+  const [fxx, fxy, fyy] = hessian;
+  const D = fxx * fyy - fxy * fxy;
+  if (Math.abs(D) < eps) return 'inconclusive';
+  if (D < 0) return 'saddle';
+  return fxx > 0 ? 'local min' : 'local max';
+}
+
+/**
+ * Format the readout strings from a 2×2 symmetric Hessian. Pure;
+ * allocates one fresh struct per call. The readout throttles
+ * `setValues()` to ≈30 Hz so allocation rate stays bounded.
+ *
+ * Both the entries and `D` use `formatSignedMagnitude` (`±N.NN` with
+ * U+2212 minus) for visual consistency with the cluster's other
+ * readouts — gradient-levels' components, tangent-planes' normal
+ * components, the equation-readout coefficients.
+ */
+export function formatSaddleExtremaReadout(
+  hessian: Hessian,
+  eps: number = DEFAULT_INCONCLUSIVE_EPS,
+): SaddleExtremaReadoutStrings {
+  const [fxx, fxy, fyy] = hessian;
+  const D = fxx * fyy - fxy * fxy;
+  return {
+    hessianEntries: [
+      formatSignedMagnitude(fxx),
+      formatSignedMagnitude(fxy),
+      formatSignedMagnitude(fyy),
+    ],
+    determinant: formatSignedMagnitude(D),
+    verdict: classifySaddleExtrema(hessian, eps),
+  };
+}

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -6,6 +6,7 @@ import {
   BLUISH_GREEN,
   DEFAULT_AXIS_COLORS,
   VERMILLION,
+  YELLOW,
 } from '@/scaffold/design/tokens';
 import { Label } from '@/scaffold/ui/Label';
 import { Slider } from '@/scaffold/ui/Slider';
@@ -20,6 +21,7 @@ import {
   type GraphSurfaceHandles,
 } from './GraphSurface';
 import { DEFAULT_PRESET_INDEX, PRESETS } from './presets';
+import { SaddleExtremaReadout } from './SaddleExtremaReadout';
 
 // Saddle / extrema scene (#175 epic). Fourth and final member of the
 // calculus3 cluster, alongside quadrics, tangent-planes, and gradient-levels.
@@ -47,6 +49,13 @@ const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
 const AXIS_INDICATOR_POSITION = new THREE.Vector3(0.35, 1.17, -0.7);
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
 const BASE_COLOR = new THREE.Color(0.4, 0.7, 0.95);
+
+// Classification readout (#181) — three lines (Hessian entries / D /
+// verdict). Anchored above the preset row (preset-row buttons cap at
+// y ≈ 1.32 including button radius) with ~0.12 m vertical clearance.
+// Shares the foreground-UI z-plane with the slider rack and preset
+// row so the user's gaze stays in one depth band.
+const READOUT_POSITION = new THREE.Vector3(0, 1.5, -0.7);
 
 // Slider rack — two-row symmetric straddle around SLIDER_RACK_CENTER. The
 // 3-row top-heavy pattern from gradient-levels (θ/φ/k at [center+pitch,
@@ -143,6 +152,7 @@ let yLabel: Label | undefined;
 let indicator: THREE.Mesh | undefined;
 let presetButtons: TapButton[] = [];
 let activePresetIndex = DEFAULT_PRESET_INDEX;
+let saddleExtremaReadout: SaddleExtremaReadout | undefined;
 let camera: THREE.Camera | undefined;
 let controllers: readonly THREE.Object3D[] = [];
 
@@ -280,6 +290,22 @@ const saddleExtremaExhibit: Exhibit = {
     worldAxes.group.position.copy(AXIS_INDICATOR_POSITION);
     group.add(worldAxes.group);
 
+    // Classification readout (#181). f_xx and f_yy tinted with the
+    // cluster's math-X / math-Y axis colors (vermillion / bluish-green)
+    // to reinforce "f_xx is the pure-x² term, f_yy is the pure-y²
+    // term"; the cross-term f_xy stays white to read as "neither pure
+    // axis." D and verdict use YELLOW — the same accent gradient-levels
+    // (#166) uses for the |∇f| numeric. Boots hidden; the first
+    // update() tick populates the slots and uncloaks.
+    saddleExtremaReadout = new SaddleExtremaReadout({
+      fxxColor: VERMILLION,
+      fxyColor: 0xffffff,
+      fyyColor: BLUISH_GREEN,
+      accentColor: YELLOW,
+    });
+    saddleExtremaReadout.group.position.copy(READOUT_POSITION);
+    group.add(saddleExtremaReadout.group);
+
     // Preset row (#178) — five archetypes left → right, mirroring the
     // PRESETS array order. The starter (saddle, DEFAULT_PRESET_INDEX) is
     // marked sticky-active so the user reads which archetype is current.
@@ -333,9 +359,22 @@ const saddleExtremaExhibit: Exhibit = {
         yLabel.setSecondary(formatLinearDecimal(y));
         yLabel.faceCamera(camera);
       }
+
+      // 4. Classification readout (#181). Hessian evaluated at the
+      //    current (x, y) — the readout shows what the second-
+      //    derivative test would *report* at that point, treating it
+      //    as if it were a critical point. SPEC.md §"Classification
+      //    readout" documents the always-on-at-any-point contract.
+      if (saddleExtremaReadout) {
+        saddleExtremaReadout.setValues(activePreset.hessF(x, y));
+      }
     }
 
-    // 4. Preset-button hover + press-flash tick. Faces the camera so
+    if (saddleExtremaReadout && camera) {
+      saddleExtremaReadout.faceCamera(camera);
+    }
+
+    // 5. Preset-button hover + press-flash tick. Faces the camera so
     //    labels stay readable at any user yaw, mirroring the slider-
     //    label and worldAxes billboarding contract.
     for (const btn of presetButtons) {
@@ -374,6 +413,8 @@ const saddleExtremaExhibit: Exhibit = {
     yLabel = undefined;
     for (const btn of presetButtons) btn.dispose();
     presetButtons = [];
+    saddleExtremaReadout?.dispose();
+    saddleExtremaReadout = undefined;
     if (indicator) {
       indicator.geometry.dispose();
       (indicator.material as THREE.Material).dispose();

--- a/test/exhibits/saddle-extrema/formatSaddleExtremaReadout.test.ts
+++ b/test/exhibits/saddle-extrema/formatSaddleExtremaReadout.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifySaddleExtrema,
+  formatSaddleExtremaReadout,
+} from '@/exhibits/saddle-extrema/formatSaddleExtremaReadout';
+import { PRESETS } from '@/exhibits/saddle-extrema/presets';
+
+// Pure-formatter + classifier coverage for the saddle-extrema readout
+// (#181). Numeric formatting follows `formatSignedMagnitude` (covered
+// at scaffold level); the per-archetype classification verdicts are
+// the load-bearing logic here.
+
+const MINUS = '−'; // U+2212
+
+describe('classifySaddleExtrema — second-derivative test branches', () => {
+  it('D > 0 and f_xx > 0 ⇒ local min', () => {
+    // f = x² + y² at origin ⇒ H = [[2, 0], [0, 2]], D = 4.
+    expect(classifySaddleExtrema([2, 0, 2])).toBe('local min');
+  });
+
+  it('D > 0 and f_xx < 0 ⇒ local max', () => {
+    // f = -(x² + y²) at origin ⇒ H = [[-2, 0], [0, -2]], D = 4.
+    expect(classifySaddleExtrema([-2, 0, -2])).toBe('local max');
+  });
+
+  it('D < 0 ⇒ saddle', () => {
+    // f = x² - y² at origin ⇒ H = [[2, 0], [0, -2]], D = -4.
+    expect(classifySaddleExtrema([2, 0, -2])).toBe('saddle');
+  });
+
+  it('D == 0 (monkey saddle at origin) ⇒ inconclusive', () => {
+    // f = x³ - 3xy² at origin ⇒ H = 0 ⇒ D = 0 ⇒ test fails.
+    expect(classifySaddleExtrema([0, 0, 0])).toBe('inconclusive');
+  });
+
+  it('D == 0 (x⁴ + y⁴ at origin, surface IS a local min) ⇒ inconclusive', () => {
+    // The §11.7–11.8 punch-line case: D = 0 but surface is unambiguously
+    // a local min. The verdict honors the test's silence rather than
+    // promoting it to 'local min' via knowledge the test doesn't have.
+    expect(classifySaddleExtrema([0, 0, 0])).toBe('inconclusive');
+  });
+
+  it('|D| < eps default (1e-9) ⇒ inconclusive', () => {
+    // f_xx · f_yy − f_xy² ≈ 1e-10 — below the default band.
+    expect(classifySaddleExtrema([1e-5, 0, 1e-5])).toBe('inconclusive');
+  });
+
+  it('non-zero cross term still classifies via D sign', () => {
+    // f_xx = 3, f_xy = 1, f_yy = 2 ⇒ D = 6 - 1 = 5 > 0, f_xx > 0 ⇒ min.
+    expect(classifySaddleExtrema([3, 1, 2])).toBe('local min');
+  });
+
+  it('caller-supplied eps band widens the inconclusive region', () => {
+    // D = 0.5; default eps would classify as 'local min' (D > 0, f_xx > 0).
+    // Caller eps = 1 reclassifies as inconclusive.
+    expect(classifySaddleExtrema([1, 0, 0.5])).toBe('local min');
+    expect(classifySaddleExtrema([1, 0, 0.5], 1)).toBe('inconclusive');
+  });
+});
+
+describe('formatSaddleExtremaReadout — string slot formatting', () => {
+  it('positive entries → leading "+" sign', () => {
+    const r = formatSaddleExtremaReadout([2, 0, 2]);
+    expect(r.hessianEntries).toEqual(['+2.00', '+0.00', '+2.00']);
+    expect(r.determinant).toBe('+4.00');
+  });
+
+  it('negative entries → leading "−" sign (U+2212)', () => {
+    const r = formatSaddleExtremaReadout([-2, 0, -2]);
+    expect(r.hessianEntries).toEqual([
+      `${MINUS}2.00`,
+      '+0.00',
+      `${MINUS}2.00`,
+    ]);
+    expect(r.determinant).toBe('+4.00');
+  });
+
+  it('saddle (D < 0) → negative determinant string', () => {
+    const r = formatSaddleExtremaReadout([2, 0, -2]);
+    expect(r.determinant).toBe(`${MINUS}4.00`);
+    expect(r.verdict).toBe('saddle');
+  });
+
+  it('non-zero cross term contributes to D = f_xx·f_yy − f_xy²', () => {
+    // f_xx = 3, f_xy = 1, f_yy = 2 ⇒ D = 5.
+    const r = formatSaddleExtremaReadout([3, 1, 2]);
+    expect(r.hessianEntries).toEqual(['+3.00', '+1.00', '+2.00']);
+    expect(r.determinant).toBe('+5.00');
+  });
+});
+
+describe('formatSaddleExtremaReadout — composition with preset library at origin', () => {
+  // Each preset's critical point sits at the origin (SPEC §"Pedagogical
+  // observation — all critical points at origin"). Feeding `hessF(0, 0)`
+  // into the formatter must produce the SPEC's tabulated verdict.
+
+  it('paraboloid at origin ⇒ local min, D = +4', () => {
+    const preset = PRESETS.find((p) => p.id === 'paraboloid')!;
+    const r = formatSaddleExtremaReadout(preset.hessF(0, 0));
+    expect(r.verdict).toBe('local min');
+    expect(r.determinant).toBe('+4.00');
+  });
+
+  it('inv-paraboloid at origin ⇒ local max, D = +4', () => {
+    const preset = PRESETS.find((p) => p.id === 'inv-paraboloid')!;
+    const r = formatSaddleExtremaReadout(preset.hessF(0, 0));
+    expect(r.verdict).toBe('local max');
+    expect(r.determinant).toBe('+4.00');
+  });
+
+  it('saddle at origin ⇒ saddle, D = −4', () => {
+    const preset = PRESETS.find((p) => p.id === 'saddle')!;
+    const r = formatSaddleExtremaReadout(preset.hessF(0, 0));
+    expect(r.verdict).toBe('saddle');
+    expect(r.determinant).toBe(`${MINUS}4.00`);
+  });
+
+  it('monkey-saddle at origin ⇒ inconclusive (D = 0)', () => {
+    const preset = PRESETS.find((p) => p.id === 'monkey-saddle')!;
+    const r = formatSaddleExtremaReadout(preset.hessF(0, 0));
+    expect(r.verdict).toBe('inconclusive');
+    expect(r.determinant).toBe('+0.00');
+  });
+
+  it('quartic-min at origin ⇒ inconclusive (D = 0, but surface IS min — test failure case)', () => {
+    const preset = PRESETS.find((p) => p.id === 'quartic-min')!;
+    const r = formatSaddleExtremaReadout(preset.hessF(0, 0));
+    // The second-derivative test is *silent* here even though the
+    // surface is a local min — surfacing this case is the pedagogical
+    // point of including the preset.
+    expect(r.verdict).toBe('inconclusive');
+    expect(r.determinant).toBe('+0.00');
+  });
+});
+
+describe('formatSaddleExtremaReadout — off-origin classification (verdict applies to displayed Hessian, not just critical points)', () => {
+  // The readout displays the second-derivative-test verdict at whatever
+  // (x, y) is selected. Strictly the test classifies *critical* points,
+  // but the readout treats the Hessian-based verdict as the displayed
+  // claim — matching the always-on quadratic-overlay (#180) approach.
+  // These cases pin the contract that the verdict tracks H, not
+  // criticality.
+
+  it('paraboloid at (0.5, 0.3): H = [[2,0],[0,2]] everywhere ⇒ local min', () => {
+    const preset = PRESETS.find((p) => p.id === 'paraboloid')!;
+    // Paraboloid Hessian is constant — same verdict everywhere.
+    const r = formatSaddleExtremaReadout(preset.hessF(0.5, 0.3));
+    expect(r.verdict).toBe('local min');
+  });
+
+  it('monkey-saddle at (0.5, 0.3): H = [[3, -1.8], [-1.8, -3]] ⇒ saddle (D = -12.24)', () => {
+    const preset = PRESETS.find((p) => p.id === 'monkey-saddle')!;
+    // hessF(0.5, 0.3) = [6·0.5, -6·0.3, -6·0.5] = [3, -1.8, -3].
+    // D = 3 · (-3) - (-1.8)² = -9 - 3.24 = -12.24 ⇒ saddle.
+    const r = formatSaddleExtremaReadout(preset.hessF(0.5, 0.3));
+    expect(r.verdict).toBe('saddle');
+    expect(r.determinant).toBe(`${MINUS}12.24`);
+  });
+});


### PR DESCRIPTION
Closes #181

## Summary

Three-line classification readout for the saddle-extrema scene above
the preset row: the symmetric Hessian entries `(f_xx, f_xy, f_yy)`,
the discriminant `D = f_xx · f_yy − f_xy²`, and the verdict from the
§11.7–11.8 second-derivative test (`local min` / `local max` /
`saddle` / `inconclusive`). Hessian comes from each preset's `hessF`
(landed in #178) evaluated at the slider-selected `(x, y)`.

Layout + color choices mirror the cluster's prior readout (#166):
`f_xx` / `f_yy` carry the math-X / math-Y axis tints to reinforce
"pure-x² / pure-y² term," the cross term `f_xy` stays white, `D` and
the verdict use YELLOW. The format helper + classifier live in their
own pure module (`formatSaddleExtremaReadout.ts`) so unit tests can
import them without triggering `registerExhibit` at test-load time —
same isolation pattern as the gradient-levels formatters.

## Test plan

- [ ] Cloudflare PR preview: load `?exhibit=saddle-extrema` on a Quest
      browser; verify the three-line readout sits above the preset
      row and reads cleanly without occlusion from the slider rack.
- [ ] Step through all 5 presets; confirm the verdict matches the
      expected archetype at the origin (paraboloid → local min,
      inv-paraboloid → local max, saddle → saddle, monkey saddle →
      inconclusive, x⁴ + y⁴ → inconclusive).
- [ ] On the monkey-saddle preset, drag `(x, y)` away from the origin
      and watch `D` cross from `0.00` to negative — verdict transitions
      from `inconclusive` to `saddle` as the Hessian sign clarifies.
- [ ] `npm run test` — 19 new cases in
      `test/exhibits/saddle-extrema/formatSaddleExtremaReadout.test.ts`,
      304/304 total green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)