### PR TITLE
feat(scene): saddle-extrema — critical-point markers at analytic CPs (#179)

### DIFF
--- a/src/exhibits/saddle-extrema/CriticalPointMarkers.ts
+++ b/src/exhibits/saddle-extrema/CriticalPointMarkers.ts
@@ -1,0 +1,105 @@
+import * as THREE from 'three';
+import { YELLOW } from '@/scaffold/design/tokens';
+import { writeGraphPointToWorld } from './GraphSurface';
+import type { SaddleExtremaPreset } from './presets';
+
+// Small marker spheres at each analytically-known critical point of the
+// active preset (#179). All v0.8 preset critical points sit at the origin
+// (cluster-shared observation in SPEC.md §"Pedagogical observation"), so
+// every preset renders one marker that lands on the slider-origin pose;
+// the data shape `CriticalPoint[]` is forward-looking for future presets
+// with off-origin or multiple CPs.
+//
+// Visual-only — sliders do NOT snap to markers. The (x, y) domain is small
+// enough that sliders find the origin easily via the existing origin-snap
+// detent (`SLIDER_SNAP_POINTS = [0]` in index.ts), and snap-detents are an
+// explicit per-scene design knob in the scaffold; the issue defers that
+// decision to v0.9 polish.
+
+// YELLOW for the marker continues the cluster's accent convention for
+// "important math fact at a point" — same color as the gradient-arrow
+// (#165), the |∇f| numeric (#166), and the D / verdict in the
+// classification readout (#181). Distinct from the off-white selected-
+// point indicator (`INDICATOR_COLOR = 0xdddddd`) so a side-by-side
+// reading is unambiguous; when the user slides the indicator onto a
+// critical point, the off-white sphere nesting over the yellow marker
+// reads as "you've reached the critical point."
+const MARKER_COLOR = YELLOW;
+
+// 0.024 m = 60% of the selected-point indicator's 0.04 m radius. The
+// marker is meant to be unobtrusive ("the lesson is the *shape*, not the
+// marker" — issue #179); smaller than the indicator keeps it visually
+// recessive while still readable at headset distance.
+const MARKER_RADIUS = 0.024;
+
+// Sphere tessellation matches the cluster's indicator + slider-thumb +
+// TapButton convention (16×12). Plenty smooth at the marker's small
+// visual size.
+const MARKER_WIDTH_SEGMENTS = 16;
+const MARKER_HEIGHT_SEGMENTS = 12;
+
+export interface CriticalPointMarkersOptions {
+  /** Active preset — provides `f` and `criticalPoints`. */
+  preset: SaddleExtremaPreset;
+  /** World-space anchor where math-origin lifts to. Same value the
+   *  graph-surface mesh + selected-point indicator anchor on. */
+  surfaceCenter: THREE.Vector3;
+}
+
+export interface CriticalPointMarkersHandles {
+  /**
+   * Group containing one marker mesh per critical point. Caller adds it
+   * to the scene; the markers are static within the group (the active
+   * preset's critical points are analytically fixed for the preset's
+   * lifetime, so no per-frame update is needed).
+   */
+  readonly group: THREE.Group;
+  /**
+   * Dispose all marker geometries + materials. Single owner — the scene's
+   * `unmount` (and `applyPreset` rebuild path) calls this once.
+   */
+  dispose(): void;
+}
+
+export function createCriticalPointMarkers(
+  opts: CriticalPointMarkersOptions,
+): CriticalPointMarkersHandles {
+  const group = new THREE.Group();
+  const meshes: THREE.Mesh[] = [];
+
+  // Reused per critical point; the SphereGeometry's world position is
+  // baked into the mesh.position at construction, so a single scratch
+  // can't clobber anything.
+  const scratchWorld = new THREE.Vector3();
+
+  // Shared geometry + material across all markers of the active preset
+  // — every marker is the same color and radius, so one instance feeds
+  // multiple meshes. Dispose-once via the shared refs below.
+  const geometry = new THREE.SphereGeometry(
+    MARKER_RADIUS,
+    MARKER_WIDTH_SEGMENTS,
+    MARKER_HEIGHT_SEGMENTS,
+  );
+  const material = new THREE.MeshStandardMaterial({ color: MARKER_COLOR });
+
+  for (const [cx, cy] of opts.preset.criticalPoints) {
+    const cz = opts.preset.f(cx, cy);
+    writeGraphPointToWorld(cx, cy, cz, opts.surfaceCenter, scratchWorld);
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.copy(scratchWorld);
+    group.add(mesh);
+    meshes.push(mesh);
+  }
+
+  return {
+    group,
+    dispose() {
+      // Shared geometry + material: one dispose call each, regardless of
+      // marker count. The meshes themselves don't own GPU resources
+      // beyond what they reference.
+      geometry.dispose();
+      material.dispose();
+      for (const mesh of meshes) group.remove(mesh);
+    },
+  };
+}

--- a/src/exhibits/saddle-extrema/SPEC.md
+++ b/src/exhibits/saddle-extrema/SPEC.md
@@ -7,8 +7,8 @@
 > #178 expands the preset library to five archetypes + adds `hessF`
 > to the preset record + ships the preset-selector UI; #181 ships the
 > live Hessian + classification readout; #179 adds critical-point
-> markers; #180 ships the local-quadratic-approximation overlay (the
-> §11.7–11.8 punch line).
+> markers + `criticalPoints` on the preset record; #180 ships the
+> local-quadratic-approximation overlay (the §11.7–11.8 punch line).
 
 ## Goal
 
@@ -83,6 +83,7 @@ Analytic data on each preset:
 - `gradF(x, y) → [f_x, f_y]` — first partials. Required (vertex normals on the graph-surface primitive read from this).
 - `hessF(x, y) → [f_xx, f_xy, f_yy]` — symmetric Hessian, three distinct entries. Stored on the preset for #181's classification readout (`D = f_xx · f_yy − f_xy²`); not consumed by #178 itself.
 - `domain: { xMin, xMax, yMin, yMax }` — per-preset rectangle, sized so the rendered surface fits the cluster envelope.
+- `criticalPoints: readonly [number, number][]` — analytically-known critical points (`∇f = 0`) in math-frame `(x, y)`. v0.8 entries are all `[[0, 0]]`; consumed by #179's markers, not by #178 / #181.
 
 ### Why per-preset domains?
 
@@ -384,10 +385,58 @@ slider-reachable domains:
 Per-slot string caching skips the write entirely when the formatted
 string hasn't changed.
 
-## Out of scope (v0.8 beyond #181)
+## Critical-point markers (#179)
 
-- **Critical-point markers (#179).** Small visual markers at the
-  analytically-known critical points (all at origin for v0.8 presets).
+Each preset declares its critical points analytically via
+`criticalPoints: readonly [number, number][]` on the preset record;
+#179 renders one small marker per CP at `(x_c, y_c, f(x_c, y_c))` on
+the graph surface so the student can navigate the `(x, y)` sliders to
+a known-interesting location and watch the local shape change.
+
+All v0.8 presets declare exactly `[[0, 0]]` — every critical point sits
+at the origin, per the cluster-shared pedagogical observation above.
+The shape `readonly [number, number][]` is forward-looking so a future
+preset with off-origin or multiple CPs drops in without an interface
+change.
+
+### Visual treatment
+
+Small YELLOW sphere (radius `0.024 m`) at each CP, lit
+`MeshStandardMaterial`. The marker is deliberately smaller than the
+selected-point indicator's `0.04 m` off-white sphere (≈60% the
+diameter) — the lesson is the *shape*, not the marker (#179 issue
+text). YELLOW continues the cluster's accent convention for
+"important math fact at a point" (gradient arrow #165, `|∇f|`
+numeric #166, `D` + verdict in the classification readout #181); the
+size + color contrast against the indicator keeps a side-by-side
+reading unambiguous.
+
+When the user navigates the indicator to a critical point, the
+indicator's larger off-white sphere nests over the marker — reading as
+"you've reached the critical point." The classification readout (#181)
+confirms the arrival with the live `D` + verdict.
+
+### Lifecycle
+
+Markers are built whole-cloth from `preset.criticalPoints` on mount and
+rebuilt on every preset swap — mirrors the `graphSurface` swap pattern
+in `applyPreset`. No per-frame update is needed (the active preset's
+critical points are analytically fixed for the preset's lifetime); the
+helper exposes `{ group, dispose() }` only. Geometry + material are
+shared across all markers of one preset and disposed once per swap.
+
+### Out of scope for #179
+
+- **Slider snap-detents on the critical points.** Visual-only per the
+  issue. The `(x, y)` domain is small enough that the existing
+  origin-snap detent (`SLIDER_SNAP_POINTS = [0]`) lands on every v0.8
+  preset's CP anyway; critical-point-aware snap is a quadric-tuned
+  scaffold knob and defers to v0.9 polish.
+- **Numerical critical-point solver.** Preset-supplied analytical CPs
+  only.
+
+## Out of scope (v0.8 beyond #179 + #181)
+
 - **Quadratic overlay (#180).** Always-on, translucent second-order
   Taylor approximation rendered as a second graph surface hugging the
   main one at the selected point. Reuses `GraphSurface` and

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -16,6 +16,10 @@ import {
 } from '@/scaffold/ui/TapButton';
 import { WorldAxes } from '@/scaffold/ui/WorldAxes';
 import {
+  createCriticalPointMarkers,
+  type CriticalPointMarkersHandles,
+} from './CriticalPointMarkers';
+import {
   createGraphSurface,
   writeGraphPointToWorld,
   type GraphSurfaceHandles,
@@ -70,8 +74,8 @@ const Y_SLIDER_Y = SLIDER_RACK_CENTER.y - SLIDER_ROW_PITCH / 2;
 // siblings. Snap detents at [0] only: slider-canonical origin, not
 // critical-point-aware (the coincidence that v0.8 preset critical points
 // sit at the origin makes origin-snap LAND on the critical point, but the
-// snap mechanism is preset-independent). Critical-point-aware snap is
-// deferred to #179.
+// snap mechanism is preset-independent). #179's markers are visual-only;
+// critical-point-aware snap defers to v0.9 polish.
 const SLIDER_SNAP_DETENT = 0.05;
 const GRAB_RADIUS_MULTIPLIER = 2.75;
 const SLIDER_SNAP_POINTS: readonly number[] = [0];
@@ -144,6 +148,7 @@ function formatLinearDecimal(v: number): string {
 
 let exhibitGroup: THREE.Group | undefined;
 let graphSurface: GraphSurfaceHandles | undefined;
+let criticalPointMarkers: CriticalPointMarkersHandles | undefined;
 let worldAxes: WorldAxes | undefined;
 let xSlider: Slider | undefined;
 let ySlider: Slider | undefined;
@@ -197,6 +202,17 @@ const saddleExtremaExhibit: Exhibit = {
       lightDir: LIGHT_DIR.clone(),
     });
     group.add(graphSurface.mesh);
+
+    // Critical-point markers (#179). Built once per preset and replaced
+    // whole-cloth on preset swap (mirrors the graphSurface lifecycle).
+    // For every v0.8 preset this is a single sphere at the origin; the
+    // helper accepts the analytic list so future off-origin / multi-CP
+    // presets drop in without a wiring change.
+    criticalPointMarkers = createCriticalPointMarkers({
+      preset: initialPreset,
+      surfaceCenter: SURFACE_CENTER,
+    });
+    group.add(criticalPointMarkers.group);
 
     // x slider — vermillion (math-X axis tint). Honest pickup since
     // x IS the math-X axis value, not a derived parameter. Mirrors
@@ -401,6 +417,8 @@ const saddleExtremaExhibit: Exhibit = {
     //    after unmount() returns, so no scene.remove() calls here.
     graphSurface?.dispose();
     graphSurface = undefined;
+    criticalPointMarkers?.dispose();
+    criticalPointMarkers = undefined;
     worldAxes?.dispose();
     worldAxes = undefined;
     xSlider?.dispose();
@@ -488,6 +506,20 @@ function applyPreset(idx: number): void {
     lightDir: LIGHT_DIR.clone(),
   });
   exhibitGroup?.add(graphSurface.mesh);
+
+  // Rebuild critical-point markers for the new preset. Same
+  // remove-before-dispose ordering as the graphSurface swap above so the
+  // old marker group doesn't leak as a child of `exhibitGroup`.
+  if (criticalPointMarkers && exhibitGroup) {
+    exhibitGroup.remove(criticalPointMarkers.group);
+    criticalPointMarkers.dispose();
+    criticalPointMarkers = undefined;
+  }
+  criticalPointMarkers = createCriticalPointMarkers({
+    preset,
+    surfaceCenter: SURFACE_CENTER,
+  });
+  exhibitGroup?.add(criticalPointMarkers.group);
 
   // Slider domains follow the preset. setRange clamps the current value
   // into the new range and re-applies snap; the indicator picks up the

--- a/src/exhibits/saddle-extrema/presets.ts
+++ b/src/exhibits/saddle-extrema/presets.ts
@@ -20,6 +20,16 @@ import type { GraphSurfaceDomain } from './GraphSurface';
  */
 export type Hessian = readonly [number, number, number];
 
+/**
+ * Analytically-known critical point in math-frame `(x, y)` coords. Every
+ * v0.8 preset has exactly one critical point at the origin (see SPEC.md
+ * §"Pedagogical observation — all critical points at origin"); the
+ * `readonly [number, number][]` shape is forward-looking so a future
+ * preset with off-origin or multiple CPs drops in without an interface
+ * change.
+ */
+export type CriticalPoint = readonly [number, number];
+
 export interface SaddleExtremaPreset {
   readonly id: string;
   readonly label: string;
@@ -32,6 +42,13 @@ export interface SaddleExtremaPreset {
   readonly hessF: (x: number, y: number) => Hessian;
   /** Per-preset (x, y) window. Picked so the surface fits the cluster envelope. */
   readonly domain: GraphSurfaceDomain;
+  /**
+   * Analytically-known critical points (`∇f = 0`). Rendered by #179 as
+   * small markers on the graph surface; not consumed by #178 / #181.
+   * v0.8 entries are all `[[0, 0]]` — every preset has one CP at the
+   * origin.
+   */
+  readonly criticalPoints: readonly CriticalPoint[];
   /** Optional grid resolution per side. Defaults to 128 at the call site. */
   readonly res?: number;
 }
@@ -45,6 +62,7 @@ export const PRESETS: readonly SaddleExtremaPreset[] = [
     gradF: (x, y) => [2 * x, 2 * y],
     hessF: () => [2, 0, 2],
     domain: { xMin: -1.2, xMax: 1.2, yMin: -1.2, yMax: 1.2 },
+    criticalPoints: [[0, 0]],
   },
   // 2. Local max — z = −(x² + y²). Inverted paraboloid; D > 0 + f_xx < 0 ⇒ max.
   {
@@ -54,6 +72,7 @@ export const PRESETS: readonly SaddleExtremaPreset[] = [
     gradF: (x, y) => [-2 * x, -2 * y],
     hessF: () => [-2, 0, -2],
     domain: { xMin: -1.2, xMax: 1.2, yMin: -1.2, yMax: 1.2 },
+    criticalPoints: [[0, 0]],
   },
   // 3. Saddle — z = x² − y². The #176 starter; D < 0 ⇒ saddle.
   {
@@ -63,6 +82,7 @@ export const PRESETS: readonly SaddleExtremaPreset[] = [
     gradF: (x, y) => [2 * x, -2 * y],
     hessF: () => [2, 0, -2],
     domain: { xMin: -1.5, xMax: 1.5, yMin: -1.5, yMax: 1.5 },
+    criticalPoints: [[0, 0]],
   },
   // 4. Monkey saddle — z = x³ − 3xy². Degenerate critical point at origin
   //    (Hessian vanishes identically there ⇒ D = 0). Three "valleys"
@@ -75,6 +95,7 @@ export const PRESETS: readonly SaddleExtremaPreset[] = [
     gradF: (x, y) => [3 * x * x - 3 * y * y, -6 * x * y],
     hessF: (x, y) => [6 * x, -6 * y, -6 * x],
     domain: { xMin: -1.2, xMax: 1.2, yMin: -1.2, yMax: 1.2 },
+    criticalPoints: [[0, 0]],
   },
   // 5. D = 0 degenerate that's still a min — z = x⁴ + y⁴. Hessian vanishes
   //    at origin (f_xx = f_xy = f_yy = 0) ⇒ D = 0 inconclusive — yet the
@@ -88,6 +109,7 @@ export const PRESETS: readonly SaddleExtremaPreset[] = [
     gradF: (x, y) => [4 * x ** 3, 4 * y ** 3],
     hessF: (x, y) => [12 * x * x, 0, 12 * y * y],
     domain: { xMin: -1, xMax: 1, yMin: -1, yMax: 1 },
+    criticalPoints: [[0, 0]],
   },
 ];
 

--- a/test/exhibits/saddle-extrema/presets.test.ts
+++ b/test/exhibits/saddle-extrema/presets.test.ts
@@ -96,6 +96,48 @@ describe('PRESETS — critical point at origin', () => {
   });
 });
 
+describe('PRESETS — criticalPoints (#179)', () => {
+  it('every preset declares at least one critical point', () => {
+    for (const p of PRESETS) {
+      expect(p.criticalPoints.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('v0.8: every preset declares exactly one critical point at the origin', () => {
+    // Pins the cluster-shared pedagogical observation in SPEC.md — every
+    // v0.8 preset's CP sits at the origin. If a future preset legitimately
+    // diverges from this (off-origin or multi-CP), this assertion is the
+    // intended forcing function to revisit SPEC.md + this test together.
+    for (const p of PRESETS) {
+      expect(p.criticalPoints).toEqual([[0, 0]]);
+    }
+  });
+
+  it('every critical point lies inside its preset domain', () => {
+    for (const p of PRESETS) {
+      for (const [cx, cy] of p.criticalPoints) {
+        expect(cx).toBeGreaterThanOrEqual(p.domain.xMin);
+        expect(cx).toBeLessThanOrEqual(p.domain.xMax);
+        expect(cy).toBeGreaterThanOrEqual(p.domain.yMin);
+        expect(cy).toBeLessThanOrEqual(p.domain.yMax);
+      }
+    }
+  });
+
+  it('gradF vanishes at every declared critical point', () => {
+    // Catches a bug where the preset author hard-codes a "critical point"
+    // that isn't actually one (e.g., copy-paste typo). Stronger than the
+    // origin-only check above because it scales with the data shape.
+    for (const p of PRESETS) {
+      for (const [cx, cy] of p.criticalPoints) {
+        const [fx, fy] = p.gradF(cx, cy);
+        expect(fx).toBeCloseTo(0);
+        expect(fy).toBeCloseTo(0);
+      }
+    }
+  });
+});
+
 describe('PRESETS — analytic derivatives agree with finite differences', () => {
   // Sample at a generic non-origin, non-axis point inside every domain.
   // (0.3, 0.2) sits inside the quartic preset's [-1, 1]² (the tightest


### PR DESCRIPTION
Closes #179

## Summary

Adds analytically-declared critical points to each saddle-extrema
preset (`criticalPoints: readonly [number, number][]`) and renders one
small YELLOW sphere per CP at `(x_c, y_c, f(x_c, y_c))` on the graph
surface. For every v0.8 preset this is a single marker at the origin
— the cluster's "all CPs sit at the origin" pedagogical observation
from SPEC.md. The data shape supports off-origin / multi-CP presets so
future entries drop in without an interface change.

Visual choices: marker radius is 60% of the off-white selected-point
indicator (0.024 m vs. 0.04 m) so the marker stays unobtrusive but
readable, and YELLOW continues the cluster's accent convention for
"important math fact at a point" (gradient arrow #165, |∇f| #166, D /
verdict #181). Visual-only per the issue — sliders do not snap to
markers (origin-snap already lands on every v0.8 CP; CP-aware snap
defers to v0.9 polish).

Marker lifecycle mirrors `graphSurface` — built whole-cloth on mount,
rebuilt on every preset swap, disposed on unmount. Geometry + material
are shared across all markers of one preset and disposed once per swap.

## Test plan

- [x] Cloudflare PR preview: load `?exhibit=saddle-extrema` on a Quest
      browser; verify a small yellow sphere sits on the surface at the
      origin for the default (saddle) preset, distinct from the larger
      off-white selected-point indicator.
- [x] Drag the `(x, y)` sliders to `(0, 0)` (origin-snap helps) and
      confirm the indicator nests over the marker; the classification
      readout reads `D = −4.00` / `saddle` for the saddle preset.
- [x] Step through all 5 presets; confirm exactly one marker appears
      on each surface at the origin and that it sits ON the surface
      (not floating above / sunk below) — paraboloid bottom, inverted-
      paraboloid top, saddle center, monkey-saddle center, quartic
      bottom.
- [x] Switch between presets repeatedly; marker should swap cleanly
      with the surface (no leftover marker from the prior preset).
- [x] `npm run test` — 4 new cases in
      `test/exhibits/saddle-extrema/presets.test.ts` covering
      `criticalPoints` invariants (≥1 CP per preset, v0.8 = `[[0, 0]]`,
      every CP inside its domain, `gradF` vanishes at every CP).
      308/308 total green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)