### PR TITLE
feat(scene): saddle-extrema — local-quadratic-approximation overlay (#180)

### DIFF
--- a/src/exhibits/saddle-extrema/SPEC.md
+++ b/src/exhibits/saddle-extrema/SPEC.md
@@ -435,16 +435,224 @@ shared across all markers of one preset and disposed once per swap.
 - **Numerical critical-point solver.** Preset-supplied analytical CPs
   only.
 
-## Out of scope (v0.8 beyond #179 + #181)
+## Quadratic overlay (#180)
 
-- **Quadratic overlay (#180).** Always-on, translucent second-order
-  Taylor approximation rendered as a second graph surface hugging the
-  main one at the selected point. Reuses `GraphSurface` and
-  `writeGraphPointToWorld`. The §11.7–11.8 punch line.
+The §11.7–11.8 *pedagogical* punch line of the scene. At the slider-
+selected point `(x₀, y₀)`, a second graph surface hugs the main one,
+rendered as the second-order Taylor expansion of the active preset's
+`f`:
+
+```
+q(x, y) = f(x₀, y₀)
+        + f_x(x₀, y₀)·(x − x₀)
+        + f_y(x₀, y₀)·(y − y₀)
+        + ½·[ f_xx·(x − x₀)²
+            + 2·f_xy·(x − x₀)·(y − y₀)
+            + f_yy·(y − y₀)² ]
+```
+
+Two cases the overlay makes literal:
+
+- **At a critical point**, the linear term vanishes and the overlay
+  IS the local quadratic — bowl up (min), bowl down (max), saddle, or
+  the degenerate flat plane (`monkey-saddle` / `quartic-min`, where
+  the Hessian vanishes and the quadratic collapses to a constant).
+- **Away from a critical point**, the linear term tips the overlay
+  into a curved tangent-shaped patch. Reading the overlay as "linear
+  plus a little curvature" makes the second-derivative test's
+  domain-of-validity legible.
+
+Always-on (mirrors tangent-planes #148; toggle UI deferred to v0.9 if
+the always-on read is cluttered in-headset).
+
+### Primitive — `TaylorOverlay.ts`
+
+A new same-scene helper distinct from `GraphSurface.ts`. The main
+surface is *built once per preset* (opaque cluster-lambert
+ShaderMaterial); the overlay is *mutated every frame* (translucent
+body+rim shader). The two lifecycles + materials + domains differ
+enough that a shared primitive would compromise both call sites.
+`TaylorOverlay` reuses only the math-frame helpers
+(`writeGraphPointToWorld`, `writeMathToWorld`) — `GraphSurface`
+deliberately designed those as cross-consumer.
+
+Scaffold extraction to `src/scaffold/` is deferred per the
+extract-on-second-consumer rule. The overlay is consumer #1 of "per-
+frame mutating graph surface"; a future ODE phase-portrait scene may
+trigger extraction in v1.x.
+
+### Neighborhood size
+
+Per-preset half-extent = `25% × min(domain x-range, domain y-range) / 2`:
+
+| Preset | Domain | Half-extent |
+|---|---|---|
+| `paraboloid` / `inv-paraboloid` / `monkey-saddle` | range 2.4 | 0.30 |
+| `saddle` | range 3.0 | 0.375 |
+| `quartic-min` | range 2.0 | 0.25 |
+
+Min-of-range keeps the patch square in math coords (uniform rim band
+on all four edges, no stretched-rect look). At origin pose the patch
+is well inside every preset's domain.
+
+**No clamping at slider edges.** When `(x₀, y₀)` is near a corner,
+the overlay extends past the main surface's edge. The Taylor
+approximation is defined on all of ℝ²; the floating-past-edge read is
+a feature, not a bug. Symmetric edge-shrink is the v0.9 escape hatch
+if smoke flags this read poorly. `quartic-min` at `(0.9, 0)` is the
+worst case (flat overlay, right half floating); explicitly smoke-
+checked.
+
+### Tessellation — `res = 49`
+
+Odd resolution so the center vertex `(u = v = 0)` lands exactly at
+the middle index. With `res = 49`, that's index `24` in both `i` and
+`j`, flat index `1200`. Vertex spacing on the saddle preset (the
+largest half-extent): `2·0.375 / 48 ≈ 15.6 mm` in math coords; on the
+quartic: `2·0.25 / 48 ≈ 10.4 mm`. Smooth at any headset distance.
+
+Even resolutions (e.g., 48) would put the center between vertices,
+defeating the "overlay center IS the indicator" visual claim by a
+small linear-interpolation error and breaking the center-vertex
+tests.
+
+`49² = 2401` vertices ⇒ ~58 KB of position + normal buffer writes per
+frame. Negligible for Quest 3; well under the main surface's 16384-
+vertex one-time build.
+
+### Per-frame update path
+
+`setPose(x0, y0)` reads the active preset's `f`, `gradF`, `hessF` at
+`(x0, y0)`, then walks the `res × res` grid in `(u, v)` and writes
+positions + normals into the existing typed arrays. `position` and
+`normal` BufferAttributes are marked `needsUpdate = true`; `aLocal`
+(the math-frame `(u, v)` attribute, used by the fragment shader for
+rim distance) is unchanged on the per-frame path.
+
+Math-frame normal at `(u, v)`: the overlay surface is the graph of
+`q`, an implicit surface `{ z − q(x, y) = 0 }`, whose gradient is
+`(−q_x, −q_y, 1)`. Since `u = x − x₀` and `v = y − y₀`,
+`q_x = ∂q/∂u = f_x + f_xx·u + f_xy·v` and `q_y = ∂q/∂v = f_y + f_xy·u
++ f_yy·v`.
+
+Two scratch `Vector3` objects (one for position, one for normal) are
+allocated once and reused across all `res²` iterations — same as
+`GraphSurface.ts:155-156`. Merging into a single scratch would
+clobber position before it lands in the typed array on each iteration.
+
+### Render
+
+Translucent body + brighter rim, sky-blue per the locked #113 visual
+language. Same body / rim colors and alphas as `TangentPlane.ts` and
+`SlicingPlane.ts`; rim width tighter (0.015 m on a ~0.30 m half-
+extent gives a 5% rim-to-half-extent ratio, vs. the slicing-plane's
+1.7%).
+
+Two adaptations from the flat-rect precedent:
+
+1. **`aLocal` vec2 attribute.** `TranslucentRect.ts` reads
+   `position.xy` for the rim-distance computation because its mesh is
+   an axis-aligned plane geometry. The overlay's `position` is in
+   world space (lifted via `writeGraphPointToWorld`), so a separate
+   `aLocal` attribute carries the math-frame `(u, v)` directly to the
+   fragment shader.
+2. **Subtle lambert on the body** (`color = uBodyColor × (0.6 + 0.4 ·
+   max(dot(n, L), 0))`). A flat-lit translucent curved surface reads
+   as a uniform tint that hides the bowl / saddle / flat curvature
+   that's the whole reason for the overlay. Low-amplitude lambert
+   (vs. the main surface's `0.2 + 0.8·dot`) makes curvature legible
+   without competing with the main surface for "solid surface"
+   presence. The rim stays flat (lambert applied only to body) so the
+   patch boundary stays uniform regardless of surface tilt.
+
+### Material flags
+
+```ts
+transparent: true,
+depthWrite: false,
+side: THREE.DoubleSide,
+polygonOffset: true,
+polygonOffsetFactor: -1,
+polygonOffsetUnits: -1,
+```
+
+`renderOrder = 1` on the mesh (renders after the opaque main
+surface).
+
+**Why `polygonOffset` ships day one.** For the three exact-quadratic
+presets (`paraboloid`, `inv-paraboloid`, `saddle`), the second-order
+Taylor approximation IS the surface across the entire patch (no
+truncation error). The overlay coincides with the main surface in
+*thousands of fragments*, not just at the center vertex. Without
+`polygonOffset` the GPU's tie-breaking is implementation-defined and
+the result is z-fighting. Negative factor + units shift the overlay's
+depth toward the camera so coplanar fragments consistently pass the
+depth test on top.
+
+### Occlusion contract
+
+`depthWrite: false` means the overlay does NOT write to the depth
+buffer; it still *reads* depth. So:
+
+- **Behind the main surface**: overlay fragments fail the depth test
+  → not drawn. Correct (back half hides behind front half).
+- **In front of the main surface**: overlay fragments pass → alpha-
+  blend over the main surface. Correct (translucent tint + rim halo).
+- **Coplanar with the main surface**: `polygonOffset` shifts depth
+  toward camera; overlay consistently passes the depth test.
+- **In front of the opaque indicator / CP marker**: overlay alpha-
+  blends over them. Indicator (off-white) shows as slightly bluer
+  off-white sphere; CP marker (yellow) shows as slightly cyan yellow
+  — both still distinct.
+- **Behind the indicator / CP marker**: overlay fails the depth test
+  against the marker's opaque depth → marker reads on top of overlay
+  in those pixels.
+
+### Buffer + culling
+
+`position` and `normal` BufferAttributes use
+`setUsage(THREE.DynamicDrawUsage)` — driver hint that these buffers
+are written every frame. `aLocal` stays `StaticDrawUsage` (only
+rewritten on preset swap, cadence ~seconds).
+
+`mesh.frustumCulled = false`. Three.js doesn't auto-invalidate the
+cached bounding sphere when position attributes are marked
+`needsUpdate`; per-frame position writes leave the cached bounds
+stale. The overlay is small and anchored near `SURFACE_CENTER` (which
+is always in view by cluster framing), so frustum culling on it never
+pays for itself anyway. Pinned by Vitest so a future "performance
+cleanup" can't silently re-enable it.
+
+### Lifecycle
+
+Built once at mount with the initial preset. On preset swap
+(`setPreset(preset, x0, y0)`):
+
+1. Cache the new preset reference.
+2. Recompute `halfExtent` from the new preset's domain.
+3. Rewrite the `aLocal` typed array; mark `aLocalAttr.needsUpdate`.
+4. Update the `uHalfExtent` uniform so the rim shader's smoothstep
+   comparator agrees with the new local-coords range.
+5. Refresh positions + normals at the (possibly clamped) slider
+   values so the next frame doesn't render the prior preset's shape.
+
+Disposed once at unmount: dispose `geometry` + `material`. No shared
+resources with the main `graphSurface` mesh.
+
+## Out of scope (v0.9+)
+
+- **Toggle UI for overlay on/off.** Deferred to v0.9 polish iff the
+  always-on read is cluttered in-headset.
+- **Symmetric overlay-shrink near domain edges.** v0.9 escape hatch
+  if smoke shows the floating-past-edge read as a bug rather than a
+  feature (especially on `quartic-min` at `(0.9, 0)`).
 - **`GraphSurface` extraction to `src/scaffold/`.** Deferred until a
   second scene wants the primitive (likely v1.x). The overlay in #180
   is a same-scene consumer; doesn't count for the extract-on-second-
   consumer rule.
+- **`TaylorOverlay` extraction to `src/scaffold/`.** Same posture —
+  consumer #1; a future ODE phase-portrait scene may trigger
+  extraction.
 - **Numerical critical-point solver.** Preset-supplied analytical
   critical points only.
 - **User-supplied `f(x, y)`.** Strong long-term motivator for the
@@ -452,3 +660,7 @@ shared across all markers of one preset and disposed once per swap.
 - **Runtime `f` / `gradF` non-finite-value validation.** v0.8 presets
   are all polynomials; sampling validation is over-engineering against
   a deferred risk.
+- **Higher-order Taylor (cubic +).** Second-order is the §11.7–11.8
+  lesson; cubic would address the monkey-saddle and quartic-min
+  degenerate cases but the visual machinery doubles in size and the
+  pedagogical lift is unclear.

--- a/src/exhibits/saddle-extrema/TaylorOverlay.ts
+++ b/src/exhibits/saddle-extrema/TaylorOverlay.ts
@@ -1,0 +1,341 @@
+import * as THREE from 'three';
+import { writeMathToWorld } from '@/scaffold/math/frames';
+import { writeGraphPointToWorld } from './GraphSurface';
+import type { SaddleExtremaPreset } from './presets';
+
+// Local-quadratic-approximation overlay for the saddle / extrema scene
+// (#180; epic #175 closer). At the slider-selected point (x₀, y₀), this
+// renders the second-order Taylor expansion of the active preset's f
+// as a translucent meshed surface "patch" hugging the main surface.
+//
+//   q(x, y) = f(x₀, y₀)
+//           + f_x(x₀, y₀)·(x − x₀)
+//           + f_y(x₀, y₀)·(y − y₀)
+//           + ½·[ f_xx·(x − x₀)² + 2·f_xy·(x − x₀)·(y − y₀) + f_yy·(y − y₀)² ]
+//
+// Pedagogical hook (§11.7–11.8): the second-derivative test isn't a
+// sign-checking ritual — it's a question about local shape. At a
+// critical point the linear term vanishes and the overlay IS the local
+// quadratic (bowl up / bowl down / saddle / flat-degenerate). Away
+// from a critical point the linear term tips the overlay into a curved
+// tangent patch.
+//
+// Architectural notes:
+// - Builds its own BufferGeometry and ShaderMaterial. Does NOT call
+//   createGraphSurface (#176) — that's a one-shot builder for the main
+//   surface; this overlay's lifecycle is mutate-every-frame.
+// - Shares only the math-frame helpers (writeGraphPointToWorld /
+//   writeMathToWorld) with the main surface, per the #176 SPEC's
+//   "same-scene consumer of helpers" anticipation.
+// - Translucent body+rim recipe lifted from the locked #113 / #148
+//   precedent (TranslucentRect.ts), with two adaptations: per-vertex
+//   `aLocal` attribute (since the mesh is curved, not flat) and a
+//   subtle lambert on the body (so curvature reads — flat-lit reads as
+//   a uniform tint that hides the very shape the overlay teaches).
+// - polygonOffset shipped day one: for the exact-quadratic presets
+//   (paraboloid / inv-paraboloid / saddle), the Taylor approximation
+//   IS the surface across the entire patch, not just at the center
+//   vertex. Coplanar geometry without the offset z-fights deterministically.
+
+/**
+ * Compute the overlay's half-extent in math coords for a given preset.
+ *
+ * Fraction of the preset's narrower domain side so the patch stays
+ * square in math coords (rim band is uniform on all four edges) and
+ * fits comfortably inside the preset's domain at origin pose. Tuned
+ * per SPEC.md "Quadratic overlay (#180)"; iterate in-headset.
+ */
+const HALF_EXTENT_FRACTION = 0.25; // 25% × (min-side / 2)
+
+function computeHalfExtent(preset: SaddleExtremaPreset): number {
+  const xRange = preset.domain.xMax - preset.domain.xMin;
+  const yRange = preset.domain.yMax - preset.domain.yMin;
+  return (HALF_EXTENT_FRACTION * Math.min(xRange, yRange)) / 2;
+}
+
+// Tessellation resolution. Odd so the center vertex (u = v = 0) lands
+// exactly at index `(res - 1) / 2` in both i and j — critical because
+// the indicator's selected point IS the overlay's center, and visual /
+// test claims rely on a vertex existing there. 49² = 2401 vertices;
+// total per-frame buffer write (position + normal) is ~58 KB.
+const RES = 49;
+
+// Visual recipe — translucent body + brighter rim, sky-blue per the
+// #113 locked visual language. Same body / rim colors and alphas as
+// TangentPlane.ts and SlicingPlane.ts; rim width tighter (0.015 m on a
+// ~0.30 m half-extent gives 5% rim-to-half-extent ratio, somewhat
+// heavier than the slicing-plane's 1.7% but less heavy than the v1
+// plan's 7%).
+const OVERLAY_BODY_COLOR = new THREE.Color(0.34, 0.71, 0.91);
+const OVERLAY_BODY_ALPHA = 0.10;
+const OVERLAY_RIM_COLOR = new THREE.Color(0.70, 0.90, 0.99);
+const OVERLAY_RIM_ALPHA = 0.65;
+const OVERLAY_RIM_WIDTH = 0.015;
+
+// Subtle lambert on the body — body color ranges [0.6, 1.0] × baseColor
+// vs. the main surface's [0.2, 1.0]. Low-amplitude so the overlay
+// doesn't compete with the main surface for "solid surface" presence
+// but high enough that the bowl / saddle / flat curvature reads
+// without referencing the main surface underneath. The rim stays flat
+// (lambert applied only to body) so the patch boundary stays uniform
+// regardless of surface tilt.
+const LAMBERT_AMBIENT = 0.6;
+const LAMBERT_DIFFUSE = 0.4;
+
+const RENDER_ORDER = 1;
+
+// polygonOffset values. Negative factor + units shift the overlay's
+// depth toward the camera, so coplanar fragments (every fragment of
+// the paraboloid / inv-paraboloid / saddle presets) consistently pass
+// the depth test on top of the main surface rather than relying on
+// GPU tie-breaking. Tunable in-headset if it over-separates visually.
+const POLYGON_OFFSET_FACTOR = -1;
+const POLYGON_OFFSET_UNITS = -1;
+
+const VERTEX_SHADER = /* glsl */ `
+  attribute vec2 aLocal;
+  varying vec2 vLocal;
+  varying vec3 vNormal;
+
+  void main() {
+    vLocal = aLocal;
+    // mat3(modelMatrix) * normal puts the normal in world space,
+    // matching the world-space uLightDir uniform. Same convention as
+    // GraphSurface.ts's vertex shader; normalMatrix would put it in
+    // view space and the lambert would drift under head rotation.
+    vNormal = normalize(mat3(modelMatrix) * normal);
+    gl_Position = projectionMatrix * viewMatrix * modelMatrix
+                * vec4(position, 1.0);
+  }
+`;
+
+const FRAGMENT_SHADER = /* glsl */ `
+  precision highp float;
+
+  uniform float uHalfExtent;
+  uniform float uRimWidth;
+  uniform vec3  uBodyColor;
+  uniform float uBodyAlpha;
+  uniform vec3  uRimColor;
+  uniform float uRimAlpha;
+  uniform vec3  uLightDir;
+  uniform float uLambertAmbient;
+  uniform float uLambertDiffuse;
+
+  varying vec2 vLocal;
+  varying vec3 vNormal;
+
+  void main() {
+    // Rim distance in math-frame meters, same as TranslucentRect.ts.
+    float distFromEdge = uHalfExtent - max(abs(vLocal.x), abs(vLocal.y));
+    float rim = 1.0 - smoothstep(0.0, uRimWidth, distFromEdge);
+
+    // Subtle lambert on the body only — so curvature reads without
+    // making the patch look solid. Rim stays flat-lit so the boundary
+    // is uniform regardless of surface tilt.
+    float lambert = max(dot(normalize(vNormal), normalize(uLightDir)), 0.0);
+    vec3 bodyShaded = uBodyColor * (uLambertAmbient + uLambertDiffuse * lambert);
+
+    vec3 color = mix(bodyShaded, uRimColor, rim);
+    float alpha = mix(uBodyAlpha, uRimAlpha, rim);
+    gl_FragColor = vec4(color, alpha);
+  }
+`;
+
+export interface TaylorOverlayOptions {
+  /** Active preset — provides f / gradF / hessF / domain. */
+  preset: SaddleExtremaPreset;
+  /** World-space anchor; math-origin lifts to this point. */
+  surfaceCenter: THREE.Vector3;
+  /** World-space directional-light direction (pre-normalized at the
+   *  call site; cloned into the uLightDir uniform). Same value the
+   *  scene's DirectionalLight + GraphSurface use. */
+  lightDir: THREE.Vector3;
+}
+
+export interface TaylorOverlayHandles {
+  readonly mesh: THREE.Mesh;
+  /**
+   * Update the overlay to the new (x₀, y₀) selected point. Mutates
+   * `position` + `normal` BufferAttributes in place; marks them
+   * dirty. No allocation.
+   */
+  setPose(x0: number, y0: number): void;
+  /**
+   * Swap the active preset. Recomputes half-extent, rewrites the
+   * static-per-frame `aLocal` attribute, updates the `uHalfExtent`
+   * uniform, and refreshes positions + normals for the boot pose so
+   * the overlay isn't visually stale until the next setPose tick.
+   */
+  setPreset(preset: SaddleExtremaPreset, x0: number, y0: number): void;
+  /** Dispose geometry + material exactly once. */
+  dispose(): void;
+}
+
+export function createTaylorOverlay(
+  opts: TaylorOverlayOptions,
+): TaylorOverlayHandles {
+  let preset = opts.preset;
+  let halfExtent = computeHalfExtent(preset);
+  const { surfaceCenter } = opts;
+
+  const vertexCount = RES * RES;
+  const quadCount = (RES - 1) * (RES - 1);
+  const indexCount = quadCount * 2 * 3;
+
+  const positions = new Float32Array(vertexCount * 3);
+  const normals = new Float32Array(vertexCount * 3);
+  const locals = new Float32Array(vertexCount * 2);
+  // RES = 49 ⇒ 2401 vertices, comfortably under the Uint16 ceiling.
+  const indices = new Uint16Array(indexCount);
+
+  // Static index buffer — winding mirrors GraphSurface.ts:193-207.
+  let k = 0;
+  for (let j = 0; j < RES - 1; j++) {
+    for (let i = 0; i < RES - 1; i++) {
+      const bl = j * RES + i;
+      const br = j * RES + (i + 1);
+      const tl = (j + 1) * RES + i;
+      const tr = (j + 1) * RES + (i + 1);
+      indices[k++] = bl;
+      indices[k++] = br;
+      indices[k++] = tl;
+      indices[k++] = br;
+      indices[k++] = tr;
+      indices[k++] = tl;
+    }
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  const positionAttr = new THREE.BufferAttribute(positions, 3);
+  positionAttr.setUsage(THREE.DynamicDrawUsage);
+  const normalAttr = new THREE.BufferAttribute(normals, 3);
+  normalAttr.setUsage(THREE.DynamicDrawUsage);
+  // `aLocal` stays at the default StaticDrawUsage — it's rewritten
+  // only on preset swap, not per frame.
+  const localAttr = new THREE.BufferAttribute(locals, 2);
+  geometry.setAttribute('position', positionAttr);
+  geometry.setAttribute('normal', normalAttr);
+  geometry.setAttribute('aLocal', localAttr);
+  geometry.setIndex(new THREE.BufferAttribute(indices, 1));
+
+  const material = new THREE.ShaderMaterial({
+    vertexShader: VERTEX_SHADER,
+    fragmentShader: FRAGMENT_SHADER,
+    transparent: true,
+    depthWrite: false,
+    side: THREE.DoubleSide,
+    polygonOffset: true,
+    polygonOffsetFactor: POLYGON_OFFSET_FACTOR,
+    polygonOffsetUnits: POLYGON_OFFSET_UNITS,
+    uniforms: {
+      uHalfExtent: { value: halfExtent },
+      uRimWidth: { value: OVERLAY_RIM_WIDTH },
+      uBodyColor: { value: OVERLAY_BODY_COLOR.clone() },
+      uBodyAlpha: { value: OVERLAY_BODY_ALPHA },
+      uRimColor: { value: OVERLAY_RIM_COLOR.clone() },
+      uRimAlpha: { value: OVERLAY_RIM_ALPHA },
+      uLightDir: { value: opts.lightDir.clone() },
+      uLambertAmbient: { value: LAMBERT_AMBIENT },
+      uLambertDiffuse: { value: LAMBERT_DIFFUSE },
+    },
+  });
+
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.renderOrder = RENDER_ORDER;
+  // Per-frame position mutation invalidates the cached bounding sphere
+  // (Three.js doesn't auto-recompute on needsUpdate). The overlay is
+  // always near SURFACE_CENTER and small; frustum culling on a tiny
+  // mesh in the FOV center never pays for itself.
+  mesh.frustumCulled = false;
+
+  // Persistent scratch — allocated once. Two separate Vector3s (one
+  // position, one normal); merging would clobber position before it's
+  // written to the typed array on each iteration. Same pattern as
+  // GraphSurface.ts:155-156.
+  const scratchPos = new THREE.Vector3();
+  const scratchNorm = new THREE.Vector3();
+
+  function recomputeLocal(): void {
+    const step = (2 * halfExtent) / (RES - 1);
+    for (let j = 0; j < RES; j++) {
+      const v = -halfExtent + j * step;
+      for (let i = 0; i < RES; i++) {
+        const u = -halfExtent + i * step;
+        const idx = (j * RES + i) * 2;
+        locals[idx + 0] = u;
+        locals[idx + 1] = v;
+      }
+    }
+  }
+
+  function writePose(x0: number, y0: number): void {
+    const f0 = preset.f(x0, y0);
+    const [fx, fy] = preset.gradF(x0, y0);
+    const [fxx, fxy, fyy] = preset.hessF(x0, y0);
+    const step = (2 * halfExtent) / (RES - 1);
+
+    for (let j = 0; j < RES; j++) {
+      const v = -halfExtent + j * step;
+      for (let i = 0; i < RES; i++) {
+        const u = -halfExtent + i * step;
+        // q(u, v) = f₀ + fx·u + fy·v
+        //        + ½·(fxx·u² + 2·fxy·u·v + fyy·v²)
+        const q =
+          f0 +
+          fx * u +
+          fy * v +
+          0.5 * (fxx * u * u + 2 * fxy * u * v + fyy * v * v);
+        // ∂q/∂x = ∂q/∂u (since x = x₀ + u): fx + fxx·u + fxy·v.
+        // ∂q/∂y = ∂q/∂v: fy + fxy·u + fyy·v.
+        const qx = fx + fxx * u + fxy * v;
+        const qy = fy + fxy * u + fyy * v;
+
+        writeGraphPointToWorld(x0 + u, y0 + v, q, surfaceCenter, scratchPos);
+        writeMathToWorld([-qx, -qy, 1], scratchNorm).normalize();
+
+        const vIdx = (j * RES + i) * 3;
+        positions[vIdx + 0] = scratchPos.x;
+        positions[vIdx + 1] = scratchPos.y;
+        positions[vIdx + 2] = scratchPos.z;
+        normals[vIdx + 0] = scratchNorm.x;
+        normals[vIdx + 1] = scratchNorm.y;
+        normals[vIdx + 2] = scratchNorm.z;
+      }
+    }
+  }
+
+  // Seed initial state — `aLocal` and an initial position/normal pose
+  // so the first paint isn't from a zero buffer. The scene re-calls
+  // setPose on every frame; this just makes the very-first paint sane.
+  recomputeLocal();
+  writePose(0, 0);
+
+  return {
+    mesh,
+
+    setPose(x0: number, y0: number): void {
+      writePose(x0, y0);
+      positionAttr.needsUpdate = true;
+      normalAttr.needsUpdate = true;
+    },
+
+    setPreset(nextPreset: SaddleExtremaPreset, x0: number, y0: number): void {
+      preset = nextPreset;
+      halfExtent = computeHalfExtent(nextPreset);
+      recomputeLocal();
+      localAttr.needsUpdate = true;
+      (material.uniforms.uHalfExtent as { value: number }).value = halfExtent;
+      // Refresh positions + normals for the boot pose so the next
+      // frame doesn't render a stale shape from the prior preset.
+      writePose(x0, y0);
+      positionAttr.needsUpdate = true;
+      normalAttr.needsUpdate = true;
+    },
+
+    dispose(): void {
+      geometry.dispose();
+      material.dispose();
+    },
+  };
+}

--- a/src/exhibits/saddle-extrema/TaylorOverlay.ts
+++ b/src/exhibits/saddle-extrema/TaylorOverlay.ts
@@ -1,6 +1,4 @@
 import * as THREE from 'three';
-import { writeMathToWorld } from '@/scaffold/math/frames';
-import { writeGraphPointToWorld } from './GraphSurface';
 import type { SaddleExtremaPreset } from './presets';
 
 // Local-quadratic-approximation overlay for the saddle / extrema scene
@@ -211,8 +209,11 @@ export function createTaylorOverlay(
   positionAttr.setUsage(THREE.DynamicDrawUsage);
   const normalAttr = new THREE.BufferAttribute(normals, 3);
   normalAttr.setUsage(THREE.DynamicDrawUsage);
-  // `aLocal` stays at the default StaticDrawUsage — it's rewritten
-  // only on preset swap, not per frame.
+  // `aLocal` stays at the default StaticDrawUsage — static relative
+  // to frame frequency. It IS rewritten on preset swap (cadence
+  // ~seconds, on tap), but the driver hint "this buffer doesn't
+  // change frequently" still applies — preset taps are tens of
+  // seconds apart in practice, not per frame.
   const localAttr = new THREE.BufferAttribute(locals, 2);
   geometry.setAttribute('position', positionAttr);
   geometry.setAttribute('normal', normalAttr);
@@ -291,8 +292,25 @@ export function createTaylorOverlay(
         const qx = fx + fxx * u + fxy * v;
         const qy = fy + fxy * u + fyy * v;
 
-        writeGraphPointToWorld(x0 + u, y0 + v, q, surfaceCenter, scratchPos);
-        writeMathToWorld([-qx, -qy, 1], scratchNorm).normalize();
+        // Inline the math-frame → world-frame mapping + surfaceCenter
+        // offset. Equivalent to:
+        //   writeGraphPointToWorld(x0 + u, y0 + v, q, surfaceCenter, scratchPos);
+        //   writeMathToWorld([-qx, -qy, 1], scratchNorm).normalize();
+        // Both helpers internally pack their scalar inputs into a
+        // MathVec3 tuple, which allocates a fresh array per call.
+        // Inside this 2401-iteration hot path (at 60 Hz that's ~144K
+        // short-lived arrays/sec) the GC pressure produced frame-rate
+        // hitches in headset. Inlining the math (math (a, b, c) →
+        // world (a, c, -b), then + surfaceCenter) keeps the helpers'
+        // semantics without their per-call tuple. Caught by GPT-5.5
+        // in PR-#187 /roundtable-review.
+        scratchPos.set(
+          x0 + u + surfaceCenter.x,
+          q + surfaceCenter.y,
+          -(y0 + v) + surfaceCenter.z,
+        );
+        // Math normal: writeMathToWorld([-qx, -qy, 1], …) → (-qx, 1, qy).
+        scratchNorm.set(-qx, 1, qy).normalize();
 
         const vIdx = (j * RES + i) * 3;
         positions[vIdx + 0] = scratchPos.x;

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -26,6 +26,10 @@ import {
 } from './GraphSurface';
 import { DEFAULT_PRESET_INDEX, PRESETS } from './presets';
 import { SaddleExtremaReadout } from './SaddleExtremaReadout';
+import {
+  createTaylorOverlay,
+  type TaylorOverlayHandles,
+} from './TaylorOverlay';
 
 // Saddle / extrema scene (#175 epic). Fourth and final member of the
 // calculus3 cluster, alongside quadrics, tangent-planes, and gradient-levels.
@@ -149,6 +153,7 @@ function formatLinearDecimal(v: number): string {
 let exhibitGroup: THREE.Group | undefined;
 let graphSurface: GraphSurfaceHandles | undefined;
 let criticalPointMarkers: CriticalPointMarkersHandles | undefined;
+let taylorOverlay: TaylorOverlayHandles | undefined;
 let worldAxes: WorldAxes | undefined;
 let xSlider: Slider | undefined;
 let ySlider: Slider | undefined;
@@ -213,6 +218,24 @@ const saddleExtremaExhibit: Exhibit = {
       surfaceCenter: SURFACE_CENTER,
     });
     group.add(criticalPointMarkers.group);
+
+    // Local-quadratic-approximation overlay (#180; the §11.7–11.8
+    // pedagogical punch line). Sits on top of the main surface,
+    // translucent body + brighter rim, mutates positions + normals
+    // every frame from the per-frame (x, y) and the active preset's
+    // (f, gradF, hessF). polygonOffset shipped day-one — the
+    // exact-quadratic presets coincide with the main surface across
+    // the entire patch, not just at the center vertex.
+    taylorOverlay = createTaylorOverlay({
+      preset: initialPreset,
+      surfaceCenter: SURFACE_CENTER,
+      lightDir: LIGHT_DIR.clone(),
+    });
+    // Seed the overlay's pose to the initial slider values so the
+    // first paint isn't a stale zero pose (overlay constructor seeds
+    // at (0, 0); the indicator boots at (X_INITIAL, Y_INITIAL)).
+    taylorOverlay.setPose(X_INITIAL, Y_INITIAL);
+    group.add(taylorOverlay.mesh);
 
     // x slider — vermillion (math-X axis tint). Honest pickup since
     // x IS the math-X axis value, not a derived parameter. Mirrors
@@ -365,6 +388,14 @@ const saddleExtremaExhibit: Exhibit = {
         indicator.position.copy(indicatorWorld);
       }
 
+      // 2b. Quadratic-overlay pose (#180). Mutates positions + normals
+      //     of the overlay's BufferGeometry to the Taylor expansion of
+      //     the active preset at the current (x, y). Always-on per the
+      //     v0.8 design decision; toggle UI deferred to v0.9 polish.
+      if (taylorOverlay) {
+        taylorOverlay.setPose(x, y);
+      }
+
       // 3. Per-slider value labels — linear-decimal format (Cartesian
       //    coords, not angles).
       if (xLabel && camera) {
@@ -419,6 +450,8 @@ const saddleExtremaExhibit: Exhibit = {
     graphSurface = undefined;
     criticalPointMarkers?.dispose();
     criticalPointMarkers = undefined;
+    taylorOverlay?.dispose();
+    taylorOverlay = undefined;
     worldAxes?.dispose();
     worldAxes = undefined;
     xSlider?.dispose();
@@ -526,6 +559,18 @@ function applyPreset(idx: number): void {
   // (possibly clamped) value via the next update() tick.
   xSlider?.setRange(preset.domain.xMin, preset.domain.xMax);
   ySlider?.setRange(preset.domain.yMin, preset.domain.yMax);
+
+  // Quadratic overlay (#180) — swap the active preset reference,
+  // recompute half-extent, rewrite the aLocal attribute, refresh
+  // positions + normals at the (possibly clamped) slider values so
+  // the next frame doesn't render the prior preset's shape. setRange
+  // above runs first so the values are clamped before the overlay
+  // reads them.
+  taylorOverlay?.setPreset(
+    preset,
+    xSlider?.value ?? 0,
+    ySlider?.value ?? 0,
+  );
 }
 
 registerExhibit(saddleExtremaExhibit);

--- a/test/exhibits/saddle-extrema/TaylorOverlay.test.ts
+++ b/test/exhibits/saddle-extrema/TaylorOverlay.test.ts
@@ -455,6 +455,40 @@ describe('createTaylorOverlay — material flags', () => {
   });
 });
 
+describe('createTaylorOverlay — out-of-domain robustness', () => {
+  it('produces all-finite positions when overlay extends past preset domain', () => {
+    // Sonnet PR-review LOW F1: when the slider sits at (xMax, yMax)
+    // and halfExtent extends past the domain, f(x0+u, y0+v) is called
+    // with arguments outside [xMin, xMax]×[yMin, yMax]. Current v0.8
+    // presets are global polynomials so f never NaNs/asserts at the
+    // boundary, but this test pins the property so a future preset
+    // whose f misbehaves at domain edges trips at unit-test time.
+    // Worst v0.8 case: quartic-min at (xMax, yMax) = (1, 1) with
+    // halfExtent = 0.25, sampling out to x = y = 1.25.
+    const quartic = PRESETS.find((p) => p.id === 'quartic-min')!;
+    const overlay = createTaylorOverlay({
+      preset: quartic,
+      surfaceCenter: SURFACE_CENTER,
+      lightDir: LIGHT_DIR,
+    });
+    try {
+      overlay.setPose(quartic.domain.xMax, quartic.domain.yMax);
+      const pos = overlay.mesh.geometry.getAttribute('position');
+      const norm = overlay.mesh.geometry.getAttribute('normal');
+      for (let i = 0; i < pos.count; i++) {
+        expect(Number.isFinite(pos.getX(i))).toBe(true);
+        expect(Number.isFinite(pos.getY(i))).toBe(true);
+        expect(Number.isFinite(pos.getZ(i))).toBe(true);
+        expect(Number.isFinite(norm.getX(i))).toBe(true);
+        expect(Number.isFinite(norm.getY(i))).toBe(true);
+        expect(Number.isFinite(norm.getZ(i))).toBe(true);
+      }
+    } finally {
+      overlay.dispose();
+    }
+  });
+});
+
 describe('createTaylorOverlay — dispose', () => {
   it('disposes both geometry and material exactly once', () => {
     const handles = makeOverlay();

--- a/test/exhibits/saddle-extrema/TaylorOverlay.test.ts
+++ b/test/exhibits/saddle-extrema/TaylorOverlay.test.ts
@@ -1,0 +1,467 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+import { createTaylorOverlay } from '@/exhibits/saddle-extrema/TaylorOverlay';
+import { writeGraphPointToWorld } from '@/exhibits/saddle-extrema/GraphSurface';
+import { PRESETS } from '@/exhibits/saddle-extrema/presets';
+
+// Vitest coverage for the local-quadratic-approximation overlay (#180;
+// epic #175 closer). Strategy mirrors GraphSurface.test.ts — pure
+// helper-level coverage. The overlay is the §11.7–11.8 pedagogical
+// punch line; its math correctness is what makes "the local quadratic
+// IS the local shape at a critical point" a true claim. Tessellation
+// + per-frame mutation contracts get pinned here.
+
+const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
+const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
+
+// Saddle preset — third entry per `presets.ts`. Picked because:
+// (a) Hessian has mixed signs (f_xx = 2, f_yy = -2), exercising
+//     analytic-normal derivation across both sign regimes,
+// (b) at (x0, y0) = (0, 0) the linear term vanishes and the overlay
+//     is pure quadratic — the cleanest test of the q formula,
+// (c) at (x0, y0) = (0.5, 0) the linear term is non-trivial.
+const SADDLE_PRESET = PRESETS[2];
+
+// Production resolution. Tests assert against the same RES the
+// production overlay uses; smaller RES would mask the odd-grid
+// center-vertex invariant that's the whole point of RES = 49.
+const RES = 49;
+
+// Half-extent for the saddle preset. The overlay's helper computes
+// `halfExtent = 0.25 × min(xRange, yRange) / 2` — saddle's domain is
+// [-1.5, 1.5]² (range 3.0 each side) ⇒ halfExtent = 0.375. Tests
+// reproduce the formula independently as a check that the helper
+// hasn't drifted.
+const SADDLE_HALF_EXTENT = (0.25 * Math.min(3.0, 3.0)) / 2;
+
+function makeOverlay(
+  preset = SADDLE_PRESET,
+): ReturnType<typeof createTaylorOverlay> {
+  return createTaylorOverlay({
+    preset,
+    surfaceCenter: SURFACE_CENTER,
+    lightDir: LIGHT_DIR,
+  });
+}
+
+// Center index — for odd RES = 49, the middle is (RES - 1) / 2 = 24
+// in both i and j; flat index = 24 * 49 + 24 = 1200.
+const CENTER_I = (RES - 1) / 2;
+const CENTER_J = (RES - 1) / 2;
+const CENTER_FLAT = CENTER_J * RES + CENTER_I;
+
+describe('createTaylorOverlay — odd-res center vertex parity', () => {
+  it('places a vertex exactly at (u, v) = (0, 0)', () => {
+    const { mesh, dispose } = makeOverlay();
+    try {
+      const aLocal = mesh.geometry.getAttribute('aLocal');
+      // For RES = 49 with symmetric domain [-half, +half], the middle
+      // index lands on (0, 0). If RES were even, this would fail.
+      expect(aLocal.getX(CENTER_FLAT)).toBeCloseTo(0);
+      expect(aLocal.getY(CENTER_FLAT)).toBeCloseTo(0);
+    } finally {
+      dispose();
+    }
+  });
+
+  it('corner vertices sit at (±half, ±half)', () => {
+    const { mesh, dispose } = makeOverlay();
+    try {
+      const aLocal = mesh.geometry.getAttribute('aLocal');
+      // (i, j) = (0, 0) ⇒ flat 0; (RES-1, RES-1) ⇒ flat RES²-1.
+      expect(aLocal.getX(0)).toBeCloseTo(-SADDLE_HALF_EXTENT);
+      expect(aLocal.getY(0)).toBeCloseTo(-SADDLE_HALF_EXTENT);
+      const tr = RES * RES - 1;
+      expect(aLocal.getX(tr)).toBeCloseTo(SADDLE_HALF_EXTENT);
+      expect(aLocal.getY(tr)).toBeCloseTo(SADDLE_HALF_EXTENT);
+    } finally {
+      dispose();
+    }
+  });
+});
+
+describe('createTaylorOverlay — quadratic invariance at the selected point', () => {
+  it('center vertex sits at world writeGraphPointToWorld(x0, y0, f(x0, y0))', () => {
+    const { mesh, dispose, setPose } = makeOverlay();
+    try {
+      const x0 = 0.5;
+      const y0 = -0.3;
+      setPose(x0, y0);
+
+      const expected = new THREE.Vector3();
+      writeGraphPointToWorld(
+        x0,
+        y0,
+        SADDLE_PRESET.f(x0, y0),
+        SURFACE_CENTER,
+        expected,
+      );
+
+      const pos = mesh.geometry.getAttribute('position');
+      expect(pos.getX(CENTER_FLAT)).toBeCloseTo(expected.x);
+      expect(pos.getY(CENTER_FLAT)).toBeCloseTo(expected.y);
+      expect(pos.getZ(CENTER_FLAT)).toBeCloseTo(expected.z);
+    } finally {
+      dispose();
+    }
+  });
+
+  it('works for every preset at a non-trivial pose', () => {
+    for (const preset of PRESETS) {
+      const overlay = makeOverlay(preset);
+      try {
+        const x0 = 0.2;
+        const y0 = 0.1;
+        overlay.setPose(x0, y0);
+        const expected = new THREE.Vector3();
+        writeGraphPointToWorld(
+          x0,
+          y0,
+          preset.f(x0, y0),
+          SURFACE_CENTER,
+          expected,
+        );
+        const pos = overlay.mesh.geometry.getAttribute('position');
+        expect(pos.getX(CENTER_FLAT)).toBeCloseTo(expected.x);
+        expect(pos.getY(CENTER_FLAT)).toBeCloseTo(expected.y);
+        expect(pos.getZ(CENTER_FLAT)).toBeCloseTo(expected.z);
+      } finally {
+        overlay.dispose();
+      }
+    }
+  });
+});
+
+describe('createTaylorOverlay — at a critical point, overlay equals pure quadratic', () => {
+  // At (x₀, y₀) = (0, 0) on the saddle, f₀ = 0 and (fx, fy) = (0, 0).
+  // The Taylor expansion collapses to ½·(fxx·u² + 2·fxy·u·v + fyy·v²)
+  // = ½·(2u² + 0 − 2v²) = u² − v². Math-Z = u² − v² should be the
+  // graph height at every (u, v); the math→world frame map (math-Z
+  // → +world-Y) means the world-Y coord of each vertex equals
+  // surfaceCenter.y + (u² − v²).
+
+  it('saddle at origin — corner (+half, +half) has world-Y = surfaceCenter.y', () => {
+    const { mesh, dispose, setPose } = makeOverlay();
+    try {
+      setPose(0, 0);
+      const aLocal = mesh.geometry.getAttribute('aLocal');
+      const pos = mesh.geometry.getAttribute('position');
+      const tr = RES * RES - 1;
+      const u = aLocal.getX(tr);
+      const v = aLocal.getY(tr);
+      const expectedZ = u * u - v * v; // u = v = +half ⇒ 0
+      expect(pos.getY(tr)).toBeCloseTo(SURFACE_CENTER.y + expectedZ);
+    } finally {
+      dispose();
+    }
+  });
+
+  it('saddle at origin — corner (+half, -half) has world-Y = surfaceCenter.y', () => {
+    const { mesh, dispose, setPose } = makeOverlay();
+    try {
+      setPose(0, 0);
+      const aLocal = mesh.geometry.getAttribute('aLocal');
+      const pos = mesh.geometry.getAttribute('position');
+      // (i, j) = (RES-1, 0) ⇒ flat RES-1
+      const idx = RES - 1;
+      const u = aLocal.getX(idx);
+      const v = aLocal.getY(idx);
+      expect(u).toBeCloseTo(SADDLE_HALF_EXTENT);
+      expect(v).toBeCloseTo(-SADDLE_HALF_EXTENT);
+      const expectedZ = u * u - v * v; // u² − v² = 0 (saddle symmetry)
+      expect(pos.getY(idx)).toBeCloseTo(SURFACE_CENTER.y + expectedZ);
+    } finally {
+      dispose();
+    }
+  });
+
+  it('saddle at origin — edge midpoint matches u² − v²', () => {
+    const { mesh, dispose, setPose } = makeOverlay();
+    try {
+      setPose(0, 0);
+      const aLocal = mesh.geometry.getAttribute('aLocal');
+      const pos = mesh.geometry.getAttribute('position');
+      // (i = CENTER_I, j = 0): top-edge middle.
+      const idx = 0 * RES + CENTER_I;
+      const u = aLocal.getX(idx);
+      const v = aLocal.getY(idx);
+      expect(u).toBeCloseTo(0);
+      expect(v).toBeCloseTo(-SADDLE_HALF_EXTENT);
+      const expectedZ = u * u - v * v;
+      expect(pos.getY(idx)).toBeCloseTo(SURFACE_CENTER.y + expectedZ);
+    } finally {
+      dispose();
+    }
+  });
+});
+
+describe('createTaylorOverlay — away from a critical point, linear+quadratic shape', () => {
+  // At (x₀, y₀) = (0.5, 0) on the saddle (f = x² − y²): f₀ = 0.25,
+  // fx = 1, fy = 0, fxx = 2, fxy = 0, fyy = −2.
+  //   q(u, v) = 0.25 + 1·u + ½·(2u² − 2v²)
+  //          = 0.25 + u + u² − v².
+  // At a positive-u corner (u = +half, v = 0), q = 0.25 + half + half².
+
+  it('linear term contributes at off-CP pose', () => {
+    const { mesh, dispose, setPose } = makeOverlay();
+    try {
+      setPose(0.5, 0);
+      const aLocal = mesh.geometry.getAttribute('aLocal');
+      const pos = mesh.geometry.getAttribute('position');
+      // Right-edge middle: i = RES-1, j = CENTER_J.
+      const idx = CENTER_J * RES + (RES - 1);
+      const u = aLocal.getX(idx);
+      const v = aLocal.getY(idx);
+      expect(u).toBeCloseTo(SADDLE_HALF_EXTENT);
+      expect(v).toBeCloseTo(0);
+      const expectedZ = 0.25 + u + u * u - v * v;
+      expect(pos.getY(idx)).toBeCloseTo(SURFACE_CENTER.y + expectedZ);
+    } finally {
+      dispose();
+    }
+  });
+});
+
+describe('createTaylorOverlay — setPose lifecycle', () => {
+  it('mutates positions but leaves aLocal unchanged', () => {
+    const { mesh, dispose, setPose } = makeOverlay();
+    try {
+      const aLocal = mesh.geometry.getAttribute('aLocal');
+      const aLocalCopy = new Float32Array(aLocal.array);
+
+      const pos = mesh.geometry.getAttribute('position');
+      const posBeforeY = pos.getY(CENTER_FLAT);
+
+      setPose(0.7, -0.2);
+
+      // aLocal untouched.
+      for (let i = 0; i < aLocal.array.length; i++) {
+        expect(aLocal.array[i]).toBe(aLocalCopy[i]);
+      }
+      // Position moved (saddle f at (0.7, -0.2) = 0.49 - 0.04 = 0.45,
+      // distinct from f(0, 0) = 0 the constructor seeded).
+      expect(pos.getY(CENTER_FLAT)).not.toBeCloseTo(posBeforeY);
+    } finally {
+      dispose();
+    }
+  });
+
+  it('marks both position and normal needsUpdate exactly once per call', () => {
+    const { mesh, dispose, setPose } = makeOverlay();
+    try {
+      const pos = mesh.geometry.getAttribute('position') as THREE.BufferAttribute;
+      const norm = mesh.geometry.getAttribute('normal') as THREE.BufferAttribute;
+      const posSpy = vi.spyOn(pos, 'needsUpdate', 'set');
+      const normSpy = vi.spyOn(norm, 'needsUpdate', 'set');
+
+      setPose(0.3, 0.4);
+
+      expect(posSpy).toHaveBeenCalledTimes(1);
+      expect(posSpy).toHaveBeenCalledWith(true);
+      expect(normSpy).toHaveBeenCalledTimes(1);
+      expect(normSpy).toHaveBeenCalledWith(true);
+    } finally {
+      dispose();
+    }
+  });
+
+  it('does NOT mark aLocal needsUpdate on setPose', () => {
+    const { mesh, dispose, setPose } = makeOverlay();
+    try {
+      const aLocal = mesh.geometry.getAttribute('aLocal') as THREE.BufferAttribute;
+      const localSpy = vi.spyOn(aLocal, 'needsUpdate', 'set');
+
+      setPose(0.3, 0.4);
+
+      expect(localSpy).not.toHaveBeenCalled();
+    } finally {
+      dispose();
+    }
+  });
+});
+
+describe('createTaylorOverlay — setPreset lifecycle', () => {
+  it('updates halfExtent uniform when switching to a smaller-domain preset', () => {
+    const overlay = makeOverlay(SADDLE_PRESET);
+    try {
+      const material = (overlay.mesh.material as THREE.ShaderMaterial);
+      const initialHalf = (material.uniforms.uHalfExtent as { value: number })
+        .value;
+      expect(initialHalf).toBeCloseTo(SADDLE_HALF_EXTENT);
+
+      // quartic-min has domain [-1, 1]² (range 2.0); half = 0.25 * 2 / 2 = 0.25.
+      const quartic = PRESETS.find((p) => p.id === 'quartic-min')!;
+      overlay.setPreset(quartic, 0, 0);
+
+      const after = (material.uniforms.uHalfExtent as { value: number }).value;
+      expect(after).toBeCloseTo((0.25 * 2.0) / 2);
+      expect(after).not.toBeCloseTo(initialHalf);
+    } finally {
+      overlay.dispose();
+    }
+  });
+
+  it('rewrites aLocal corners to the new half-extent', () => {
+    const overlay = makeOverlay(SADDLE_PRESET);
+    try {
+      const quartic = PRESETS.find((p) => p.id === 'quartic-min')!;
+      overlay.setPreset(quartic, 0, 0);
+      const aLocal = overlay.mesh.geometry.getAttribute('aLocal');
+      const quarticHalf = (0.25 * 2.0) / 2;
+      // Corner (0, 0) ⇒ (-half, -half) at new preset.
+      expect(aLocal.getX(0)).toBeCloseTo(-quarticHalf);
+      expect(aLocal.getY(0)).toBeCloseTo(-quarticHalf);
+    } finally {
+      overlay.dispose();
+    }
+  });
+
+  it('marks aLocal needsUpdate on setPreset (per roundtable Sonnet F2 + GPT F4)', () => {
+    const overlay = makeOverlay(SADDLE_PRESET);
+    try {
+      const aLocal = overlay.mesh.geometry.getAttribute(
+        'aLocal',
+      ) as THREE.BufferAttribute;
+      const localSpy = vi.spyOn(aLocal, 'needsUpdate', 'set');
+
+      const quartic = PRESETS.find((p) => p.id === 'quartic-min')!;
+      overlay.setPreset(quartic, 0, 0);
+
+      expect(localSpy).toHaveBeenCalledWith(true);
+    } finally {
+      overlay.dispose();
+    }
+  });
+
+  it('also refreshes positions + normals from the new preset', () => {
+    const overlay = makeOverlay(SADDLE_PRESET);
+    try {
+      // Switch to paraboloid (f = x² + y²); at (0, 0) the center
+      // vertex sits at math-Z = 0 (same as saddle), but at the corner
+      // (+half, +half) the paraboloid's z = 2·half² is positive,
+      // unlike the saddle's z = 0.
+      const paraboloid = PRESETS.find((p) => p.id === 'paraboloid')!;
+      overlay.setPreset(paraboloid, 0, 0);
+
+      const aLocal = overlay.mesh.geometry.getAttribute('aLocal');
+      const pos = overlay.mesh.geometry.getAttribute('position');
+      const tr = RES * RES - 1;
+      const u = aLocal.getX(tr);
+      const v = aLocal.getY(tr);
+      const expectedZ = u * u + v * v;
+      expect(pos.getY(tr)).toBeCloseTo(SURFACE_CENTER.y + expectedZ);
+    } finally {
+      overlay.dispose();
+    }
+  });
+});
+
+describe('createTaylorOverlay — analytic normals', () => {
+  it('every normal is unit-length on the saddle preset (mixed-sign Hessian)', () => {
+    const { mesh, dispose, setPose } = makeOverlay();
+    try {
+      setPose(0.3, -0.4);
+      const norm = mesh.geometry.getAttribute('normal');
+      for (let i = 0; i < norm.count; i++) {
+        const mag = Math.hypot(norm.getX(i), norm.getY(i), norm.getZ(i));
+        expect(mag).toBeCloseTo(1);
+      }
+    } finally {
+      dispose();
+    }
+  });
+
+  it('center-vertex normal at saddle origin points straight up in world coords', () => {
+    const { mesh, dispose, setPose } = makeOverlay();
+    try {
+      setPose(0, 0);
+      // At a critical point, qx = qy = 0 everywhere along u = v = 0,
+      // so the math-frame normal is (0, 0, 1) → world (0, 1, 0).
+      const norm = mesh.geometry.getAttribute('normal');
+      expect(norm.getX(CENTER_FLAT)).toBeCloseTo(0);
+      expect(norm.getY(CENTER_FLAT)).toBeCloseTo(1);
+      expect(norm.getZ(CENTER_FLAT)).toBeCloseTo(0);
+    } finally {
+      dispose();
+    }
+  });
+});
+
+describe('createTaylorOverlay — buffer-usage hints + culling', () => {
+  it('position attribute uses DynamicDrawUsage', () => {
+    const { mesh, dispose } = makeOverlay();
+    try {
+      const pos = mesh.geometry.getAttribute('position') as THREE.BufferAttribute;
+      expect(pos.usage).toBe(THREE.DynamicDrawUsage);
+    } finally {
+      dispose();
+    }
+  });
+
+  it('normal attribute uses DynamicDrawUsage', () => {
+    const { mesh, dispose } = makeOverlay();
+    try {
+      const norm = mesh.geometry.getAttribute('normal') as THREE.BufferAttribute;
+      expect(norm.usage).toBe(THREE.DynamicDrawUsage);
+    } finally {
+      dispose();
+    }
+  });
+
+  it('aLocal attribute uses default StaticDrawUsage', () => {
+    const { mesh, dispose } = makeOverlay();
+    try {
+      const aLocal = mesh.geometry.getAttribute('aLocal') as THREE.BufferAttribute;
+      expect(aLocal.usage).toBe(THREE.StaticDrawUsage);
+    } finally {
+      dispose();
+    }
+  });
+
+  it('mesh.frustumCulled is false (stale-bounds mitigation per §2.4.2)', () => {
+    const { mesh, dispose } = makeOverlay();
+    try {
+      expect(mesh.frustumCulled).toBe(false);
+    } finally {
+      dispose();
+    }
+  });
+});
+
+describe('createTaylorOverlay — material flags', () => {
+  it('has polygonOffset enabled with negative factor + units', () => {
+    const { mesh, dispose } = makeOverlay();
+    try {
+      const mat = mesh.material as THREE.ShaderMaterial;
+      expect(mat.polygonOffset).toBe(true);
+      expect(mat.polygonOffsetFactor).toBeLessThan(0);
+      expect(mat.polygonOffsetUnits).toBeLessThan(0);
+    } finally {
+      dispose();
+    }
+  });
+
+  it('is transparent, double-sided, depthWrite false, renderOrder 1', () => {
+    const { mesh, dispose } = makeOverlay();
+    try {
+      const mat = mesh.material as THREE.ShaderMaterial;
+      expect(mat.transparent).toBe(true);
+      expect(mat.depthWrite).toBe(false);
+      expect(mat.side).toBe(THREE.DoubleSide);
+      expect(mesh.renderOrder).toBe(1);
+    } finally {
+      dispose();
+    }
+  });
+});
+
+describe('createTaylorOverlay — dispose', () => {
+  it('disposes both geometry and material exactly once', () => {
+    const handles = makeOverlay();
+    const geomSpy = vi.spyOn(handles.mesh.geometry, 'dispose');
+    const matSpy = vi.spyOn(handles.mesh.material as THREE.ShaderMaterial, 'dispose');
+    handles.dispose();
+    expect(geomSpy).toHaveBeenCalledTimes(1);
+    expect(matSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #180. Closes epic #175 (saddle / extrema scene — 6/6 children done).

## Summary

At the slider-selected point `(x₀, y₀)`, render the second-order Taylor approximation `q(x, y)` of the active preset's `f` as a translucent meshed surface "patch" hugging the main surface. This is the §11.7–11.8 *pedagogical* punch line of the saddle-extrema scene: at a critical point the linear term vanishes and the overlay IS the local quadratic (bowl up / bowl down / saddle / flat-degenerate); away from a critical point the overlay tips into a curved tangent-shaped patch, making the second-derivative test's domain-of-validity legible.

**New helper `TaylorOverlay.ts`** owns its own `BufferGeometry` + custom `ShaderMaterial` and mutates `position` + `normal` BufferAttributes every frame from `(x, y)` slider state + the active preset's `f` / `gradF` / `hessF`. Shares only the math-frame helpers (`writeGraphPointToWorld`, `writeMathToWorld`) with the main `GraphSurface` — per the #176 SPEC's "same-scene consumer of helpers" anticipation.

Plan went through `/roundtable-plan-review` (Sonnet + GPT-5.5 Pro + DeepSeek V4 Pro) on 2026-05-11. v1 came back **REVISE / REVISE / PROCEED**; v2 applied all ten findings; Sonnet tightening pass on v2.1 returned **PROCEED**. Notable shifts from v1:

- **`polygonOffset` ships day one**, not deferred to smoke. The three exact-quadratic presets (`paraboloid`, `inv-paraboloid`, `saddle`) coincide with the main surface across the entire patch (not just the center), so z-fighting would be deterministic without the offset.
- **`res = 49`**, not 48 — odd resolution puts a vertex exactly at the center `(u = v = 0)` at index 24, matching the indicator's selected point.
- **Subtle lambert on the body** (`0.6 + 0.4·dot(n, L)`) so curvature reads. A flat-lit translucent curved surface reads as a uniform tint, hiding the bowl / saddle / flat shape the overlay is meant to teach.
- **`frustumCulled = false` + `DynamicDrawUsage`** for the stale-bounding-sphere mitigation; pinned by Vitest.

Plan doc at `_private/plans/180-saddle-extrema-quadratic-overlay.md` (maintainer-only).

## Test plan

**Vitest** (24 new tests in `test/exhibits/saddle-extrema/TaylorOverlay.test.ts` — all green; 332 tests passing total):

- [x] Odd-res center vertex parity (vertex exactly at `(0, 0)` and corners at `(±half, ±half)`).
- [x] Quadratic invariance at the selected point (center vertex sits at `writeGraphPointToWorld(x0, y0, f(x0, y0))`).
- [x] At a critical point the overlay equals the pure quadratic (saddle at origin: `u² − v²`).
- [x] Away from a critical point the linear term contributes (saddle at `(0.5, 0)`: `0.25 + u + u² − v²`).
- [x] `setPose` mutates positions + normals but leaves `aLocal` unchanged.
- [x] `setPose` marks `position.needsUpdate` + `normal.needsUpdate` exactly once each per call (spy-based).
- [x] `setPose` does NOT mark `aLocal.needsUpdate` (cadence proof).
- [x] `setPreset` updates `uHalfExtent` uniform + rewrites `aLocal` corners + marks `aLocal.needsUpdate` + refreshes positions.
- [x] Analytic normals: every normal is unit-length on the saddle (mixed-sign Hessian); center-vertex normal at saddle origin is `(0, 1, 0)` in world coords.
- [x] Buffer hints + culling: `position` + `normal` use `DynamicDrawUsage`, `aLocal` stays `StaticDrawUsage`, `mesh.frustumCulled` is `false`.
- [x] Material flags: `polygonOffset` enabled with negative factor + units; `transparent`, `depthWrite: false`, `DoubleSide`, `renderOrder = 1`.
- [x] Dispose contract: geometry + material each disposed exactly once.

**Toolchain** (all green locally):

- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint` clean.
- [x] `npm test` — 332 passed (308 prior + 24 new).
- [x] `npm run build` — Vite build clean (~720 KB bundle, unchanged shape).

**Cloudflare PR preview (headset smoke):**

- [ ] Boot saddle preset (default). Overlay visible at boot pose `(0.5, 0.3)`. Body sky-blue translucent with subtle lambert showing curvature; rim brighter, faintly outlining the patch.
- [ ] Slide `(x, y)` to `(0, 0)` — the critical point. Overlay's center nests at the YELLOW CP marker. Overlay is pure quadratic — visibly a saddle (one direction up, one down). **No z-fighting** on the coplanar patch (polygonOffset working).
- [ ] Step through all five presets at origin:
  - [ ] `paraboloid` — overlay = bowl-up matching main surface; clear rim halo even though coplanar.
  - [ ] `inv-paraboloid` — overlay = bowl-down matching main surface.
  - [ ] `saddle` — overlay matches main saddle.
  - [ ] `monkey-saddle` — overlay = FLAT PATCH (Hessian vanishes). Main surface curves up/down in three lobes around it.
  - [ ] `quartic-min` — overlay = FLAT PATCH. Main surface = bowl. The §11.7–11.8 punch line.
- [ ] Slide `(x, y)` away from origin on saddle. Overlay tilts (linear term kicks in); rim still readable.
- [ ] **Quartic-min edge case:** slide to `(0.9, 0)`. Overlay's right edge floats past the main surface's right edge at `x = 1.0`. Confirm this reads as "the local quadratic extends beyond the rendered domain" rather than as a visual artifact.
- [ ] **Subtle-lambert legibility:** confirm curvature of bowl-up, bowl-down, saddle, and the two flats is distinguishable from just the overlay shading alone. Tune `0.6 + 0.4·lambert` if too subtle or too bright.
- [ ] No visual regression in manipulator, tangent-planes, or gradient-levels.
- [ ] No FPS regression (FpsOverlay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)