### PR TITLE
feat(shell): ?mode= URL-param parsing (#189 pancake step 1)

### DIFF
--- a/src/shell/url-routing.ts
+++ b/src/shell/url-routing.ts
@@ -8,6 +8,47 @@ import type { Exhibit } from './Exhibit';
 
 export type HistoryMode = 'push' | 'replace' | 'none';
 
+// Form-factor modes the shell can boot into (#189, pancake step 1
+// of #105). `'vr'` is today's path; `'desktop'` + `'mobile'` are
+// pancake form factors landing in later #105 steps. Listed as a
+// `const` tuple so the runtime check in `resolveMode` and the
+// `Mode` type stay in lockstep — adding a fourth mode (e.g.,
+// emulator) is a single-line change here.
+export const MODES = ['vr', 'desktop', 'mobile'] as const;
+export type Mode = (typeof MODES)[number];
+
+export interface ModeResolveResult {
+  // The mode the user explicitly requested via `?mode=`, or `null`
+  // when there was no usable override and the caller should fall
+  // through to auto-detect (per plan §3.2). Mirrors
+  // `resolveExhibitId`'s shape, but the "default" for mode is the
+  // async `isSessionSupported` probe — not a synchronously
+  // resolvable value — so we return `null` rather than picking one.
+  mode: Mode | null;
+  // True when the resolver had to fall back from a non-null
+  // requested value. Same console-warn semantics as
+  // `resolveExhibitId.fellBack`:
+  //   - `null` / `undefined` (no `?mode=`)  → fellBack=false
+  //   - `''`  (`?mode=` empty)              → fellBack=true
+  //   - any unknown value                   → fellBack=true
+  //   - one of `MODES`                      → fellBack=false
+  fellBack: boolean;
+}
+
+/**
+ * Parse a `?mode=` value into a recognized `Mode` or `null` for
+ * "no override; auto-detect." Pure; the shell handles the
+ * console-warn and the async mode probe per plan §3.2.
+ */
+export function resolveMode(
+  requested: string | null | undefined,
+): ModeResolveResult {
+  if (requested != null && (MODES as readonly string[]).includes(requested)) {
+    return { mode: requested as Mode, fellBack: false };
+  }
+  return { mode: null, fellBack: requested != null };
+}
+
 export interface ResolveResult {
   // The cluster-member id we ended up on. When the requested id was
   // unrecognized / empty / non-cluster, this is `clusterExhibits[0].id`.
@@ -58,6 +99,12 @@ export interface UrlSyncPlan {
  * just at boot, so back-button history doesn't accumulate redundant
  * `?exhibit=<defaultId>` entries when the user hops to a non-default
  * scene and back.
+ *
+ * Mode-preservation invariant (#189, plan G6): this function only
+ * mutates the `exhibit` search param, so any unrelated params on
+ * `currentHref` — including `?mode=` for pancake form-factor
+ * selection — survive the rewrite. SceneRack navigation in pancake
+ * therefore preserves `mode=desktop` (or `mobile`) for free.
  */
 export function planUrlSync(
   id: string,

--- a/test/shell/url-routing.test.ts
+++ b/test/shell/url-routing.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import type { Exhibit } from '@/shell/Exhibit';
 import { CLUSTER_CALCULUS3 } from '@/shell/clusters';
-import { resolveExhibitId, planUrlSync } from '@/shell/url-routing';
+import {
+  resolveExhibitId,
+  resolveMode,
+  planUrlSync,
+} from '@/shell/url-routing';
 
 // Stand-in cluster exhibits for the resolver tests. Only the `id`
 // and `cluster` fields matter for `resolveExhibitId`; the rest are
@@ -146,5 +150,161 @@ describe('planUrlSync', () => {
     );
     expect(plan.write).toBe('push');
     expect(plan.href).toBe('https://example.com/geometer/?fps=1&exhibit=tangent-planes');
+  });
+
+  // Mode-preservation invariant (#189, plan G6): the SceneRack-nav
+  // path in pancake mode rewrites `?exhibit=` on every cluster
+  // switch; `?mode=desktop` / `?mode=mobile` must ride through
+  // unchanged so the user doesn't fall out of pancake mid-session.
+  describe('mode preservation (#189)', () => {
+    it('preserves ?mode=desktop when canonicalizing default id', () => {
+      const plan = planUrlSync(
+        defaultId,
+        'replace',
+        defaultId,
+        'https://example.com/geometer/?exhibit=quadrics&mode=desktop',
+      );
+      expect(plan.write).toBe('replace');
+      expect(plan.href).toBe('https://example.com/geometer/?mode=desktop');
+    });
+
+    it('preserves ?mode=mobile when setting a non-default id from bare', () => {
+      const plan = planUrlSync(
+        'tangent-planes',
+        'push',
+        defaultId,
+        'https://example.com/geometer/?mode=mobile',
+      );
+      expect(plan.write).toBe('push');
+      expect(plan.href).toBe(
+        'https://example.com/geometer/?mode=mobile&exhibit=tangent-planes',
+      );
+    });
+
+    it('preserves ?mode=desktop across SceneRack-style id swap', () => {
+      // SceneRack tap: was on quadrics with mode=desktop, taps the
+      // tangent-planes tab. planUrlSync is called with the new id.
+      const plan = planUrlSync(
+        'tangent-planes',
+        'push',
+        defaultId,
+        'https://example.com/geometer/?exhibit=quadrics&mode=desktop',
+      );
+      expect(plan.write).toBe('push');
+      expect(plan.href).toBe(
+        'https://example.com/geometer/?exhibit=tangent-planes&mode=desktop',
+      );
+    });
+
+    it('preserves ?mode=desktop on no-op write (already-settled non-default)', () => {
+      const plan = planUrlSync(
+        'tangent-planes',
+        'push',
+        defaultId,
+        'https://example.com/geometer/?exhibit=tangent-planes&mode=desktop',
+      );
+      expect(plan.write).toBe(null);
+      expect(plan.href).toBe(
+        'https://example.com/geometer/?exhibit=tangent-planes&mode=desktop',
+      );
+    });
+  });
+});
+
+describe('resolveMode', () => {
+  it('null requested → mode=null, no fallback (silent bare-URL boot)', () => {
+    const r = resolveMode(null);
+    expect(r.mode).toBe(null);
+    expect(r.fellBack).toBe(false);
+  });
+  it('undefined requested → mode=null, no fallback', () => {
+    const r = resolveMode(undefined);
+    expect(r.mode).toBe(null);
+    expect(r.fellBack).toBe(false);
+  });
+  it("empty string ('?mode=') → mode=null, fellBack=true", () => {
+    const r = resolveMode('');
+    expect(r.mode).toBe(null);
+    expect(r.fellBack).toBe(true);
+  });
+  it("unknown value ('?mode=bogus') → mode=null, fellBack=true", () => {
+    const r = resolveMode('bogus');
+    expect(r.mode).toBe(null);
+    expect(r.fellBack).toBe(true);
+  });
+  it("'vr' → mode='vr', no fallback", () => {
+    const r = resolveMode('vr');
+    expect(r.mode).toBe('vr');
+    expect(r.fellBack).toBe(false);
+  });
+  it("'desktop' → mode='desktop', no fallback", () => {
+    const r = resolveMode('desktop');
+    expect(r.mode).toBe('desktop');
+    expect(r.fellBack).toBe(false);
+  });
+  it("'mobile' → mode='mobile', no fallback", () => {
+    const r = resolveMode('mobile');
+    expect(r.mode).toBe('mobile');
+    expect(r.fellBack).toBe(false);
+  });
+  it('case-sensitive: "DESKTOP" is not recognized', () => {
+    // Match the existing `?exhibit=` semantics — case-sensitive.
+    // Keep URL keywords lowercase by convention; an uppercased
+    // value is a typo, treated like any other unknown.
+    const r = resolveMode('DESKTOP');
+    expect(r.mode).toBe(null);
+    expect(r.fellBack).toBe(true);
+  });
+});
+
+describe('combined ?mode= + ?exhibit= URLs', () => {
+  // The two parsers operate on the same URL but don't share state.
+  // These tests document the end-to-end shape a pancake boot will
+  // see when the shell wires resolveMode in (later #105 step).
+  function parseBoth(href: string): {
+    exhibit: ReturnType<typeof resolveExhibitId>;
+    mode: ReturnType<typeof resolveMode>;
+  } {
+    const params = new URL(href).searchParams;
+    return {
+      exhibit: resolveExhibitId(params.get('exhibit'), clusterExhibits),
+      mode: resolveMode(params.get('mode')),
+    };
+  }
+
+  it('?mode=desktop&exhibit=quadrics → both resolve cleanly', () => {
+    const { exhibit, mode } = parseBoth(
+      'https://example.com/geometer/?mode=desktop&exhibit=quadrics',
+    );
+    expect(exhibit.id).toBe('quadrics');
+    expect(exhibit.fellBack).toBe(false);
+    expect(mode.mode).toBe('desktop');
+    expect(mode.fellBack).toBe(false);
+  });
+
+  it('?mode=desktop&exhibit=tangent-planes → both resolve cleanly', () => {
+    const { exhibit, mode } = parseBoth(
+      'https://example.com/geometer/?mode=desktop&exhibit=tangent-planes',
+    );
+    expect(exhibit.id).toBe('tangent-planes');
+    expect(mode.mode).toBe('desktop');
+  });
+
+  it('bare URL → null mode + default exhibit, neither warns', () => {
+    const { exhibit, mode } = parseBoth('https://example.com/geometer/');
+    expect(exhibit.id).toBe(defaultId);
+    expect(exhibit.fellBack).toBe(false);
+    expect(mode.mode).toBe(null);
+    expect(mode.fellBack).toBe(false);
+  });
+
+  it('?mode=bogus&exhibit=quadrics → exhibit clean, mode fellBack', () => {
+    const { exhibit, mode } = parseBoth(
+      'https://example.com/geometer/?mode=bogus&exhibit=quadrics',
+    );
+    expect(exhibit.id).toBe('quadrics');
+    expect(exhibit.fellBack).toBe(false);
+    expect(mode.mode).toBe(null);
+    expect(mode.fellBack).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Pancake step 1 of #105 — pure-additive URL parsing infrastructure for the upcoming desktop / mobile form factors.

- Adds `resolveMode(requested)` helper in `src/shell/url-routing.ts`, mirroring `resolveExhibitId`'s `{ value, fellBack }` shape. Recognized values: `'vr'` / `'desktop'` / `'mobile'`; anything else (empty, unknown, case-mismatched) returns `mode: null` so the caller falls through to the async `isSessionSupported` probe per plan §3.2.
- Exposes a `Mode` union + `MODES` const tuple so the runtime check and the type stay in lockstep.
- Locks in `planUrlSync`'s existing mode-preservation invariant via dedicated tests (plan G6). `planUrlSync` only ever mutates the `exhibit` param, so `?mode=desktop` survives every rewrite for free — the tests document the contract so a future refactor can't break it silently.

**No consumer wiring in this PR** — value is unconsumed per the plan's step-1 design ("No behavior change yet"). The shell will start reading `resolveMode`'s output in #190 / #193 once `Pointer` + `DesktopPointer` land.

VR mode is unchanged.

## Test plan

- [x] `npm test` — 349 passed (was 334; +15 new in `url-routing.test.ts`).
- [x] `npm run build` clean (`tsc --noEmit` + Vite production build).
- [x] `npm run lint` clean.
- [x] Cloudflare PR preview opens normally in VR — no regressions (this PR doesn't touch the renderer, but worth confirming nothing slipped).

## What the new tests cover

- `resolveMode`: all of `null` / `undefined` / `''` / `'bogus'` / each of `'vr'` / `'desktop'` / `'mobile'`, plus a case-sensitivity lock (`'DESKTOP'` is a typo, treated like any unknown).
- `planUrlSync` mode-preservation: canonicalize-to-default, set-non-default-from-bare, SceneRack-style id swap, no-op write on already-settled non-default. Each case verifies `?mode=` rides through unchanged.
- Combined parsing scenarios: `?mode=desktop&exhibit=quadrics`, bare URL (neither warns), `?mode=bogus&exhibit=quadrics` (exhibit clean, mode `fellBack=true`).

## References

- Closes #189.
- Parent epic: #105 (pancake build).
- Plan doc: `_private/plans/105-pancake-build.md` §5 step 1 + G6.
- v0.9 sequencing recorded on the epics: #105 / #188 (Phase 1 of the pancake half starts here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)