### PR TITLE
feat(shell): Pointer interface + VRPointer adapter (#190)

### DIFF
--- a/src/shell/Exhibit.ts
+++ b/src/shell/Exhibit.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import type { ClusterId } from './clusters';
+import type { Pointer } from './Pointer';
 
 export interface ExhibitContext {
   // Per-exhibit root group (#150). The shell creates this on mount and
@@ -9,9 +10,21 @@ export interface ExhibitContext {
   group: THREE.Group;
   renderer: THREE.WebGLRenderer;
   camera: THREE.PerspectiveCamera;
-  // Shell-owned XR controllers (#150). Listeners are registered once in
-  // `bootShell`; the shell dispatches `selectstart` / `selectend` to the
-  // currently-mounted exhibit via `onSelectStart` / `onSelectEnd`.
+  /**
+   * Shell-owned `Pointer` instances (#190, pancake plan v3 §3.1). Same
+   * reference per frame; consumers compare by reference for grab /
+   * release bookkeeping. `controllers` lives on alongside this field
+   * during the migration window (UI primitives are still
+   * `Object3D`-typed) and retires in #191 once the bundled migration
+   * lands.
+   */
+  pointers: readonly Pointer[];
+  /**
+   * @deprecated #190 — replaced by `pointers`. Removed in #191 once
+   * `Slider` / `TapButton` / `Preset` / `SectionTab` / `SceneTab` /
+   * `AxisToggle` migrate from `THREE.Object3D` to `Pointer`. Both
+   * fields populated in lockstep until then.
+   */
   controllers: readonly THREE.Object3D[];
 }
 

--- a/src/shell/Pointer.ts
+++ b/src/shell/Pointer.ts
@@ -1,0 +1,42 @@
+import * as THREE from 'three';
+
+/**
+ * Abstract pointer for UI primitives — covers both VR controllers and
+ * the pancake (desktop / mobile) mouse / touch-driven equivalent
+ * landing in #191+ (parent #105).
+ *
+ * Step 2 of the pancake plan (#190): interface only, with a `VRPointer`
+ * adapter wrapping `XRTargetRaySpace`. UI primitives still consume
+ * `THREE.Object3D` until #191's bundled migration; for now `VRPointer`s
+ * sit alongside the existing controller fields on `ExhibitContext`.
+ *
+ * `getWorldQuaternion` is deliberately absent. Per the plan v3 §3.1
+ * filesystem read, the only pose-dependent slider math
+ * (`Slider.controllerLocalX`) reads only the controller's world
+ * *position*; every other ray-direction read on the UI primitives
+ * reduces to `getRayDirection`. Forcing a `DesktopPointer` to stub a
+ * meaningful roll would be a leak with no consumer.
+ */
+export interface Pointer {
+  /**
+   * Identity for diagnostics (logging, debug overlays). The grab /
+   * release contract on UI primitives is reference-equality on the
+   * `Pointer` instance — so `Pointer` instances must be constructed
+   * exactly once at boot mode-detection time and reused per frame.
+   */
+  readonly id: string;
+
+  /** World-space ray origin. Read fresh every frame. */
+  getRayOrigin(target: THREE.Vector3): THREE.Vector3;
+
+  /**
+   * World-space ray direction (unit vector). Read fresh every frame.
+   * Implementations must produce the *same* ray the pre-refactor
+   * primitive code would have computed from the underlying controller
+   * / mouse state — no convention change during the migration window.
+   */
+  getRayDirection(target: THREE.Vector3): THREE.Vector3;
+
+  /** Haptic pulse on this pointer. Implementations may no-op. */
+  pulse(intensity: number, durationMs: number): void;
+}

--- a/src/shell/VRPointer.ts
+++ b/src/shell/VRPointer.ts
@@ -45,8 +45,9 @@ interface ControllerWithGamepad extends THREE.Object3D {
  * `XRTargetRaySpace` (a plain `Group`) does not. Delegating would
  * flip the ray's sign and break hover / grab on every primitive once
  * #191 migrates them. We use the matching `(0,0,-1).applyQuaternion`
- * formula instead; the regression assertion in `shell.ts` compares
- * against the same formula and stays a meaningful tripwire for #191.
+ * formula instead. The yaw-180° unit test in
+ * `test/shell/VRPointer.test.ts` is the load-bearing regression
+ * guard against a future refactor reintroducing the sign flip.
  */
 export class VRPointer implements Pointer {
   readonly id: string;

--- a/src/shell/VRPointer.ts
+++ b/src/shell/VRPointer.ts
@@ -1,0 +1,78 @@
+import * as THREE from 'three';
+import type { Pointer } from './Pointer';
+
+// `XRTargetRaySpace` (the type returned by `renderer.xr.getController(i)`)
+// is exported from three's webxr addon. Importing it adds no runtime
+// surface — it's a class used only as a type in the constructor signature.
+type XRTargetRaySpace = THREE.Group;
+
+/**
+ * Per-controller `userData.gamepad` shape attached by the shell's
+ * `'connected'` listener. Mirrors the `ControllerWithGamepad` interfaces
+ * currently inlined in `Slider.ts` / `TapButton.ts` / `AxisToggle.ts`,
+ * which retire alongside the bundled UI migration in #191.
+ */
+interface ControllerWithGamepad extends THREE.Object3D {
+  userData: {
+    gamepad?: {
+      hapticActuators?: ReadonlyArray<{
+        pulse?: (intensity: number, durationMs: number) => void;
+      }>;
+    };
+  };
+}
+
+/**
+ * `Pointer` adapter wrapping an XR controller's `XRTargetRaySpace`.
+ *
+ * Goal (plan v3 §3.1 / G2): produce **the same ray** the pre-refactor
+ * UI primitives compute, so #191's bundled migration is a pure
+ * signature change rather than a behavior change.
+ *
+ * Pre-refactor code at `Slider.ts:299`, `TapButton.ts:220`, and
+ * `AxisToggle.ts:161` reads ray direction as
+ * `(0, 0, -1).applyQuaternion(controller.getWorldQuaternion(...))` —
+ * i.e. the controller's local **−Z** axis in world space, which is
+ * the direction the visible aim-ray line points
+ * (`shell.ts` builds that line from `(0,0,0)` to `(0,0,-1)`).
+ *
+ * **Why this differs from the issue's literal text.** Issue #190's
+ * body and plan v3 §3.1 both say "delegate directly to
+ * `controller.getWorldDirection(target)`" and call that bit-identical.
+ * It isn't: `Object3D.getWorldDirection` returns the **+Z** axis
+ * (`matrixWorld.elements[8..10]`, three.js r184 `Object3D.js:424`).
+ * The `Camera` subclass overrides this to negate, but
+ * `XRTargetRaySpace` (a plain `Group`) does not. Delegating would
+ * flip the ray's sign and break hover / grab on every primitive once
+ * #191 migrates them. We use the matching `(0,0,-1).applyQuaternion`
+ * formula instead; the regression assertion in `shell.ts` compares
+ * against the same formula and stays a meaningful tripwire for #191.
+ */
+export class VRPointer implements Pointer {
+  readonly id: string;
+  private readonly controller: XRTargetRaySpace;
+  // Scratch quaternion reused per `getRayDirection` call. Allocated
+  // once per `VRPointer` instance to avoid per-frame allocation on
+  // the hover / grab hot path.
+  private readonly scratchQuat = new THREE.Quaternion();
+
+  constructor(controller: XRTargetRaySpace, id: string) {
+    this.controller = controller;
+    this.id = id;
+  }
+
+  getRayOrigin(target: THREE.Vector3): THREE.Vector3 {
+    return this.controller.getWorldPosition(target);
+  }
+
+  getRayDirection(target: THREE.Vector3): THREE.Vector3 {
+    this.controller.getWorldQuaternion(this.scratchQuat);
+    return target.set(0, 0, -1).applyQuaternion(this.scratchQuat);
+  }
+
+  pulse(intensity: number, durationMs: number): void {
+    const gamepad = (this.controller as ControllerWithGamepad).userData.gamepad;
+    const actuator = gamepad?.hapticActuators?.[0];
+    actuator?.pulse?.(intensity, durationMs);
+  }
+}

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -10,6 +10,7 @@ import {
   resolveExhibitId,
   type HistoryMode,
 } from './url-routing';
+import { VRPointer } from './VRPointer';
 
 // Vite HMR can re-execute module-level code in dev. `bootShell` is
 // idempotent against double-invocation: subsequent calls early-return
@@ -132,6 +133,17 @@ export function bootShell(): void {
   }
   const controllers: readonly THREE.Object3D[] = [controller0, controller1];
 
+  // `VRPointer`s wrapping the two XR controllers (#190, pancake plan v3
+  // §3.1 / §3.5 / S4). Constructed exactly once at boot so the
+  // reference-equality grab/release contract on UI primitives holds
+  // across frames; the shell hands the same two instances to every
+  // `ExhibitContext` it builds. UI primitives still consume
+  // `Object3D` here — the bundled migration is #191. `controllers`
+  // stays populated alongside `pointers` until then.
+  const vrPointer0 = new VRPointer(controller0, 'vr-0');
+  const vrPointer1 = new VRPointer(controller1, 'vr-1');
+  const pointers: readonly VRPointer[] = [vrPointer0, vrPointer1];
+
   // SceneRack (#150 step 5): one tab per cluster member, tap →
   // `requestSwitch(id, 'push')` so a SceneTab tap pushes a new
   // history entry the user can back-button out of. The rack's
@@ -188,7 +200,13 @@ export function bootShell(): void {
     const group = new THREE.Group();
     group.name = `exhibit:${targetId}`;
     scene.add(group);
-    const ctx: ExhibitContext = { group, renderer, camera, controllers };
+    const ctx: ExhibitContext = {
+      group,
+      renderer,
+      camera,
+      controllers,
+      pointers,
+    };
     target.mount(ctx);
     currentExhibit = target;
     currentCtx = ctx;
@@ -235,6 +253,7 @@ export function bootShell(): void {
       renderer,
       camera,
       controllers,
+      pointers,
     };
     e.mount(warmCtx);
     renderer.compile(scene, camera);
@@ -250,6 +269,50 @@ export function bootShell(): void {
   // resolver can keep the bare-URL boot silent.
   scheduler.requestSwitch(requestedParam, 'replace');
 
+  // Migration-window regression assertion (#190 / pancake plan v3 §5
+  // step 3 / G2). The pre-refactor formula `(0,0,-1).applyQuaternion(
+  // controller.getWorldQuaternion(...))` lives on at `Slider.ts:299`,
+  // `TapButton.ts:220`, and `AxisToggle.ts:161` during the migration
+  // window; #191 swaps those call-sites to `pointer.getRayDirection`.
+  // This assertion runs the old formula against the new adapter
+  // every frame and warns once per controller per session if they
+  // diverge. Cheap insurance against a silent refactor of
+  // `VRPointer.getRayDirection` between #190 and #191, when callers
+  // stop reading the controller directly. Retires alongside the
+  // deprecated `controllers` field in #191.
+  //
+  // (NB: the issue body suggested comparing against
+  // `controller.getWorldDirection`. That comparison is incorrect —
+  // `Object3D.getWorldDirection` returns the +Z axis, while the
+  // primitives use -Z. We compare against the actual pre-refactor
+  // formula instead so the tripwire stays meaningful.)
+  const regressionScratchOld = new THREE.Vector3();
+  const regressionScratchNew = new THREE.Vector3();
+  const regressionScratchQuat = new THREE.Quaternion();
+  const regressionWarned = [false, false];
+  const checkPointerRegression = (): void => {
+    if (!renderer.xr.isPresenting) return;
+    for (let i = 0; i < pointers.length; i++) {
+      if (regressionWarned[i]) continue;
+      const c = controllers[i];
+      const p = pointers[i];
+      c.getWorldQuaternion(regressionScratchQuat);
+      regressionScratchOld.set(0, 0, -1).applyQuaternion(regressionScratchQuat);
+      p.getRayDirection(regressionScratchNew);
+      if (regressionScratchOld.distanceToSquared(regressionScratchNew) > 1e-10) {
+        console.warn(
+          `geometer #190: VRPointer[${i}].getRayDirection diverged from ` +
+            `the pre-refactor (0,0,-1).applyQuaternion(getWorldQuaternion) ` +
+            `formula (` +
+            `${regressionScratchOld.toArray().join(',')} vs ` +
+            `${regressionScratchNew.toArray().join(',')}). ` +
+            `This regression check retires with #191.`,
+        );
+        regressionWarned[i] = true;
+      }
+    }
+  };
+
   const timer = new THREE.Timer();
   // Page Visibility integration: prevents huge delta spikes after the tab
   // (or Quest headset) is backgrounded and re-focused mid-session.
@@ -260,6 +323,7 @@ export function bootShell(): void {
     // dispatching. Coalescing means two `requestSwitch` calls in
     // the same tick mount only the latest target.
     scheduler.drain();
+    checkPointerRegression();
     timer.update();
     const delta = timer.getDelta();
     currentExhibit?.update({ delta });

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -10,6 +10,7 @@ import {
   resolveExhibitId,
   type HistoryMode,
 } from './url-routing';
+import type { Pointer } from './Pointer';
 import { VRPointer } from './VRPointer';
 
 // Vite HMR can re-execute module-level code in dev. `bootShell` is
@@ -142,7 +143,7 @@ export function bootShell(): void {
   // stays populated alongside `pointers` until then.
   const vrPointer0 = new VRPointer(controller0, 'vr-0');
   const vrPointer1 = new VRPointer(controller1, 'vr-1');
-  const pointers: readonly VRPointer[] = [vrPointer0, vrPointer1];
+  const pointers: readonly Pointer[] = [vrPointer0, vrPointer1];
 
   // SceneRack (#150 step 5): one tab per cluster member, tap →
   // `requestSwitch(id, 'push')` so a SceneTab tap pushes a new
@@ -269,50 +270,6 @@ export function bootShell(): void {
   // resolver can keep the bare-URL boot silent.
   scheduler.requestSwitch(requestedParam, 'replace');
 
-  // Migration-window regression assertion (#190 / pancake plan v3 §5
-  // step 3 / G2). The pre-refactor formula `(0,0,-1).applyQuaternion(
-  // controller.getWorldQuaternion(...))` lives on at `Slider.ts:299`,
-  // `TapButton.ts:220`, and `AxisToggle.ts:161` during the migration
-  // window; #191 swaps those call-sites to `pointer.getRayDirection`.
-  // This assertion runs the old formula against the new adapter
-  // every frame and warns once per controller per session if they
-  // diverge. Cheap insurance against a silent refactor of
-  // `VRPointer.getRayDirection` between #190 and #191, when callers
-  // stop reading the controller directly. Retires alongside the
-  // deprecated `controllers` field in #191.
-  //
-  // (NB: the issue body suggested comparing against
-  // `controller.getWorldDirection`. That comparison is incorrect —
-  // `Object3D.getWorldDirection` returns the +Z axis, while the
-  // primitives use -Z. We compare against the actual pre-refactor
-  // formula instead so the tripwire stays meaningful.)
-  const regressionScratchOld = new THREE.Vector3();
-  const regressionScratchNew = new THREE.Vector3();
-  const regressionScratchQuat = new THREE.Quaternion();
-  const regressionWarned = [false, false];
-  const checkPointerRegression = (): void => {
-    if (!renderer.xr.isPresenting) return;
-    for (let i = 0; i < pointers.length; i++) {
-      if (regressionWarned[i]) continue;
-      const c = controllers[i];
-      const p = pointers[i];
-      c.getWorldQuaternion(regressionScratchQuat);
-      regressionScratchOld.set(0, 0, -1).applyQuaternion(regressionScratchQuat);
-      p.getRayDirection(regressionScratchNew);
-      if (regressionScratchOld.distanceToSquared(regressionScratchNew) > 1e-10) {
-        console.warn(
-          `geometer #190: VRPointer[${i}].getRayDirection diverged from ` +
-            `the pre-refactor (0,0,-1).applyQuaternion(getWorldQuaternion) ` +
-            `formula (` +
-            `${regressionScratchOld.toArray().join(',')} vs ` +
-            `${regressionScratchNew.toArray().join(',')}). ` +
-            `This regression check retires with #191.`,
-        );
-        regressionWarned[i] = true;
-      }
-    }
-  };
-
   const timer = new THREE.Timer();
   // Page Visibility integration: prevents huge delta spikes after the tab
   // (or Quest headset) is backgrounded and re-focused mid-session.
@@ -323,7 +280,6 @@ export function bootShell(): void {
     // dispatching. Coalescing means two `requestSwitch` calls in
     // the same tick mount only the latest target.
     scheduler.drain();
-    checkPointerRegression();
     timer.update();
     const delta = timer.getDelta();
     currentExhibit?.update({ delta });

--- a/test/shell/VRPointer.test.ts
+++ b/test/shell/VRPointer.test.ts
@@ -47,8 +47,8 @@ describe('VRPointer', () => {
     it('rotates with the controller (yaw 180° → world +Z)', () => {
       // Yaw 180° around world Y: local -Z → world +Z. This is the
       // sign-flip case that catches a regression to
-      // `controller.getWorldDirection` (which would still return -Z
-      // here because it reads the +Z column).
+      // `controller.getWorldDirection` (which would return world -Z
+      // here because it reads the +Z column of the rotated matrix).
       const controller = new THREE.Group();
       controller.rotation.y = Math.PI;
       const pointer = new VRPointer(controller, 'vr-0');
@@ -57,29 +57,6 @@ describe('VRPointer', () => {
       expect(target.x).toBeCloseTo(0);
       expect(target.y).toBeCloseTo(0);
       expect(target.z).toBeCloseTo(1);
-    });
-
-    it('matches the pre-refactor (0,0,-1).applyQuaternion formula exactly', () => {
-      // Equivalence check against the formula at Slider.ts:299 /
-      // TapButton.ts:220 / AxisToggle.ts:161 — same one the
-      // shell.ts regression assertion guards every frame in #191's
-      // migration window. Any sign flip or axis swap in
-      // `VRPointer.getRayDirection` would fail this.
-      const controller = new THREE.Group();
-      controller.position.set(0.4, 1.7, -1.2);
-      controller.rotation.set(0.3, -0.7, 0.15);
-      controller.updateMatrixWorld();
-
-      const pointer = new VRPointer(controller, 'vr-0');
-      const fromAdapter = pointer.getRayDirection(new THREE.Vector3());
-
-      const fromOldFormula = new THREE.Vector3(0, 0, -1).applyQuaternion(
-        controller.getWorldQuaternion(new THREE.Quaternion()),
-      );
-
-      expect(fromAdapter.x).toBeCloseTo(fromOldFormula.x, 10);
-      expect(fromAdapter.y).toBeCloseTo(fromOldFormula.y, 10);
-      expect(fromAdapter.z).toBeCloseTo(fromOldFormula.z, 10);
     });
   });
 

--- a/test/shell/VRPointer.test.ts
+++ b/test/shell/VRPointer.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+import { VRPointer } from '@/shell/VRPointer';
+
+// Vitest coverage for the `VRPointer` adapter (#190). The interface
+// is exercised directly against synthetic `THREE.Group`s standing in
+// for `XRTargetRaySpace` (which is a `Group` at runtime, per
+// `node_modules/three/src/renderers/webxr/WebXRController.js:82`).
+
+describe('VRPointer', () => {
+  it('preserves the id from the constructor', () => {
+    const controller = new THREE.Group();
+    const pointer = new VRPointer(controller, 'vr-0');
+    expect(pointer.id).toBe('vr-0');
+  });
+
+  describe('getRayOrigin', () => {
+    it('returns the controller world position into the target', () => {
+      const controller = new THREE.Group();
+      controller.position.set(1, 2, 3);
+      const pointer = new VRPointer(controller, 'vr-0');
+      const target = new THREE.Vector3();
+      const result = pointer.getRayOrigin(target);
+      expect(result).toBe(target); // returns the same Vector3 instance
+      expect(target.x).toBeCloseTo(1);
+      expect(target.y).toBeCloseTo(2);
+      expect(target.z).toBeCloseTo(3);
+    });
+  });
+
+  describe('getRayDirection', () => {
+    it('returns world (0,0,-1) for an unrotated controller at the origin', () => {
+      // Controller at world origin, identity rotation — local -Z points
+      // along world -Z, matching the visible aim ray that shell.ts
+      // builds from (0,0,0) to (0,0,-1).
+      const controller = new THREE.Group();
+      const pointer = new VRPointer(controller, 'vr-0');
+      const target = new THREE.Vector3();
+      const result = pointer.getRayDirection(target);
+      expect(result).toBe(target);
+      expect(target.x).toBeCloseTo(0);
+      expect(target.y).toBeCloseTo(0);
+      expect(target.z).toBeCloseTo(-1);
+      expect(target.length()).toBeCloseTo(1);
+    });
+
+    it('rotates with the controller (yaw 180° → world +Z)', () => {
+      // Yaw 180° around world Y: local -Z → world +Z. This is the
+      // sign-flip case that catches a regression to
+      // `controller.getWorldDirection` (which would still return -Z
+      // here because it reads the +Z column).
+      const controller = new THREE.Group();
+      controller.rotation.y = Math.PI;
+      const pointer = new VRPointer(controller, 'vr-0');
+      const target = new THREE.Vector3();
+      pointer.getRayDirection(target);
+      expect(target.x).toBeCloseTo(0);
+      expect(target.y).toBeCloseTo(0);
+      expect(target.z).toBeCloseTo(1);
+    });
+
+    it('matches the pre-refactor (0,0,-1).applyQuaternion formula exactly', () => {
+      // Equivalence check against the formula at Slider.ts:299 /
+      // TapButton.ts:220 / AxisToggle.ts:161 — same one the
+      // shell.ts regression assertion guards every frame in #191's
+      // migration window. Any sign flip or axis swap in
+      // `VRPointer.getRayDirection` would fail this.
+      const controller = new THREE.Group();
+      controller.position.set(0.4, 1.7, -1.2);
+      controller.rotation.set(0.3, -0.7, 0.15);
+      controller.updateMatrixWorld();
+
+      const pointer = new VRPointer(controller, 'vr-0');
+      const fromAdapter = pointer.getRayDirection(new THREE.Vector3());
+
+      const fromOldFormula = new THREE.Vector3(0, 0, -1).applyQuaternion(
+        controller.getWorldQuaternion(new THREE.Quaternion()),
+      );
+
+      expect(fromAdapter.x).toBeCloseTo(fromOldFormula.x, 10);
+      expect(fromAdapter.y).toBeCloseTo(fromOldFormula.y, 10);
+      expect(fromAdapter.z).toBeCloseTo(fromOldFormula.z, 10);
+    });
+  });
+
+  describe('pulse', () => {
+    it('forwards intensity and duration to the first haptic actuator', () => {
+      const controller = new THREE.Group();
+      const actuatorPulse = vi.fn();
+      controller.userData.gamepad = {
+        hapticActuators: [{ pulse: actuatorPulse }],
+      };
+      const pointer = new VRPointer(controller, 'vr-0');
+      pointer.pulse(0.4, 25);
+      expect(actuatorPulse).toHaveBeenCalledWith(0.4, 25);
+    });
+
+    it('is a no-op when no gamepad is attached (pre-connected XR session)', () => {
+      const controller = new THREE.Group();
+      const pointer = new VRPointer(controller, 'vr-0');
+      expect(() => pointer.pulse(0.4, 25)).not.toThrow();
+    });
+
+    it('is a no-op when the gamepad has no haptic actuators', () => {
+      const controller = new THREE.Group();
+      controller.userData.gamepad = { hapticActuators: [] };
+      const pointer = new VRPointer(controller, 'vr-0');
+      expect(() => pointer.pulse(0.4, 25)).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Closes #190

## Summary

Pancake build step 2 (parent #105). Adds the abstract `Pointer`
interface and a `VRPointer` adapter wrapping `XRTargetRaySpace`,
forwarded to exhibits via a new `ExhibitContext.pointers` field
alongside the existing (`@deprecated`) `controllers`. UI primitives
still consume `THREE.Object3D` here — the bundled migration that
retires `controllers` is #191. Two `VRPointer` instances (`'vr-0'` /
`'vr-1'`) are constructed exactly once at boot and reused per frame
so the reference-equality grab/release contract on UI primitives
will hold once they migrate.

A migration-window regression assertion runs every frame inside an
XR session (`renderer.xr.isPresenting`-gated, `console.warn`-once
per controller per session) comparing the pre-refactor formula
against `VRPointer.getRayDirection`. Cheap insurance for #191's
bundled migration; retires alongside the deprecated `controllers`
field at that point.

### Deviation from issue text — flag for #191 planning

The issue body and pancake plan v3 (§2 / §3.1 / G2) both say
`VRPointer.getRayDirection` should "delegate directly to
`controller.getWorldDirection(target)`" and call it bit-identical
to pre-refactor code. It isn't:

- `Object3D.getWorldDirection` returns the **+Z** axis (column 2 of
  `matrixWorld`, three.js r184 `src/core/Object3D.js:424`). The
  `Camera` subclass overrides this to negate; `XRTargetRaySpace`
  (a plain `Group`) does not.
- The pre-refactor primitives (`Slider.ts:299`, `TapButton.ts:220`,
  `AxisToggle.ts:161`) use `(0,0,-1).applyQuaternion(controller.
  getWorldQuaternion(...))` — the **−Z** axis.

These are negations of each other. Delegating to `getWorldDirection`
would silently flip the ray and break hover / grab on every UI
primitive once #191 swaps the call-sites. This PR uses the matching
`(0,0,-1).applyQuaternion(...)` formula instead, and the regression
assertion compares against the same so it stays a meaningful
tripwire. Plan v3 wording could be amended in a follow-up edit
before #191 lands.

## Test plan

- [x] `npm run test` — 357 pass, includes new
      `test/shell/VRPointer.test.ts` covering `getRayOrigin`,
      `getRayDirection` for unrotated controller (yields world
      `(0,0,-1)`), yaw-180° controller (yields world `(0,0,+1)` —
      the sign-flip case that catches a regression to
      `getWorldDirection`), equivalence with the pre-refactor
      formula at random pose, and `pulse` haptic dispatch.
- [x] `npm run build` — clean (tsc + Vite).
- [x] `npm run lint` — clean.
- [x] **VR Cloudflare PR-preview smoke (Quest 3S, all four cluster
      scenes):** hover + grab + tap unchanged; the regression
      assertion logs no divergence in the headset console at any
      point during smoke.