### PR TITLE
feat(shell): cameraControls — OrbitControls wrapper for cluster envelope (#192)

### DIFF
--- a/src/shell/cameraControls.ts
+++ b/src/shell/cameraControls.ts
@@ -1,0 +1,79 @@
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+
+/**
+ * Cluster-anchor world-space point. Matches the per-exhibit
+ * `SURFACE_CENTER` value used across the cluster scenes
+ * (`exhibits/tangent-planes/index.ts:47`,
+ * `exhibits/gradient-levels/index.ts`,
+ * `exhibits/saddle-extrema/index.ts`,
+ * `exhibits/quadrics/index.ts`) — the visible volume the desktop
+ * orbit camera should rotate around.
+ *
+ * Kept module-local rather than imported from one exhibit: the shell
+ * stays free of cross-cluster scene imports, and the four scenes'
+ * `SURFACE_CENTER` constants are already independent declarations that
+ * happen to coincide.
+ */
+const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
+
+/**
+ * `OrbitControls` wrapper configured for the cluster's spatial
+ * envelope (pancake plan v3 §3.3, parent #105, this issue #192).
+ *
+ * Leaf module — not yet consumed. #193 wires this into `bootShell()`
+ * behind the desktop boot path. Until then, this module is
+ * purely additive.
+ *
+ * Mutations applied at construction time:
+ *
+ * 1. `controls.target` set to `SURFACE_CENTER` so user-driven orbit
+ *    rotates around the cluster anchor.
+ * 2. `camera.position` overrides the unused-in-XR pre-session
+ *    `(0, 1.6, 3)` set at `shell.ts:34`. Desktop mode is the first
+ *    time the `PerspectiveCamera`'s position matters at render time
+ *    — XR renders via an `ArrayCamera` driven by HMD pose, not this
+ *    `PerspectiveCamera` (pancake plan v3 §3.3, S5 / G10).
+ * 3. `camera.lookAt(SURFACE_CENTER)` runs **after** the OrbitControls
+ *    constructor (which itself calls `update()` against the default
+ *    `target = (0,0,0)` and would re-orient + reposition the camera).
+ *    Setting target + position + lookAt last makes the first-frame
+ *    state deterministic — the next render-loop `controls.update()`
+ *    re-derives spherical from the (camera, target) pair directly,
+ *    with negligible drift (pancake plan v3 §3.3, G10).
+ *
+ * Damping is enabled, so callers must invoke `controls.update()`
+ * once per frame (per the desktop per-frame order in plan v3 §3.6).
+ *
+ * `domElement` is optional. When non-null, OrbitControls attaches
+ * its pointer / wheel / touch listeners to the element immediately.
+ * When `null` / omitted (e.g., the standalone config-validation
+ * tests), the controls instance carries the full config but stays
+ * detached — `controls.connect(el)` would attach later if needed.
+ */
+export function createCameraControls(
+  camera: THREE.PerspectiveCamera,
+  domElement: HTMLElement | null = null,
+): OrbitControls {
+  const controls = new OrbitControls(camera, domElement);
+
+  controls.minDistance = 1.5;
+  controls.maxDistance = 12;
+  controls.minPolarAngle = 0.1 * Math.PI;
+  controls.maxPolarAngle = 0.85 * Math.PI;
+
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.05;
+
+  // Reset target + camera state AFTER the OrbitControls constructor's
+  // implicit `update()` so first-frame state is the cluster-anchor
+  // configuration, not whatever spherical the constructor derived
+  // against the default `target = (0, 0, 0)`.
+  controls.target.copy(SURFACE_CENTER);
+  camera.position.set(0, 1.6, 0);
+  camera.lookAt(SURFACE_CENTER);
+
+  return controls;
+}
+
+export { SURFACE_CENTER };

--- a/src/shell/cameraControls.ts
+++ b/src/shell/cameraControls.ts
@@ -73,6 +73,21 @@ export function createCameraControls(
   camera.position.set(0, 1.6, 0);
   camera.lookAt(SURFACE_CENTER);
 
+  // Re-seed OrbitControls' internal `_lastPosition` from the corrected
+  // post-init position. Without this, the first render-loop update()
+  // sees `_lastPosition ≠ currentPosition` and fires a spurious
+  // `change` event on frame 1 — harmless under the unconditional
+  // `setAnimationLoop` render today, but a latent oddity if #193 ever
+  // wires a change-event listener. Idempotent for position because
+  // sphericalDelta + panOffset + scale are all at identity here.
+  controls.update();
+
+  // Snapshot the configured pose as the `reset()` baseline. Without
+  // this, `position0` / `target0` carry the constructor-time pre-
+  // overwrite values (default target = origin, pre-init camera
+  // position) and `controls.reset()` would teleport to the wrong pose.
+  controls.saveState();
+
   return controls;
 }
 

--- a/test/shell/cameraControls.test.ts
+++ b/test/shell/cameraControls.test.ts
@@ -89,20 +89,20 @@ describe('first render-frame stability', () => {
     const positionBefore = camera.position.clone();
     const quaternionBefore = camera.quaternion.clone();
     controls.update();
-    expect(camera.position.distanceTo(positionBefore)).toBeLessThan(1e-3);
+    expect(camera.position.distanceTo(positionBefore)).toBeLessThan(1e-10);
     // Quaternion components compared individually — angleTo would
     // require both unit-length quaternions and we want a tight bound.
     expect(Math.abs(camera.quaternion.x - quaternionBefore.x)).toBeLessThan(
-      1e-3,
+      1e-10,
     );
     expect(Math.abs(camera.quaternion.y - quaternionBefore.y)).toBeLessThan(
-      1e-3,
+      1e-10,
     );
     expect(Math.abs(camera.quaternion.z - quaternionBefore.z)).toBeLessThan(
-      1e-3,
+      1e-10,
     );
     expect(Math.abs(camera.quaternion.w - quaternionBefore.w)).toBeLessThan(
-      1e-3,
+      1e-10,
     );
   });
 });

--- a/test/shell/cameraControls.test.ts
+++ b/test/shell/cameraControls.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import * as THREE from 'three';
+import {
+  createCameraControls,
+  SURFACE_CENTER,
+} from '@/shell/cameraControls';
+
+// Config-validation coverage for the cluster's desktop camera-controls
+// wrapper (#192, pancake plan v3 §3.3). The factory mutates the camera
+// in place and returns an OrbitControls instance carrying the cluster
+// envelope's bounds + damping. `domElement` is passed as null so the
+// test exercises the wrapper without a real DOM — sufficient for
+// config-validation, which is the issue's stated bar.
+
+const makeCamera = (): THREE.PerspectiveCamera =>
+  new THREE.PerspectiveCamera(75, 1, 0.1, 100);
+
+describe('createCameraControls', () => {
+  it('orients the camera at (0, 1.6, 0) before the controls take over', () => {
+    const camera = makeCamera();
+    camera.position.set(0, 1.6, 3); // simulate shell.ts:34's pre-XR default
+    createCameraControls(camera, null);
+    expect(camera.position.x).toBeCloseTo(0);
+    expect(camera.position.y).toBeCloseTo(1.6);
+    expect(camera.position.z).toBeCloseTo(0);
+  });
+
+  it('applies camera.lookAt(SURFACE_CENTER) before the first controls update', () => {
+    // The camera sits at (0, 1.6, 0) and SURFACE_CENTER is (0, 1.5, -4):
+    // forward unit vector is (0, -0.1/r, -4/r) for r = sqrt(0.01 + 16),
+    // i.e., direction ≈ (0, -0.025, -0.9997). The negative-z dominant
+    // component is what we care about — it confirms lookAt ran (without
+    // it, an unrotated camera looks toward +Z).
+    const camera = makeCamera();
+    createCameraControls(camera, null);
+    // Read the camera's forward via its quaternion rather than
+    // `getWorldDirection`, which depends on `matrixWorld` (only updated
+    // at render time). The quaternion is mutated synchronously by
+    // `lookAt` and is what render-time matrix construction would read
+    // anyway.
+    const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(
+      camera.quaternion,
+    );
+    expect(forward.z).toBeLessThan(-0.99);
+    expect(forward.y).toBeLessThan(0); // slight downward tilt
+    expect(Math.abs(forward.x)).toBeLessThan(1e-6);
+  });
+
+  it('sets controls.target to SURFACE_CENTER', () => {
+    const camera = makeCamera();
+    const controls = createCameraControls(camera, null);
+    expect(controls.target.x).toBeCloseTo(SURFACE_CENTER.x);
+    expect(controls.target.y).toBeCloseTo(SURFACE_CENTER.y);
+    expect(controls.target.z).toBeCloseTo(SURFACE_CENTER.z);
+  });
+
+  it('clamps distance to [1.5, 12] m around the cluster anchor', () => {
+    const camera = makeCamera();
+    const controls = createCameraControls(camera, null);
+    expect(controls.minDistance).toBe(1.5);
+    expect(controls.maxDistance).toBe(12);
+  });
+
+  it('clamps polar angle to [0.1π, 0.85π]', () => {
+    const camera = makeCamera();
+    const controls = createCameraControls(camera, null);
+    expect(controls.minPolarAngle).toBeCloseTo(0.1 * Math.PI);
+    expect(controls.maxPolarAngle).toBeCloseTo(0.85 * Math.PI);
+  });
+
+  it('enables damping with factor 0.05 (requires per-frame controls.update())', () => {
+    const camera = makeCamera();
+    const controls = createCameraControls(camera, null);
+    expect(controls.enableDamping).toBe(true);
+    expect(controls.dampingFactor).toBeCloseTo(0.05);
+  });
+});
+
+describe('first render-frame stability', () => {
+  // The next render-loop tick will call `controls.update()`. At that
+  // point the spherical is re-derived from the actual (camera, target)
+  // offset — so the orientation should be effectively unchanged from
+  // the post-construction state. Verifies the construction-time
+  // ordering closes the gap left by the OrbitControls constructor's
+  // implicit `update()` against the default `target=(0,0,0)`.
+  it('does not jump on the first controls.update() tick', () => {
+    const camera = makeCamera();
+    const controls = createCameraControls(camera, null);
+    const positionBefore = camera.position.clone();
+    const quaternionBefore = camera.quaternion.clone();
+    controls.update();
+    expect(camera.position.distanceTo(positionBefore)).toBeLessThan(1e-3);
+    // Quaternion components compared individually — angleTo would
+    // require both unit-length quaternions and we want a tight bound.
+    expect(Math.abs(camera.quaternion.x - quaternionBefore.x)).toBeLessThan(
+      1e-3,
+    );
+    expect(Math.abs(camera.quaternion.y - quaternionBefore.y)).toBeLessThan(
+      1e-3,
+    );
+    expect(Math.abs(camera.quaternion.z - quaternionBefore.z)).toBeLessThan(
+      1e-3,
+    );
+    expect(Math.abs(camera.quaternion.w - quaternionBefore.w)).toBeLessThan(
+      1e-3,
+    );
+  });
+});
+
+describe('SURFACE_CENTER export', () => {
+  it('matches the cluster anchor (0, 1.5, -4)', () => {
+    // Independent declaration, but must coincide with the per-exhibit
+    // SURFACE_CENTER constants the cluster scenes carry today
+    // (e.g., exhibits/tangent-planes/index.ts:47).
+    expect(SURFACE_CENTER.x).toBeCloseTo(0);
+    expect(SURFACE_CENTER.y).toBeCloseTo(1.5);
+    expect(SURFACE_CENTER.z).toBeCloseTo(-4);
+  });
+});


### PR DESCRIPTION
Closes #192. Step 5 in the pancake-build migration order
(`_private/plans/105-pancake-build.md` §5).

## Summary
- New `src/shell/cameraControls.ts` — `OrbitControls` wrapper configured
  for the cluster's spatial envelope (`SURFACE_CENTER = (0, 1.5, -4)`,
  distance bounds `[1.5, 12]`, polar bounds `[0.1π, 0.85π]`, damping
  `0.05`). Pancake plan v3 §3.3.
- Leaf module — not yet wired into `bootShell()`. #193 lands the
  desktop boot path that consumes it.
- Construction-time ordering: target + camera state set **after** the
  `OrbitControls` constructor's implicit `update()`, which would
  otherwise re-derive spherical against the default `target = (0,0,0)`
  and clamp `phi` away from straight-up, displacing the camera. The
  first render-loop `controls.update()` then re-derives spherical from
  the actual `(camera, target)` offset with negligible drift.
- 8 vitest cases cover the configuration values, the `lookAt`
  orientation, and a "does not jump on first `controls.update()` tick"
  stability check that pins the construction-time ordering.

## Test plan
- [x] `npx vitest run` — 378 passed (8 new in `test/shell/cameraControls.test.ts`).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run build` — clean (pre-existing chunk-size warning unchanged).
- [x] Headset / pancake smoke deferred — module is unconsumed until #193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)