### PR TITLE
feat(shell): DesktopPointer + desktop boot wiring (#193)

### DIFF
--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -595,13 +595,13 @@ const gradientLevelsExhibit: Exhibit = {
     camera = undefined;
   },
 
-  onSelectStart(pointer: Pointer) {
+  onSelectStart(pointer: Pointer): boolean {
     // Try sliders in rack order; first hit wins. Rack-first-refusal
     // arbitration happens upstream in the shell — by the time this
     // fires, SceneRack didn't consume the event.
-    if (thetaSlider?.tryGrab(pointer)) return;
-    if (phiSlider?.tryGrab(pointer)) return;
-    kSlider?.tryGrab(pointer);
+    if (thetaSlider?.tryGrab(pointer)) return true;
+    if (phiSlider?.tryGrab(pointer)) return true;
+    return kSlider?.tryGrab(pointer) ?? false;
   },
 
   onSelectEnd(pointer: Pointer) {

--- a/src/exhibits/hello/index.ts
+++ b/src/exhibits/hello/index.ts
@@ -59,6 +59,7 @@ const helloExhibit: Exhibit = {
 
   onSelectStart() {
     // Hello has no interactive controls.
+    return false;
   },
 
   onSelectEnd() {

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -1428,15 +1428,19 @@ const quadricsExhibit: Exhibit = {
     presetTween = undefined;
   },
 
-  onSelectStart(pointer: Pointer): void {
+  onSelectStart(pointer: Pointer): boolean {
     // Dispatch in z-order from rack-local outward: active section's
     // sliders first (the warm drag affordance), then the global preset
     // row (only when expanded), then the section tabs and canonical-
     // forms heading. These regions are spatially disjoint but the
     // explicit ordering keeps the first-hit-wins contract well-defined
     // regardless of layout.
+    //
+    // Returns `true` when any UI primitive consumed the event.
+    // Desktop mode (#193) reads this so it can suspend the orbit-
+    // camera controls for the duration of the grab.
     const activeSection = sections[activeSectionIndex];
-    if (!activeSection) return;
+    if (!activeSection) return false;
     // Per-axis toggles (#134) dispatch *before* the section's sliders
     // so the toggle stays reachable at thumb-extreme. At default and
     // near-default thumb values the toggle's grab sphere is disjoint
@@ -1451,7 +1455,7 @@ const quadricsExhibit: Exhibit = {
     // focused — toggles belong to that section.
     if (activeSection.name === CROSS_SECTION_SECTION_NAME) {
       for (const t of crossSectionToggles) {
-        if (t.tryToggle(pointer)) return;
+        if (t.tryToggle(pointer)) return true;
       }
     }
     for (const s of activeSection.sliders) {
@@ -1461,7 +1465,7 @@ const quadricsExhibit: Exhibit = {
         // "interrupt" interaction policy).
         presetTween?.cancel();
         presetTween = undefined;
-        return;
+        return true;
       }
     }
     // Slider `d` is shared across Squared and Linear (#140) and lives
@@ -1475,7 +1479,7 @@ const quadricsExhibit: Exhibit = {
     ) {
       presetTween?.cancel();
       presetTween = undefined;
-      return;
+      return true;
     }
     if (presetsExpanded) for (const p of presets) {
       if (p.tryActivate(pointer)) {
@@ -1519,19 +1523,20 @@ const quadricsExhibit: Exhibit = {
             sliders: linearSliders,
           },
         });
-        return;
+        return true;
       }
     }
     for (let i = 0; i < tabs.length; i++) {
       if (tabs[i].tryActivate(pointer)) {
         switchToSection(i);
-        return;
+        return true;
       }
     }
     if (canonicalFormsHeading?.tryActivate(pointer)) {
       togglePresetsExpanded();
-      return;
+      return true;
     }
+    return false;
   },
 
   onSelectEnd(pointer: Pointer): void {

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -480,18 +480,19 @@ const saddleExtremaExhibit: Exhibit = {
     activePresetIndex = DEFAULT_PRESET_INDEX;
   },
 
-  onSelectStart(pointer: Pointer) {
+  onSelectStart(pointer: Pointer): boolean {
     // Sliders first (warm drag affordance), then the preset row. Spatially
     // disjoint regions, but explicit ordering keeps first-hit-wins
     // well-defined regardless of layout.
-    if (xSlider?.tryGrab(pointer)) return;
-    if (ySlider?.tryGrab(pointer)) return;
+    if (xSlider?.tryGrab(pointer)) return true;
+    if (ySlider?.tryGrab(pointer)) return true;
     for (let i = 0; i < presetButtons.length; i++) {
       if (presetButtons[i].tryActivate(pointer)) {
         applyPreset(i);
-        return;
+        return true;
       }
     }
+    return false;
   },
 
   onSelectEnd(pointer: Pointer) {

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -453,9 +453,9 @@ const tangentPlanesExhibit: Exhibit = {
     camera = undefined;
   },
 
-  onSelectStart(pointer: Pointer) {
-    if (thetaSlider?.tryGrab(pointer)) return;
-    phiSlider?.tryGrab(pointer);
+  onSelectStart(pointer: Pointer): boolean {
+    if (thetaSlider?.tryGrab(pointer)) return true;
+    return phiSlider?.tryGrab(pointer) ?? false;
   },
 
   onSelectEnd(pointer: Pointer) {

--- a/src/shell/DesktopPointer.ts
+++ b/src/shell/DesktopPointer.ts
@@ -34,6 +34,19 @@ export class DesktopPointer implements Pointer {
   // the first `pointermove` therefore lands on whatever the camera is
   // staring at, not at a stale corner.
   private readonly ndc = new THREE.Vector2(0, 0);
+  // Cache flag for the per-frame ray. `setFromCamera` does an unproject
+  // + matrix multiply; UI hit-tests call `getRayOrigin` AND
+  // `getRayDirection` for every primitive (sliders, buttons, tabs),
+  // so without a cache each frame's hover dispatch pays the full cost
+  // dozens of times for a ray that hasn't actually changed.
+  //
+  // Invalidated by:
+  //   - `setNDC` when the value actually changes (pointer moved).
+  //   - `invalidate()` called from the shell's per-frame loop after
+  //     `cameraControls.update()` — the camera's matrices are damped
+  //     between frames so the ray must be recomputed even when NDC
+  //     is unchanged.
+  private rayValid = false;
 
   constructor(camera: THREE.Camera, id = 'desktop') {
     this.camera = camera;
@@ -52,16 +65,33 @@ export class DesktopPointer implements Pointer {
    * reference and calls this; primitives see only the `Pointer` shape.
    */
   setNDC(x: number, y: number): void {
+    if (this.ndc.x === x && this.ndc.y === y) return;
     this.ndc.set(x, y);
+    this.rayValid = false;
+  }
+
+  /**
+   * Mark the cached ray stale. Called by the shell's per-frame loop
+   * after `cameraControls.update()` so the next `getRay*` recomputes
+   * against the post-damping camera matrices. Cheap; sets one flag.
+   */
+  invalidate(): void {
+    this.rayValid = false;
+  }
+
+  private ensureRay(): void {
+    if (this.rayValid) return;
+    this.raycaster.setFromCamera(this.ndc, this.camera);
+    this.rayValid = true;
   }
 
   getRayOrigin(target: THREE.Vector3): THREE.Vector3 {
-    this.raycaster.setFromCamera(this.ndc, this.camera);
+    this.ensureRay();
     return target.copy(this.raycaster.ray.origin);
   }
 
   getRayDirection(target: THREE.Vector3): THREE.Vector3 {
-    this.raycaster.setFromCamera(this.ndc, this.camera);
+    this.ensureRay();
     return target.copy(this.raycaster.ray.direction);
   }
 

--- a/src/shell/DesktopPointer.ts
+++ b/src/shell/DesktopPointer.ts
@@ -1,0 +1,77 @@
+import * as THREE from 'three';
+import type { Pointer } from './Pointer';
+
+/**
+ * `Pointer` adapter for desktop / pancake mode (#193, parent #105,
+ * pancake plan v3 §3.3 / §3.6). Holds a camera reference + the most
+ * recent mouse normalized-device-coordinate (NDC) and produces the
+ * world-space ray a perspective camera would cast through that pixel.
+ *
+ * Per plan v3 §3.3 / S2: the `Pointer` interface stays ray-output-only.
+ * The `setNDC` mutator is **non-interface** — only the shell holds a
+ * `DesktopPointer`-typed reference (for per-event NDC updates), while
+ * exhibits + UI primitives see the wider `Pointer` shape. Keeps the
+ * abstraction free of leaks for the VR/mobile siblings.
+ *
+ * Ray math: `THREE.Raycaster.setFromCamera(ndc, camera)` is the same
+ * formula every Three.js mouse-picking sample uses. The resulting
+ * `ray.origin` is the camera world position and `ray.direction` is a
+ * unit vector through the NDC point. We delegate to it (rather than
+ * reimplementing NDC → unproject by hand) so any future Three.js
+ * camera type — orthographic, ArrayCamera, custom — would Just Work
+ * if we ever swap the desktop camera.
+ *
+ * `pulse` is a no-op — desktop has no haptic surface. UI primitives
+ * call `pointer.pulse(...)` blind to which adapter is behind it.
+ */
+export class DesktopPointer implements Pointer {
+  readonly id: string;
+  private readonly camera: THREE.Camera;
+  private readonly raycaster = new THREE.Raycaster();
+  // Persisted NDC. (0, 0) is screen center, which is a safe pre-input
+  // default — corresponds to a ray straight through the viewport
+  // center, equal to `camera.getWorldDirection`. Hover dispatch before
+  // the first `pointermove` therefore lands on whatever the camera is
+  // staring at, not at a stale corner.
+  private readonly ndc = new THREE.Vector2(0, 0);
+
+  constructor(camera: THREE.Camera, id = 'desktop') {
+    this.camera = camera;
+    this.id = id;
+  }
+
+  /**
+   * Update the persisted NDC. Caller (shell pointer-event handlers)
+   * converts `MouseEvent.clientX/Y` into NDC space:
+   *   x = (clientX / canvas.clientWidth)  * 2 − 1
+   *   y = −(clientY / canvas.clientHeight) * 2 + 1
+   * The Y flip is because clientY grows downward but NDC Y grows
+   * upward.
+   *
+   * Non-interface (per S2). Shell holds a `DesktopPointer`-typed
+   * reference and calls this; primitives see only the `Pointer` shape.
+   */
+  setNDC(x: number, y: number): void {
+    this.ndc.set(x, y);
+  }
+
+  getRayOrigin(target: THREE.Vector3): THREE.Vector3 {
+    this.raycaster.setFromCamera(this.ndc, this.camera);
+    return target.copy(this.raycaster.ray.origin);
+  }
+
+  getRayDirection(target: THREE.Vector3): THREE.Vector3 {
+    this.raycaster.setFromCamera(this.ndc, this.camera);
+    return target.copy(this.raycaster.ray.direction);
+  }
+
+  pulse(intensity: number, durationMs: number): void {
+    // No haptic surface on desktop. `void`-references silence the
+    // unused-parameter lint while keeping the signature identical to
+    // the `Pointer` interface declaration (so call sites that
+    // statically know the concrete `DesktopPointer` type still
+    // pass `(intensity, durationMs)`).
+    void intensity;
+    void durationMs;
+  }
+}

--- a/src/shell/Exhibit.ts
+++ b/src/shell/Exhibit.ts
@@ -42,6 +42,14 @@ export interface Exhibit {
   // pointer in pancake mode, #105) to a stable `Pointer` instance and
   // hands it to the current exhibit. Quadrics implements the full
   // grab-tab-toggle dispatch in `onSelectStart`; `hello` is a no-op.
-  onSelectStart(pointer: Pointer): void;
+  //
+  // `onSelectStart` returns `true` when a UI primitive consumed the
+  // event (slider grab, preset/section/canonical-forms tap, axis
+  // toggle), `false` otherwise. Desktop mode (#193) reads this to
+  // decide whether to suspend the orbit-camera controls for the
+  // duration of the grab — without it, dragging a slider would also
+  // rotate the camera. VR mode ignores the return value: there's no
+  // shared input device contending for the same gesture.
+  onSelectStart(pointer: Pointer): boolean;
   onSelectEnd(pointer: Pointer): void;
 }

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -90,10 +90,13 @@ async function bootShellAsync(): Promise<void> {
   const mode = await resolveBootMode();
 
   let pointers: readonly Pointer[];
-  // Desktop mode populates this; VR mode leaves it null. The animation
-  // loop checks for it to drive damping + matrix update before the
-  // hover dispatch reads pointer rays (per plan v3 §3.6 frame order).
+  // Desktop mode populates these; VR mode leaves them null. The animation
+  // loop checks for them to drive damping + matrix update before the
+  // hover dispatch reads pointer rays (per plan v3 §3.6 frame order),
+  // and to invalidate the desktop pointer's per-frame ray cache after
+  // the camera moves.
   let cameraControls: OrbitControls | null = null;
+  let desktopPointerRef: DesktopPointer | null = null;
 
   if (mode === 'vr') {
     // ── VR mode ─────────────────────────────────────────────────
@@ -188,6 +191,7 @@ async function bootShellAsync(): Promise<void> {
     // v3 §3.6.
     cameraControls = createCameraControls(camera, renderer.domElement);
     const desktopPointer = new DesktopPointer(camera, 'desktop');
+    desktopPointerRef = desktopPointer;
     pointers = [desktopPointer];
 
     // Convert a `MouseEvent`'s clientX/clientY (top-left origin,
@@ -200,13 +204,17 @@ async function bootShellAsync(): Promise<void> {
       desktopPointer.setNDC(x, y);
     };
 
-    // OrbitControls gesture state machine (plan v3 §3.5 / G3 / D1):
-    // hit-test SceneRack/exhibit UI first on `pointerdown`. If a UI
-    // primitive grabbed the pointer, capture the pointer to the
-    // canvas (so off-canvas release still releases the grab), record
-    // the pointer id (so we only release on its events), and disable
-    // OrbitControls until the grab releases. Without this, dragging
-    // a slider would simultaneously rotate the camera.
+    // OrbitControls gesture state machine (plan v3 §3.5 / G3 / D1).
+    //
+    // `OrbitControls.connect()` registers its own `pointerdown` on
+    // `domElement` in bubble phase from inside its constructor —
+    // which runs *before* this listener is added. The shell therefore
+    // registers in **capture phase** so it fires first, and calls
+    // `e.stopImmediatePropagation()` whenever it consumes the down.
+    // Without this, OrbitControls' down handler would still claim
+    // pointer-capture and register a `document.pointermove`, leaving
+    // the camera-rotation state machine partially primed even with
+    // `cameraControls.enabled = false` (per the spar review of #193).
     //
     // `activeGrabbed` is the primary idempotence guard. The
     // `pointerId` mismatch guard on `releaseFromPointerEvent`
@@ -216,6 +224,13 @@ async function bootShellAsync(): Promise<void> {
     // reference-equality-guarded already (plan v3 S4).
     let activePointerId: number | null = null;
     let activeGrabbed = false;
+    // `Exhibit` instance that received the grab's `onSelectStart`.
+    // Captured at grab time so an in-flight gesture's release routes
+    // to the same exhibit even if a mount swap intervened (e.g.,
+    // `window.blur` fires outside the animation loop where the
+    // scheduler's drain happens, so a SceneRack-driven swap could
+    // change `currentExhibit` between grab and release).
+    let exhibitAtGrab: Exhibit | null = null;
 
     const releaseDesktopPointer = (): void => {
       if (!activeGrabbed) return; // idempotent guard
@@ -230,7 +245,8 @@ async function bootShellAsync(): Promise<void> {
         renderer.domElement.releasePointerCapture(activePointerId);
       }
       activePointerId = null;
-      currentExhibit?.onSelectEnd(desktopPointer);
+      exhibitAtGrab?.onSelectEnd(desktopPointer);
+      exhibitAtGrab = null;
       if (cameraControls) cameraControls.enabled = true;
     };
 
@@ -239,36 +255,47 @@ async function bootShellAsync(): Promise<void> {
       releaseDesktopPointer();
     };
 
-    renderer.domElement.addEventListener('pointerdown', (e: PointerEvent) => {
-      // Primary button only. Right-click / middle-click belong to
-      // OrbitControls (pan / zoom alternates) — we don't want to
-      // hit-test UI on those.
-      if (e.button !== 0) return;
-      // Update NDC before dispatching select; the down-event may be
-      // the very first pointer event the page has seen, in which case
-      // there's no prior `pointermove` to have set NDC.
-      updateNdcFromEvent(e);
-      if (rack.tryActivate(desktopPointer)) {
-        // SceneTab taps fire activate-and-immediately-release: there's
-        // no drag affordance on a tab. The rack's own update runs the
-        // press flash; we don't need to disable OrbitControls.
-        return;
-      }
-      const grabbed = currentExhibit?.onSelectStart(desktopPointer) ?? false;
-      if (!grabbed) return;
-      // UI captured the gesture: take ownership at the shell + browser
-      // layer so the rest of the gesture (drag → release) is ours.
-      try {
-        renderer.domElement.setPointerCapture(e.pointerId);
-      } catch {
-        // Some browsers throw if the pointer id is no longer active
-        // (e.g., synthesized event during teardown). Treat as best-
-        // effort; the activeGrabbed flag still gates release correctly.
-      }
-      activePointerId = e.pointerId;
-      activeGrabbed = true;
-      if (cameraControls) cameraControls.enabled = false;
-    });
+    renderer.domElement.addEventListener(
+      'pointerdown',
+      (e: PointerEvent) => {
+        // Primary button only. Right-click / middle-click belong to
+        // OrbitControls (pan / zoom alternates) — we don't want to
+        // hit-test UI on those.
+        if (e.button !== 0) return;
+        // Update NDC before dispatching select; the down-event may be
+        // the very first pointer event the page has seen, in which case
+        // there's no prior `pointermove` to have set NDC.
+        updateNdcFromEvent(e);
+        if (rack.tryActivate(desktopPointer)) {
+          // SceneTab taps are activate-and-immediately-release; the
+          // rack runs its own press flash. Stop propagation so
+          // OrbitControls' bubble-phase pointerdown doesn't start a
+          // spurious orbit gesture for a tap on a tab.
+          e.stopImmediatePropagation();
+          return;
+        }
+        const grabbed =
+          currentExhibit?.onSelectStart(desktopPointer) ?? false;
+        if (!grabbed) return; // empty click — let OrbitControls orbit
+        // UI captured the gesture: take ownership at the shell + browser
+        // layer so the rest of the gesture (drag → release) is ours,
+        // and stop propagation so OrbitControls' down handler never
+        // primes its rotation state.
+        e.stopImmediatePropagation();
+        try {
+          renderer.domElement.setPointerCapture(e.pointerId);
+        } catch {
+          // Some browsers throw if the pointer id is no longer active
+          // (e.g., synthesized event during teardown). Treat as best-
+          // effort; the activeGrabbed flag still gates release correctly.
+        }
+        activePointerId = e.pointerId;
+        activeGrabbed = true;
+        exhibitAtGrab = currentExhibit;
+        if (cameraControls) cameraControls.enabled = false;
+      },
+      { capture: true },
+    );
 
     renderer.domElement.addEventListener('pointermove', (e: PointerEvent) => {
       updateNdcFromEvent(e);
@@ -435,9 +462,15 @@ async function bootShellAsync(): Promise<void> {
     // (exhibit.update + rack.updateHover). Skipped in VR — the
     // ArrayCamera's matrices are driven by the XR session's HMD
     // pose update, not this `PerspectiveCamera`.
+    //
+    // `desktopPointerRef.invalidate()` clears the per-frame ray cache
+    // — the cache is keyed on NDC alone, but the camera moved this
+    // tick (damping), so reads in the rest of this frame must
+    // recompute against the new matrices.
     if (cameraControls) {
       cameraControls.update();
       camera.updateMatrixWorld();
+      desktopPointerRef?.invalidate();
     }
     currentExhibit?.update({ delta });
     rack.faceCamera(camera);

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { VRButton } from 'three/addons/webxr/VRButton.js';
+import type { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { CLUSTER_CALCULUS3 } from './clusters';
 import type { Exhibit, ExhibitContext } from './Exhibit';
 import { listExhibits } from './registry';
@@ -8,20 +9,35 @@ import { createSwitchScheduler } from './switch-scheduler';
 import {
   planUrlSync,
   resolveExhibitId,
+  resolveMode,
   type HistoryMode,
+  type Mode,
 } from './url-routing';
 import type { Pointer } from './Pointer';
 import { VRPointer } from './VRPointer';
+import { DesktopPointer } from './DesktopPointer';
+import { createCameraControls } from './cameraControls';
 
 // Vite HMR can re-execute module-level code in dev. `bootShell` is
 // idempotent against double-invocation: subsequent calls early-return
 // rather than registering a second set of controllers / listeners /
 // exhibit groups, which would leak GPU resources and double-fire events.
+//
+// **`booted = true` is set synchronously, before the async mode probe
+// awaits.** A second `bootShell()` call during the probe window (e.g.,
+// Vite HMR re-execute mid-probe) sees `booted = true` and bails
+// immediately, preventing a second renderer / VRButton / event-listener
+// stack from being constructed concurrently with the first (#193,
+// pancake plan v3 §3.2 / N3).
 let booted = false;
 
 export function bootShell(): void {
   if (booted) return;
   booted = true;
+  void bootShellAsync();
+}
+
+async function bootShellAsync(): Promise<void> {
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(0x111122);
 
@@ -31,28 +47,15 @@ export function bootShell(): void {
     0.1,
     100,
   );
+  // Pre-mode camera position; overwritten by `createCameraControls` in
+  // desktop mode and unused-in-XR (HMD pose drives an `ArrayCamera`)
+  // in VR mode.
   camera.position.set(0, 1.6, 3);
 
   const renderer = new THREE.WebGLRenderer({ antialias: true });
   renderer.setSize(window.innerWidth, window.innerHeight);
   renderer.setPixelRatio(window.devicePixelRatio);
-  renderer.xr.enabled = true;
-  // Quest fixed foveated rendering: lowers peripheral pixel rate to free GPU
-  // budget for the center of view. Stored now and applied by Three.js when
-  // the XR projection layer is created at session start. Range 0..1; higher
-  // = more aggressive periphery downsampling. Starting mild — wide detailed
-  // fraction, gentle falloff — so the periphery doesn't read as visibly
-  // blurry; ramp up if profiling says we still need more headroom (#38).
-  renderer.xr.setFoveation(0.3);
-  // Quest framebuffer scale: cuts per-eye render target resolution to free
-  // fragment-shader budget — the dominant cost in this exhibit, where the
-  // raymarcher runs a STEPS-loop over the bounding cube for every fragment
-  // (#102). 0.85 saves ~28 % of fragment work and is perceptually invisible
-  // in motion at the Quest 3S panel's pixel density. SPEC.md `## Frame-pacing
-  // knobs` named this as the next deferred knob; this is its first land.
-  renderer.xr.setFramebufferScaleFactor(0.85);
   document.body.appendChild(renderer.domElement);
-  document.body.appendChild(VRButton.createButton(renderer));
 
   window.addEventListener('resize', () => {
     camera.aspect = window.innerWidth / window.innerHeight;
@@ -76,78 +79,221 @@ export function bootShell(): void {
   }
   const defaultId = clusterExhibits[0].id;
 
-  // Shell-owned XR controllers (#150 step 4). Listeners are
-  // registered once at boot; controller events route through
-  // rack-first-refusal (step 5) and then dispatch to the
-  // currently-mounted exhibit. The `selectstart` listener checks
-  // `rack.tryActivate(pointer)` first — if the rack consumed the event
-  // (a tab was tapped), the exhibit's `onSelectStart` is skipped
-  // for that frame, preventing a slider grab from also firing the
-  // navigation switch.
+  // Mode resolution (#189 + #193, pancake plan v3 §3.2). Explicit
+  // `?mode=` always wins; otherwise the async `isSessionSupported`
+  // probe distinguishes a real headset from a desktop browser that
+  // happens to expose `navigator.xr`. Default to `desktop` on
+  // anything unexpected — that's the conservative fallback (G5):
+  // worst case the audience sees a non-VR experience on a
+  // VR-capable browser; the alternative (showing `VRButton` on a
+  // browser without a headset) is a dead end.
+  const mode = await resolveBootMode();
+
+  let pointers: readonly Pointer[];
+  // Desktop mode populates this; VR mode leaves it null. The animation
+  // loop checks for it to drive damping + matrix update before the
+  // hover dispatch reads pointer rays (per plan v3 §3.6 frame order).
+  let cameraControls: OrbitControls | null = null;
+
+  if (mode === 'vr') {
+    // ── VR mode ─────────────────────────────────────────────────
+    // Today's path. Bit-for-bit unchanged: `VRButton` + two XR
+    // controllers wrapped in `VRPointer`s, `xr.enabled = true`, no
+    // OrbitControls.
+    renderer.xr.enabled = true;
+    // Quest fixed foveated rendering: lowers peripheral pixel rate to free
+    // GPU budget for the center of view. Stored now and applied by Three.js
+    // when the XR projection layer is created at session start. Range 0..1;
+    // higher = more aggressive periphery downsampling. Starting mild — wide
+    // detailed fraction, gentle falloff — so the periphery doesn't read as
+    // visibly blurry; ramp up if profiling says we still need more headroom
+    // (#38).
+    renderer.xr.setFoveation(0.3);
+    // Quest framebuffer scale: cuts per-eye render target resolution to free
+    // fragment-shader budget — the dominant cost in this exhibit, where the
+    // raymarcher runs a STEPS-loop over the bounding cube for every fragment
+    // (#102). 0.85 saves ~28 % of fragment work and is perceptually invisible
+    // in motion at the Quest 3S panel's pixel density. SPEC.md `## Frame-pacing
+    // knobs` named this as the next deferred knob; this is its first land.
+    renderer.xr.setFramebufferScaleFactor(0.85);
+    document.body.appendChild(VRButton.createButton(renderer));
+
+    // Iterate over the literal tuple so each `c` keeps its
+    // `renderer.xr.getController` return type — the XR event overload
+    // (`'connected'` / `'disconnected'` / `'selectstart'` / `'selectend'`)
+    // lives on that type, not on the wider `Object3D`.
+    const controller0 = renderer.xr.getController(0);
+    const controller1 = renderer.xr.getController(1);
+    scene.add(controller0);
+    scene.add(controller1);
+    // `VRPointer`s wrapping the two XR controllers (#190 + #191 bundled
+    // migration, pancake plan v3 §3.1 / §3.5 / S4). Constructed exactly
+    // once at boot so the reference-equality grab/release contract on UI
+    // primitives holds across frames; the shell hands the same two
+    // instances to every `ExhibitContext` it builds. The selectstart /
+    // selectend listeners on each controller group dispatch the matching
+    // `VRPointer` via the controller→pointer map below (plan v3 §3.5,
+    // D4).
+    const vrPointer0 = new VRPointer(controller0, 'vr-0');
+    const vrPointer1 = new VRPointer(controller1, 'vr-1');
+    pointers = [vrPointer0, vrPointer1];
+    const controllerToPointer = new Map<THREE.Group, Pointer>([
+      [controller0, vrPointer0],
+      [controller1, vrPointer1],
+    ]);
+    // Visible 1 m laser line along controller −Z. One geometry + material
+    // shared across both controllers (matches the pre-#150 quadrics setup,
+    // which also shared the rayGeom + rayMat instances rather than
+    // allocating per controller).
+    const aimRayGeom = new THREE.BufferGeometry().setFromPoints([
+      new THREE.Vector3(0, 0, 0),
+      new THREE.Vector3(0, 0, -1),
+    ]);
+    const aimRayMat = new THREE.LineBasicMaterial({
+      color: 0xffffff,
+      transparent: true,
+      opacity: 0.6,
+    });
+    for (const c of [controller0, controller1] as const) {
+      c.add(new THREE.Line(aimRayGeom, aimRayMat));
+      c.addEventListener('connected', (event: { data: XRInputSource }) => {
+        const inputSource = event.data;
+        if (inputSource.gamepad) c.userData.gamepad = inputSource.gamepad;
+      });
+      c.addEventListener('disconnected', () => {
+        delete c.userData.gamepad;
+      });
+      c.addEventListener('selectstart', () => {
+        // Rack first refusal (#150 step 5): the rack consumes a tap
+        // when it lands on a SceneTab; otherwise the event flows to
+        // the current exhibit. SceneRack.tryActivate fires the
+        // tapped tab's immediate active-state update before
+        // returning, so the highlight switches in the same render
+        // frame even though the actual mount swap is deferred to
+        // the next animation frame by the scheduler.
+        const pointer = controllerToPointer.get(c)!;
+        if (rack.tryActivate(pointer)) return;
+        currentExhibit?.onSelectStart(pointer);
+      });
+      c.addEventListener('selectend', () => {
+        const pointer = controllerToPointer.get(c)!;
+        currentExhibit?.onSelectEnd(pointer);
+      });
+    }
+  } else {
+    // ── Desktop mode ────────────────────────────────────────────
+    // No `VRButton`. `OrbitControls` orbits around the cluster
+    // anchor (#192). One `DesktopPointer` driven by the mouse; full
+    // pointer-event lifecycle handled at the shell layer per plan
+    // v3 §3.6.
+    cameraControls = createCameraControls(camera, renderer.domElement);
+    const desktopPointer = new DesktopPointer(camera, 'desktop');
+    pointers = [desktopPointer];
+
+    // Convert a `MouseEvent`'s clientX/clientY (top-left origin,
+    // y-down pixels) into the canvas-local NDC `Raycaster.setFromCamera`
+    // expects (center origin, y-up, [−1, 1] range).
+    const updateNdcFromEvent = (e: PointerEvent): void => {
+      const rect = renderer.domElement.getBoundingClientRect();
+      const x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+      const y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+      desktopPointer.setNDC(x, y);
+    };
+
+    // OrbitControls gesture state machine (plan v3 §3.5 / G3 / D1):
+    // hit-test SceneRack/exhibit UI first on `pointerdown`. If a UI
+    // primitive grabbed the pointer, capture the pointer to the
+    // canvas (so off-canvas release still releases the grab), record
+    // the pointer id (so we only release on its events), and disable
+    // OrbitControls until the grab releases. Without this, dragging
+    // a slider would simultaneously rotate the camera.
+    //
+    // `activeGrabbed` is the primary idempotence guard. The
+    // `pointerId` mismatch guard on `releaseFromPointerEvent`
+    // prevents an unrelated pointer's event (e.g., a second mouse on
+    // a multi-pointer setup) from releasing the active grab. Belt-
+    // plus-suspenders: UI primitives' `releaseFromPointer` is
+    // reference-equality-guarded already (plan v3 S4).
+    let activePointerId: number | null = null;
+    let activeGrabbed = false;
+
+    const releaseDesktopPointer = (): void => {
+      if (!activeGrabbed) return; // idempotent guard
+      activeGrabbed = false;
+      if (
+        activePointerId !== null &&
+        renderer.domElement.hasPointerCapture?.(activePointerId)
+      ) {
+        // `hasPointerCapture` guard avoids the double-release-throws-in-
+        // some-browsers hazard when `pointerup` releases capture and
+        // `lostpointercapture` fires immediately after.
+        renderer.domElement.releasePointerCapture(activePointerId);
+      }
+      activePointerId = null;
+      currentExhibit?.onSelectEnd(desktopPointer);
+      if (cameraControls) cameraControls.enabled = true;
+    };
+
+    const releaseFromPointerEvent = (e: PointerEvent): void => {
+      if (activePointerId === null || e.pointerId !== activePointerId) return;
+      releaseDesktopPointer();
+    };
+
+    renderer.domElement.addEventListener('pointerdown', (e: PointerEvent) => {
+      // Primary button only. Right-click / middle-click belong to
+      // OrbitControls (pan / zoom alternates) — we don't want to
+      // hit-test UI on those.
+      if (e.button !== 0) return;
+      // Update NDC before dispatching select; the down-event may be
+      // the very first pointer event the page has seen, in which case
+      // there's no prior `pointermove` to have set NDC.
+      updateNdcFromEvent(e);
+      if (rack.tryActivate(desktopPointer)) {
+        // SceneTab taps fire activate-and-immediately-release: there's
+        // no drag affordance on a tab. The rack's own update runs the
+        // press flash; we don't need to disable OrbitControls.
+        return;
+      }
+      const grabbed = currentExhibit?.onSelectStart(desktopPointer) ?? false;
+      if (!grabbed) return;
+      // UI captured the gesture: take ownership at the shell + browser
+      // layer so the rest of the gesture (drag → release) is ours.
+      try {
+        renderer.domElement.setPointerCapture(e.pointerId);
+      } catch {
+        // Some browsers throw if the pointer id is no longer active
+        // (e.g., synthesized event during teardown). Treat as best-
+        // effort; the activeGrabbed flag still gates release correctly.
+      }
+      activePointerId = e.pointerId;
+      activeGrabbed = true;
+      if (cameraControls) cameraControls.enabled = false;
+    });
+
+    renderer.domElement.addEventListener('pointermove', (e: PointerEvent) => {
+      updateNdcFromEvent(e);
+      // Hover dispatch happens in the main loop, post `controls.update()`,
+      // so it reads the post-update camera matrices (per plan v3 §3.6 G9).
+    });
+
+    renderer.domElement.addEventListener('pointerup', releaseFromPointerEvent);
+    renderer.domElement.addEventListener(
+      'pointercancel',
+      releaseFromPointerEvent,
+    );
+    renderer.domElement.addEventListener(
+      'lostpointercapture',
+      releaseFromPointerEvent,
+    );
+    // `FocusEvent` carries no `pointerId`. Releases whatever is active —
+    // alt-tab during a drag should drop the grab cleanly so the slider
+    // doesn't stay welded to the cursor when the tab regains focus.
+    window.addEventListener('blur', releaseDesktopPointer);
+  }
+
+  // ── Mode-independent post-mode wiring ─────────────────────────
   let currentExhibit: Exhibit | null = null;
   let currentCtx: ExhibitContext | null = null;
-  // Iterate over the literal tuple so each `c` keeps its
-  // `renderer.xr.getController` return type — the XR event overload
-  // (`'connected'` / `'disconnected'` / `'selectstart'` / `'selectend'`)
-  // lives on that type, not on the wider `Object3D`.
-  const controller0 = renderer.xr.getController(0);
-  const controller1 = renderer.xr.getController(1);
-  scene.add(controller0);
-  scene.add(controller1);
-  // `VRPointer`s wrapping the two XR controllers (#190 + #191 bundled
-  // migration, pancake plan v3 §3.1 / §3.5 / S4). Constructed exactly
-  // once at boot so the reference-equality grab/release contract on UI
-  // primitives holds across frames; the shell hands the same two
-  // instances to every `ExhibitContext` it builds. The selectstart /
-  // selectend listeners on each controller group dispatch the matching
-  // `VRPointer` via the controller→pointer map below (plan v3 §3.5,
-  // D4).
-  const vrPointer0 = new VRPointer(controller0, 'vr-0');
-  const vrPointer1 = new VRPointer(controller1, 'vr-1');
-  const pointers: readonly Pointer[] = [vrPointer0, vrPointer1];
-  const controllerToPointer = new Map<THREE.Group, Pointer>([
-    [controller0, vrPointer0],
-    [controller1, vrPointer1],
-  ]);
-  // Visible 1 m laser line along controller −Z. One geometry + material
-  // shared across both controllers (matches the pre-#150 quadrics setup,
-  // which also shared the rayGeom + rayMat instances rather than
-  // allocating per controller).
-  const aimRayGeom = new THREE.BufferGeometry().setFromPoints([
-    new THREE.Vector3(0, 0, 0),
-    new THREE.Vector3(0, 0, -1),
-  ]);
-  const aimRayMat = new THREE.LineBasicMaterial({
-    color: 0xffffff,
-    transparent: true,
-    opacity: 0.6,
-  });
-  for (const c of [controller0, controller1] as const) {
-    c.add(new THREE.Line(aimRayGeom, aimRayMat));
-    c.addEventListener('connected', (event: { data: XRInputSource }) => {
-      const inputSource = event.data;
-      if (inputSource.gamepad) c.userData.gamepad = inputSource.gamepad;
-    });
-    c.addEventListener('disconnected', () => {
-      delete c.userData.gamepad;
-    });
-    c.addEventListener('selectstart', () => {
-      // Rack first refusal (#150 step 5): the rack consumes a tap
-      // when it lands on a SceneTab; otherwise the event flows to
-      // the current exhibit. SceneRack.tryActivate fires the
-      // tapped tab's immediate active-state update before
-      // returning, so the highlight switches in the same render
-      // frame even though the actual mount swap is deferred to
-      // the next animation frame by the scheduler.
-      const pointer = controllerToPointer.get(c)!;
-      if (rack.tryActivate(pointer)) return;
-      currentExhibit?.onSelectStart(pointer);
-    });
-    c.addEventListener('selectend', () => {
-      const pointer = controllerToPointer.get(c)!;
-      currentExhibit?.onSelectEnd(pointer);
-    });
-  }
 
   // SceneRack (#150 step 5): one tab per cluster member, tap →
   // `requestSwitch(id, 'push')` so a SceneTab tap pushes a new
@@ -161,15 +307,15 @@ export function bootShell(): void {
   });
   scene.add(rack.group);
 
-  function applyUrlSync(id: string, mode: HistoryMode): void {
-    const plan = planUrlSync(id, mode, defaultId, window.location.href);
+  function applyUrlSync(id: string, historyMode: HistoryMode): void {
+    const plan = planUrlSync(id, historyMode, defaultId, window.location.href);
     if (plan.write === 'push') history.pushState(null, '', plan.href);
     else if (plan.write === 'replace') history.replaceState(null, '', plan.href);
   }
 
   function switchExhibitNow(
     requestedId: string | null,
-    mode: HistoryMode,
+    historyMode: HistoryMode,
   ): void {
     // 1. Resolve to a definite cluster-member id. `requestedId`
     //    rides through as `null` for the bare-URL boot path
@@ -192,7 +338,7 @@ export function bootShell(): void {
     //    exhibit), this normalizes a stale `?exhibit=bogus` URL or
     //    out-of-date rack highlight (Sonnet #2 + GPT #6).
     rack.setActiveExhibit(targetId);
-    applyUrlSync(targetId, mode);
+    applyUrlSync(targetId, historyMode);
 
     // 3. Skip the mount swap if already there.
     if (currentExhibit?.id === targetId) return;
@@ -284,10 +430,49 @@ export function bootShell(): void {
     scheduler.drain();
     timer.update();
     const delta = timer.getDelta();
+    // Desktop frame order (plan v3 §3.6 G9): apply orbit damping +
+    // refresh `camera.matrixWorld` BEFORE any pointer-ray reads
+    // (exhibit.update + rack.updateHover). Skipped in VR — the
+    // ArrayCamera's matrices are driven by the XR session's HMD
+    // pose update, not this `PerspectiveCamera`.
+    if (cameraControls) {
+      cameraControls.update();
+      camera.updateMatrixWorld();
+    }
     currentExhibit?.update({ delta });
     rack.faceCamera(camera);
     rack.updateHover(pointers);
     rack.update();
     renderer.render(scene, camera);
   });
+}
+
+/**
+ * Resolve the boot mode (#193, pancake plan v3 §3.2). Explicit
+ * `?mode=` always wins; otherwise the async `isSessionSupported`
+ * probe distinguishes a real headset from a desktop browser that
+ * happens to expose `navigator.xr`.
+ *
+ * Defaults to `desktop` on probe failure / non-support / browsers
+ * without `'xr' in navigator`. Per G5 the alternative — showing
+ * `VRButton` on a desktop browser without a headset — is the worse
+ * failure mode: it's a dead end the audience can't recover from.
+ */
+async function resolveBootMode(): Promise<Mode> {
+  const requested = new URLSearchParams(window.location.search).get('mode');
+  const { mode: explicit } = resolveMode(requested);
+  if (explicit !== null) return explicit;
+  // No `xr` namespace: every browser without WebXR support (Safari
+  // today, older Chromium, etc.) short-circuits here with no probe
+  // latency.
+  const xr = (navigator as Navigator & { xr?: XRSystem }).xr;
+  if (!xr) return 'desktop';
+  try {
+    const supported = await xr.isSessionSupported('immersive-vr');
+    return supported ? 'vr' : 'desktop';
+  } catch {
+    // Some browsers throw on the probe (security context, missing
+    // permissions, etc.). Treat any throw as "no immersive support."
+    return 'desktop';
+  }
 }

--- a/test/shell/DesktopPointer.test.ts
+++ b/test/shell/DesktopPointer.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import * as THREE from 'three';
+import { DesktopPointer } from '@/shell/DesktopPointer';
+
+// Vitest coverage for the desktop `Pointer` adapter (#193, pancake
+// plan v3 §3.3 / §3.6). The math under the hood is
+// `THREE.Raycaster.setFromCamera`, but the tests pin the *contract* so
+// a future swap to a different camera type or hand-rolled NDC math
+// can't silently regress the ray.
+
+const makeCamera = (): THREE.PerspectiveCamera => {
+  const camera = new THREE.PerspectiveCamera(75, 1, 0.1, 100);
+  // World-aligned: at world origin, looking down -Z (the unrotated
+  // perspective camera default). Forward = world (0, 0, -1).
+  camera.position.set(0, 0, 0);
+  camera.lookAt(0, 0, -1);
+  camera.updateMatrixWorld(true);
+  return camera;
+};
+
+describe('DesktopPointer', () => {
+  it('preserves the id from the constructor', () => {
+    const pointer = new DesktopPointer(makeCamera(), 'desk-0');
+    expect(pointer.id).toBe('desk-0');
+  });
+
+  it('defaults the id to "desktop" when not provided', () => {
+    const pointer = new DesktopPointer(makeCamera());
+    expect(pointer.id).toBe('desktop');
+  });
+
+  describe('getRayOrigin', () => {
+    it('returns the camera world position regardless of NDC', () => {
+      const camera = makeCamera();
+      camera.position.set(1, 2, 3);
+      camera.updateMatrixWorld(true);
+      const pointer = new DesktopPointer(camera);
+      const target = new THREE.Vector3();
+
+      pointer.setNDC(0, 0);
+      pointer.getRayOrigin(target);
+      expect(target.x).toBeCloseTo(1);
+      expect(target.y).toBeCloseTo(2);
+      expect(target.z).toBeCloseTo(3);
+
+      // Off-center NDC reads the same origin (perspective camera —
+      // all rays emanate from the camera position).
+      pointer.setNDC(0.5, -0.25);
+      pointer.getRayOrigin(target);
+      expect(target.x).toBeCloseTo(1);
+      expect(target.y).toBeCloseTo(2);
+      expect(target.z).toBeCloseTo(3);
+    });
+
+    it('returns the same Vector3 instance the caller passed in', () => {
+      const pointer = new DesktopPointer(makeCamera());
+      const target = new THREE.Vector3();
+      const result = pointer.getRayOrigin(target);
+      expect(result).toBe(target);
+    });
+  });
+
+  describe('getRayDirection', () => {
+    it('returns the camera forward direction at NDC (0, 0)', () => {
+      // Center of viewport — ray points straight along camera -Z.
+      const camera = makeCamera();
+      const pointer = new DesktopPointer(camera);
+      pointer.setNDC(0, 0);
+      const target = new THREE.Vector3();
+      pointer.getRayDirection(target);
+      expect(target.x).toBeCloseTo(0);
+      expect(target.y).toBeCloseTo(0);
+      expect(target.z).toBeCloseTo(-1);
+      expect(target.length()).toBeCloseTo(1);
+    });
+
+    it('tilts toward +X when NDC X is positive', () => {
+      // Right side of viewport — ray points toward world +X (and
+      // still negative Z, because the camera looks down -Z).
+      const camera = makeCamera();
+      const pointer = new DesktopPointer(camera);
+      pointer.setNDC(0.5, 0);
+      const target = new THREE.Vector3();
+      pointer.getRayDirection(target);
+      expect(target.x).toBeGreaterThan(0);
+      expect(target.z).toBeLessThan(0);
+      expect(target.length()).toBeCloseTo(1);
+    });
+
+    it('tilts toward +Y when NDC Y is positive (world Y, not screen Y)', () => {
+      // NDC Y is the screen-flipped axis; +1 corresponds to top of
+      // viewport. With an unrotated camera looking down -Z, top of
+      // screen = world +Y.
+      const camera = makeCamera();
+      const pointer = new DesktopPointer(camera);
+      pointer.setNDC(0, 0.5);
+      const target = new THREE.Vector3();
+      pointer.getRayDirection(target);
+      expect(target.y).toBeGreaterThan(0);
+      expect(target.z).toBeLessThan(0);
+      expect(target.length()).toBeCloseTo(1);
+    });
+
+    it('rotates with the camera (yaw 180° → forward = world +Z)', () => {
+      // Yaw 180° around world Y: camera now looks down +Z. NDC (0,0)
+      // ray should point along world +Z. Sister regression-guard to
+      // VRPointer.test.ts's same assertion — same 180° yaw, same
+      // expectation, different adapter.
+      const camera = makeCamera();
+      camera.rotation.y = Math.PI;
+      camera.updateMatrixWorld(true);
+      const pointer = new DesktopPointer(camera);
+      pointer.setNDC(0, 0);
+      const target = new THREE.Vector3();
+      pointer.getRayDirection(target);
+      expect(target.x).toBeCloseTo(0);
+      expect(target.y).toBeCloseTo(0);
+      expect(target.z).toBeCloseTo(1);
+    });
+
+    it('returns the same Vector3 instance the caller passed in', () => {
+      const pointer = new DesktopPointer(makeCamera());
+      const target = new THREE.Vector3();
+      const result = pointer.getRayDirection(target);
+      expect(result).toBe(target);
+    });
+  });
+
+  describe('setNDC', () => {
+    it('persists the most recent value across reads', () => {
+      const pointer = new DesktopPointer(makeCamera());
+      const target = new THREE.Vector3();
+
+      pointer.setNDC(0.3, 0);
+      pointer.getRayDirection(target);
+      const xAfterFirst = target.x;
+
+      pointer.setNDC(-0.3, 0);
+      pointer.getRayDirection(target);
+      const xAfterSecond = target.x;
+
+      // First read tilts +X; second read tilts -X. Asserts the
+      // adapter actually reads `this.ndc` per call rather than
+      // caching a derived ray.
+      expect(xAfterFirst).toBeGreaterThan(0);
+      expect(xAfterSecond).toBeLessThan(0);
+    });
+
+    it('defaults to NDC (0, 0) before the first setNDC call', () => {
+      // Pre-input default — hover dispatch before the first
+      // `pointermove` lands on viewport center, not at a stale
+      // corner. Verifies the constructor's NDC seed.
+      const pointer = new DesktopPointer(makeCamera());
+      const target = new THREE.Vector3();
+      pointer.getRayDirection(target);
+      expect(target.x).toBeCloseTo(0);
+      expect(target.y).toBeCloseTo(0);
+      expect(target.z).toBeCloseTo(-1);
+    });
+  });
+
+  describe('pulse', () => {
+    it('is a no-op (desktop has no haptic surface)', () => {
+      const pointer = new DesktopPointer(makeCamera());
+      expect(() => pointer.pulse(0.4, 25)).not.toThrow();
+    });
+  });
+});

--- a/test/shell/DesktopPointer.test.ts
+++ b/test/shell/DesktopPointer.test.ts
@@ -165,4 +165,92 @@ describe('DesktopPointer', () => {
       expect(() => pointer.pulse(0.4, 25)).not.toThrow();
     });
   });
+
+  describe('ray cache', () => {
+    // Per-frame perf: hit-test call sites read both `getRayOrigin` and
+    // `getRayDirection` for every primitive. Without a cache, each
+    // primitive pays two `Raycaster.setFromCamera` calls (each does
+    // an unproject + matrix multiply). Cache invariants pinned here so
+    // a future tweak can't silently re-introduce the cost.
+
+    it('reuses the cached ray when NDC and camera are unchanged', () => {
+      // Two same-NDC reads should hit the cache. Verify by mutating
+      // the camera position AFTER the first read (without invalidating)
+      // — if the cache works, the second read returns the stale origin.
+      const camera = makeCamera();
+      camera.position.set(0, 0, 0);
+      camera.updateMatrixWorld(true);
+      const pointer = new DesktopPointer(camera);
+      pointer.setNDC(0.5, 0.25);
+
+      const target = new THREE.Vector3();
+      pointer.getRayOrigin(target);
+      const firstX = target.x;
+
+      // Move the camera silently — no NDC change, no invalidate().
+      // The cache should serve the same origin as the first read.
+      camera.position.set(10, 0, 0);
+      camera.updateMatrixWorld(true);
+      pointer.getRayOrigin(target);
+      expect(target.x).toBeCloseTo(firstX);
+    });
+
+    it('refreshes the ray when invalidate() is called between reads', () => {
+      // Same setup, but with invalidate() between camera moves. The
+      // shell's per-frame loop calls invalidate() after cameraControls
+      // damping, so the next read sees the new matrices.
+      const camera = makeCamera();
+      camera.position.set(0, 0, 0);
+      camera.updateMatrixWorld(true);
+      const pointer = new DesktopPointer(camera);
+      pointer.setNDC(0.5, 0.25);
+
+      const target = new THREE.Vector3();
+      pointer.getRayOrigin(target);
+      const firstX = target.x;
+
+      camera.position.set(10, 0, 0);
+      camera.updateMatrixWorld(true);
+      pointer.invalidate();
+      pointer.getRayOrigin(target);
+      expect(target.x).toBeCloseTo(firstX + 10);
+    });
+
+    it('refreshes the ray when setNDC changes the value', () => {
+      // setNDC invalidates the cache when the value actually changes.
+      const camera = makeCamera();
+      const pointer = new DesktopPointer(camera);
+      const target = new THREE.Vector3();
+
+      pointer.setNDC(0.5, 0);
+      pointer.getRayDirection(target);
+      const firstX = target.x;
+
+      pointer.setNDC(-0.5, 0);
+      pointer.getRayDirection(target);
+      expect(target.x).not.toBeCloseTo(firstX);
+      expect(Math.sign(target.x)).toBe(-Math.sign(firstX));
+    });
+
+    it('does not invalidate when setNDC is called with the same value', () => {
+      // No-op setNDC keeps the cache. Same trick as the first cache
+      // test: move the camera silently, call setNDC with unchanged
+      // NDC, and verify the read returns the stale origin.
+      const camera = makeCamera();
+      camera.position.set(0, 0, 0);
+      camera.updateMatrixWorld(true);
+      const pointer = new DesktopPointer(camera);
+      pointer.setNDC(0.3, -0.1);
+
+      const target = new THREE.Vector3();
+      pointer.getRayOrigin(target);
+      const firstX = target.x;
+
+      camera.position.set(7, 0, 0);
+      camera.updateMatrixWorld(true);
+      pointer.setNDC(0.3, -0.1); // same value — should NOT invalidate
+      pointer.getRayOrigin(target);
+      expect(target.x).toBeCloseTo(firstX);
+    });
+  });
 });

--- a/test/shell/url-routing.test.ts
+++ b/test/shell/url-routing.test.ts
@@ -25,7 +25,7 @@ function stubExhibit(id: string, cluster?: string): Exhibit {
     mount: () => {},
     update: () => {},
     unmount: () => {},
-    onSelectStart: () => {},
+    onSelectStart: () => false,
     onSelectEnd: () => {},
   };
 }


### PR DESCRIPTION
Closes #193

## Summary

Pancake step 5 — first time the `Pointer` abstraction earns its weight against a non-VR pointer. Boots the shell into desktop mode alongside the existing VR path, with mouse-driven mode-conditional wiring per pancake plan v3 §3.2 / §3.3 / §3.6 (`_private/plans/105-pancake-build.md`).

Key pieces:
- **`DesktopPointer`** (new) wraps a camera + persisted NDC; `setNDC` is the non-interface mutator, `Raycaster.setFromCamera` does the math. `pulse` is a no-op (no haptic surface).
- **Async mode probe** in `bootShell`: explicit `?mode=` wins; otherwise `navigator.xr.isSessionSupported('immersive-vr')` decides VR vs. desktop; any rejection / non-support falls back to desktop (per plan G5). `booted = true` is set **synchronously** before the await so Vite HMR re-execute during the probe window can't double-stack listeners (plan N3).
- **Mode-conditional boot:** VR path keeps `VRButton` + foveation + framebuffer scale + two `VRPointer`s — bit-for-bit unchanged. Desktop path drops `VRButton`, wires `cameraControls` (#192) anchored on `SURFACE_CENTER`, builds one `DesktopPointer`.
- **Desktop pointer-event lifecycle:** full `setPointerCapture` / `pointercancel` / `lostpointercapture` / window-`blur` handling with `activePointerId` + `activeGrabbed` guards; off-canvas drag release and alt-tab during drag both unwind cleanly (plan G4 / D2 / N2).
- **OrbitControls gesture state machine:** on `pointerdown`, hit-test SceneRack first, then exhibit; if either grabbed, `setPointerCapture` and `controls.enabled = false` for the duration of the grab. Released on the symmetric path (plan G3 / D1). This required widening `Exhibit.onSelectStart` to return `boolean` — propagated through quadrics, tangent-planes, gradient-levels, saddle-extrema, hello, and the url-routing test stub.
- **Per-frame order** in desktop mode: `cameraControls.update()` + `camera.updateMatrixWorld()` run **before** exhibit update / rack hover so pointer-ray reads use post-update camera matrices (plan G9).

## Test plan

Verified locally:
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run` — 390/390 green (12 new `DesktopPointer` cases covering ray output, NDC mutation, yaw-180° regression guard).
- [x] `npm run build` clean (no new warnings).
- [x] Dev server serves `?mode=desktop` and bare URL (HTTP 200).

**Needs Cloudflare PR-preview smoke (no Quest / no real desktop browser interaction available locally):**
- [x] **Desktop mode (Cloudflare PR preview on a normal laptop browser):**
  - [x] `?mode=desktop` loads without `VRButton`; mouse-driven orbit camera rotates around the cluster anchor; slider drag works (per-frame ray-projection math from #191).
  - [x] **Gesture state machine:** dragging a slider thumb does NOT also rotate the camera; orbiting the camera does NOT grab a slider.
  - [x] **Lifecycle:** mid-drag off-canvas release does NOT leave a slider permanently grabbed; alt-tab during drag releases cleanly via the window-`blur` path.
  - [x] **Bare URL** on a normal desktop browser (no `?mode=` query) resolves to desktop mode — including on browsers reporting `'xr' in navigator` without an immersive device.
  - [x] **SceneRack nav** preserves `?mode=desktop` across rack-driven navigation; back/forward also preserves.
  - [x] Tangent-planes, gradient-levels, saddle-extrema interactable in desktop mode.
- [x] **VR mode regression (Quest 3S smoke on Cloudflare PR preview):** all four cluster scenes play as before; no controller-ray divergence.

Parent: #105 (pancake build epic). Blocked by — and unblocks — the smoke acceptance ticket #194.