### PR TITLE
docs(readme): pancake "Without a headset" — shipped, not roadmapped (#194)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,18 @@ boundaries (Ellipsoid → Hyperboloid → Cone → ...).
 
 ## Try it
 
-Live at <https://skylinetrailcomputing.github.io/geometer/>. Click **Enter VR** once the page loads.
+Live at <https://skylinetrailcomputing.github.io/geometer/>. The bare URL auto-detects whether to boot in immersive (Quest headset) or desktop mode; visit it on any modern browser without setup. To force a mode explicitly, append `?mode=vr` or `?mode=desktop`.
 
-Headset paths that work today:
+Headset paths:
 
-- **Quest browser** (Quest 3, 3S, 2, Pro) — open the link directly on the headset. See [`DEV_QUEST_SETUP.md`](DEV_QUEST_SETUP.md) for first-run guidance.
+- **Quest browser** (Quest 3, 3S, 2, Pro) — open the link directly on the headset, then tap **Enter VR**. See [`DEV_QUEST_SETUP.md`](DEV_QUEST_SETUP.md) for first-run guidance.
 - **Desktop Chrome with a tethered headset** — useful for development and inspection.
 
 ### Without a headset
 
-A first-class **native pancake build** — desktop (mouse + keyboard, WASD or orbit) and mobile (touch), designed from the ground up for non-VR rather than emulating headset controllers — is on the roadmap. Tracked in [#105](https://github.com/skylinetrailcomputing/geometer/issues/105).
+A laptop or desktop browser with no immersive device gets the **native pancake build**: an orbit camera around the cluster envelope (drag empty space to rotate, scroll to zoom), and a mouse-driven pointer that drags sliders, taps presets, and switches section tabs through the same UI primitives the VR controllers drive. Designed from the ground up for non-VR; not a headset-emulator shim. Tracked in [#105](https://github.com/skylinetrailcomputing/geometer/issues/105).
 
-WebXR emulator extensions (Meta's Immersive Web Emulator, Mozilla's WebXR API Emulator) are **not a supported path**. As discussed in [#80](https://github.com/skylinetrailcomputing/geometer/issues/80), Meta's IWE structurally can't render Three.js content in current Chromium because it doesn't polyfill the WebXR Layers API — Chromium ≥147 forces Three.js down the `XRWebGLBinding` path regardless of the `'layers'` feature flag, and there's no three.js-side fix. Even when emulators do work mechanically, headset-controller emulation isn't an intuitive desktop UX. For now, a real Quest (3 / 3S / 2 / Pro) is the headset path.
+WebXR emulator extensions (Meta's Immersive Web Emulator, Mozilla's WebXR API Emulator) remain **unsupported** — see [#80](https://github.com/skylinetrailcomputing/geometer/issues/80) for the structural reason (Meta's IWE doesn't polyfill the WebXR Layers API, which Chromium ≥147 forces Three.js to use). Use pancake mode for non-headset access; use a real Quest (3 / 3S / 2 / Pro) for the headset experience. A touch-driven mobile build is a follow-up.
 
 ## Run locally
 


### PR DESCRIPTION
## Summary

- README's `## Try it` / `### Without a headset` sections updated to describe shipped behavior: bare URL auto-detects mode (immersive on a paired Quest, desktop everywhere else); `?mode=vr` / `?mode=desktop` force-override. Removes the "is on the roadmap" framing for the pancake build.
- Mobile is intentionally not advertised — `MobilePointer` is the v0.9 stretch / v1.x follow-up and not wired today.
- Plan v3 §5 step 8 of `_private/plans/105-pancake-build.md`. This is the small wiring landing-strip for #194; the smoke artifact (checklist results, screenshots) attaches to the issue close.

## Smoke gate (#194)

Local desktop walk on `localhost:5174/` is green: section tabs, every squared / linear / cross-section slider, every preset, axis toggles, classifier readout, gesture state machine (slider drag doesn't orbit, empty-space drag doesn't grab), off-canvas release, alt-tab mid-drag, SceneRack-nav preserves `?mode=desktop`, sibling scenes interactable.

`tsc --noEmit && vite build` clean; 394 vitest tests pass; `planUrlSync` mode-preservation tests (url-routing.test.ts:159–208) cover the SceneRack-nav-preserves-`?mode=` bullet by construction.

## Test plan

- [x] Cloudflare PR preview, desktop: re-walk the desktop smoke checklist from the preview URL (one re-run from an outside-contributor surface).
- [x] Cloudflare PR preview, Quest 3S: VR mode regression check across quadrics / tangent-planes / gradient-levels / saddle-extrema — all four scenes play as before (the #190 ray-direction regression assertion logged no divergence during v0.9 work, so this is confirmation, not exploration).
- [x] Bare PR-preview URL on a normal Chromium desktop browser (no headset, no `?mode=`) resolves to desktop mode.

Closes #194.