### PR TITLE
docs(readme): status + roadmap reflect shipped cluster + pancake (#195)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,11 @@
 
 A free, open-source WebXR sandbox of geometry exhibits aimed at undergraduate students of calculus, linear algebra, and differential equations. The thesis: VR earns its keep on math where the bottleneck for the learner is *3D spatial intuition* — quadric surfaces, vector fields, eigenvectors and eigenspaces, ODE phase portraits in 3D.
 
-**Status:** v0.4 — `quadrics` exhibit shipped. Slider-driven
-`ax² + by² + cz² = d` explorer with live family classification, a
-two-line equation readout, a canonical-pose preset grid with
-animated family-transition tweens, parametric / world-axis
-gridlines for depth cues, and a section rack covering cross-sections
-(a sliding intersection plane that traces a glowing curve through
-the surface) and linear terms (`u`, `v`, `w` sliders that translate
-the surface off-center).
+**Status:** v0.8 — the four scenes of the v1.0 quadrics cluster have
+shipped (quadrics manipulator, tangent planes, gradient + level
+surfaces, saddle / extrema). v0.9 is in progress: the native pancake
+build for desktop has shipped; cross-cluster polish is the remaining
+v0.9 work, and a touch-driven mobile build is a follow-up.
 
 ## Demo
 
@@ -66,10 +63,10 @@ The roadmap sequences exhibits around specific undergraduate courses where 3D sp
 v1.0 ships a cluster of programmatically separate scenes — each focused on a distinct early-course stuck-point — that share infrastructure (camera, design language, scene navigation):
 
 - **Quadrics manipulator** *(shipped through v0.5)* — slider-driven implicit-surface explorer with live family classification, cross-sections, and linear-term translation. §10.6.
-- **Tangent planes** *(v0.6)* — moving tangent plane attached to the surface, sliding the contact point continuously. §11.4.
-- **Gradient / level surfaces** *(v0.7)* — §11.6.
-- **Saddle / extrema** *(v0.8)* — §11.7–11.8.
-- **Basic pancake build** *(v0.9)* — desktop + mobile non-VR scaffolded alongside the Quest experience.
+- **Tangent planes** *(shipped, v0.6)* — moving tangent plane attached to the surface, sliding the contact point continuously. §11.4.
+- **Gradient / level surfaces** *(shipped, v0.7)* — §11.6.
+- **Saddle / extrema** *(shipped, v0.8)* — §11.7–11.8.
+- **Native pancake build** *(v0.9, desktop shipped)* — non-VR form factor scaffolded alongside the Quest experience; touch-driven mobile is a follow-up ([#196](https://github.com/skylinetrailcomputing/geometer/issues/196)).
 
 ### Beyond v1.0 (still APPM 2350)
 
@@ -85,7 +82,7 @@ Targeting spring or summer 2027. Eigenvectors visualized as the unit-sphere → 
 ### Reach (form factors)
 
 - **Headset** — Quest 3, 3S, 2, Pro. Current default.
-- **Native pancake build** ([#105](https://github.com/skylinetrailcomputing/geometer/issues/105)) — desktop + mobile, scaffolded in v0.9 for v1.0 and polished post-1.0.
+- **Native pancake build** ([#105](https://github.com/skylinetrailcomputing/geometer/issues/105)) — desktop shipped in v0.9; touch-driven mobile is a follow-up ([#196](https://github.com/skylinetrailcomputing/geometer/issues/196)).
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- **Status block:** bump the v0.4-era "`quadrics` exhibit shipped" framing to a v0.8 description of the full four-scene quadrics cluster, plus a v0.9-in-progress note covering the shipped desktop pancake and the cross-cluster polish that remains.
- **Roadmap:** mark tangent-planes / gradient-levels / saddle-extrema entries as `*(shipped, v0.X)*`; restate the pancake entry as v0.9-desktop-shipped with touch-driven mobile as a follow-up linking to #196.
- **Reach (form factors):** pancake build entry now distinguishes desktop-shipped from the mobile follow-up, mirroring the roadmap copy.

Picks up where #209 left off — that PR refreshed the "Try it" / "Without a headset" sections but left the Status header and Roadmap list still describing the cluster and pancake as roadmapped. This PR closes out #195's acceptance:

- [x] README "Without a headset" section rewritten to point at the bare URL + `?mode=desktop` — _already done by #209_.
- [x] Emulator caveat language pushed to a "for contributors"-style aside on #80's closure — _already done by #209_.
- [x] #196 (mobile) is punted, no `?mode=mobile` mention; v1.x follow-up captured by linking #196 from the roadmap + Reach entries.
- [x] Roadmap section updated to reflect #105's resolution.

## Test plan

- [x] `git diff` reviewed — three localized text-only changes, no link rot.
- [x] `pre-commit run --files README.md` clean.
- [x] Render check on the GitHub PR preview to confirm the bulleted markdown still reads cleanly after the edits.

Closes #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)