### PR TITLE
feat(pages): /release/ surface pinned to latest v*.*.* tag (#127)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,15 @@
 name: deploy-pages
 
+# Deploys two surfaces from a single Pages artifact:
+#   /geometer/         — rolling tip of main; redeploys on every main push
+#   /geometer/release/ — pinned at the latest v*.*.* tag; content only
+#                        moves when a new tag is pushed
+# See _private/plans/127-audience-facing-deploy.md for rationale.
+
 on:
   push:
     branches: [main]
+    tags: ['v*.*.*']
   workflow_dispatch:
 
 permissions:
@@ -19,14 +26,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: npm
       - run: npm ci
-      - run: npm run build
+      - name: Build main into dist/
+        run: npm run build
         env:
           BASE_PATH: /geometer/
+
+      - name: Resolve latest release tag
+        id: latest-tag
+        run: |
+          tag=$(git describe --tags --abbrev=0 --match 'v*.*.*')
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Latest release tag: $tag"
+
+      - name: Build release tag into dist/release/
+        run: |
+          set -euo pipefail
+          tag='${{ steps.latest-tag.outputs.tag }}'
+          worktree="$RUNNER_TEMP/geometer-release-src"
+          git worktree add "$worktree" "$tag"
+          (
+            cd "$worktree"
+            npm ci
+            BASE_PATH=/geometer/release/ npm run build
+          )
+          mv "$worktree/dist" "$GITHUB_WORKSPACE/dist/release"
+          git worktree remove --force "$worktree"
+
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Closes #127

## Summary

Adds an audience-facing deploy URL at `…/geometer/release/` that
only moves when a `v*.*.*` tag is pushed, while `…/geometer/` keeps
deploying the rolling tip of `main`. Single Pages site, single
workflow, single artifact — both surfaces composed at build time
(`dist/` from the checkout commit, `dist/release/` from the latest
`v*.*.*` tag built in a sibling worktree with
`BASE_PATH=/geometer/release/`).

This lands the audience-facing/rolling-tip split *before* the APPM
2350 fall-2026 cohort arrives at v1.0, instead of retrofitting it
once a half-merged refactor takes the canonical URL down mid-class.

## Pre-v1.0 behavior

`/release/` mirrors `v0.8.0` after this lands — useful as a real
shake-out surface for the mechanism before the audience arrives.
README "Live at" line stays pointing at root until v1.0 cuts;
swapping it to `/release/` is a separate one-line PR at v1.0 time
(deliberately out of scope here — pointing students at v0.8.0 would
misrepresent the release state).

## Choices not taken

- `gh-pages` branch with surgical subdir pushes — mechanically purer
  "deploy only on tag" but loses `deploy-pages@v4` for `peaceiris/`
  or hand-rolled `git push`. Not worth it.
- Two separate Pages sites (issue's shape 2) — more moving parts.
- Long-lived `release/*` branch merged forward — already rejected
  in the issue body (sparring 2026-05-07).
- Gating `/release/` on `v1*` — removes the pre-v1.0 validation
  window for the mechanism itself.

## Acceptance crosswalk (from #127)

- [x] Audience-facing release URL exists, distinct from dev-tip URL
- [x] Release URL only updates on a git tag (content sourced from
      `git describe --tags --abbrev=0 --match 'v*.*.*'`;
      bit-identical between tag bumps)
- [x] Dev-tip URL behavior unchanged
- [x] PR previews via Cloudflare still work; XR-headset debug flow
      unchanged (`pr-preview.yml` untouched)
- [ ] README links updated to point at release URL — deferred to
      v1.0 cut as a one-line follow-up
- [x] Decision recorded in `_private/` decisions log

## Test plan

This is a CI workflow change; the Cloudflare PR preview verifies
nothing here. Verification surfaces:

- [x] Local dry-run completed: `git worktree add /tmp/dryrun v0.8.0
      && cd /tmp/dryrun && npm ci && BASE_PATH=/geometer/release/
      npm run build` produced `dist/index.html` with asset URLs
      correctly prefixed `/geometer/release/`. Verified pre-push.
- [x] After merge: the `deploy-pages` Action run on the merge commit
      shows the "Resolve latest release tag" step printing `v0.8.0`
      and the "Build release tag into dist/release/" step succeeding.
- [x] After merge: `https://skylinetrailcomputing.github.io/geometer/release/`
      loads the v0.8.0 build (no saddle-extrema CP-snap from #200;
      no MobilePointer from #196).
- [x] After merge: `https://skylinetrailcomputing.github.io/geometer/`
      continues to load the rolling tip from `main` — i.e., includes
      #200's CP-snap and #196's MobilePointer.