### PR TITLE
feat(scene): tangent-planes — VR controller-aim picking (#197)

### DIFF
--- a/src/exhibits/tangent-planes/SPEC.md
+++ b/src/exhibits/tangent-planes/SPEC.md
@@ -161,6 +161,59 @@ nine numeric strings and is unit-tested under
 sibling vs. extending-`EquationReadout` decision is recorded in the
 class header — different slot model, no hide-on-zero, simpler.
 
+## Controller-aim picking (#197, v0.9)
+
+VR-only direct-manipulation affordance alongside the angular sliders.
+Aim a controller at the unit sphere and pull the trigger to land the
+contact point at the ray–surface intersection; hold the trigger to drag
+the contact point across the surface. Releases on trigger-up.
+
+- **Coexists with the sliders** — does not replace them. Sliders remain
+  the universal affordance (pancake mode and VR alike); picking is an
+  additional VR-mode input that the user can prefer for coarse
+  positioning. Mode gate: `pointer.id.startsWith('vr-')`, set by the
+  shell when constructing `VRPointer`s — pancake's `DesktopPointer`s
+  use `'desktop'` / `'mobile'` so the gate short-circuits without a
+  separate mode read.
+- **Pancake unaffected.** The mouse cursor is a sufficiently-direct
+  affordance on desktop; per-mouse raycast picking is deferred (no
+  acceptance loss for v0.9).
+- **Snap policy** — `Slider.setValue` (not `setValueRaw`) is used to
+  apply the picked angles, so each frame's pick re-applies the same
+  θ / φ snap detents the sliders use under direct drag. Picking near a
+  detent (e.g., a controller aiming approximately at the equator)
+  lands on the detent; off-snap aim lands freely. Consistent with the
+  drag-tick snap contract.
+- **Slider-grab precedence.** `onSelectStart` tries `Slider.tryGrab`
+  first; only an empty trigger pull (not on a thumb) escalates to
+  sphere-aim picking.
+- **Two-controller interaction.** Picking is a single slot —
+  first-trigger-wins, mirroring `Slider.tryGrab`'s
+  `if (grabbedBy) return false`. A second controller's trigger pull
+  while pick is active does not steal the slot; it falls through to
+  the rack / no-op. The slider-drag-while-picking case
+  (one hand holds the contact point, the other fine-tunes θ or φ)
+  works: each per-frame pick refresh skips the `Slider.setValue`
+  on any slider currently grabbed by the *other* controller, so the
+  drag tick's `rawValue` accumulator + `lastPointerAxisX` baseline
+  aren't overwritten by the pick's rebase. The skipped slider
+  resumes tracking the pick on the frame after the user releases it.
+- **Miss policy.** A controller drift mid-drag that loses the sphere
+  freezes the indicator at the last picked pose for that frame — the
+  sliders' values are simply not refreshed. Releasing the trigger
+  ends the picking gesture; the indicator path through the per-frame
+  slider-driven raycast continues unchanged.
+- **Pole degeneracy.** At a pole, `Math.atan2(0, 0) = 0` per IEEE 754,
+  so the φ slider snaps to 0 if the user aims exactly at the pole.
+  The indicator + tangent plane don't visibly move (φ is degenerate
+  there). Near-pole aim — the in-headset common case — reads
+  naturally.
+
+The math-frame inverse `anglesFromDirection` mirrors
+`directionFromAngles` and lives in `scaffold/math/`; both share the
+same parametrization tests so a θ/φ axis transposition fails at the
+unit-test level rather than slipping through to a headset smoke pass.
+
 ## Per-slider labels (#170)
 
 Each slider in the rack carries a two-line billboarded label
@@ -189,8 +242,8 @@ indicator.
 ## Out of scope (v0.6)
 
 - **Coefficient editing** — see "Equation form" above.
-- **Controller-aim point picking** — natural in headset, unusable on
-  the pancake build (#105) and Cloudflare PR previews. Deferred to v0.9.
+- **Controller-aim point picking** — landed in v0.9; see "Controller-aim
+  picking (#197, v0.9)" above.
 - **Floor** — quadrics needs a hole-punched floor for its 3.5 m
   bounding cube; tangent-planes' 1.5 m cube doesn't intersect a
   ground-level floor at the surface center, so a floor is unwarranted

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -15,6 +15,7 @@ import {
   SKY_BLUE,
   VERMILLION,
 } from '@/scaffold/design/tokens';
+import { anglesFromDirection } from '@/scaffold/math/anglesFromDirection';
 import { directionFromAngles } from '@/scaffold/math/directionFromAngles';
 import { raycastImplicit } from '@/scaffold/render/raycastImplicit';
 import { createTangentPlane, type TangentPlaneHandles } from './TangentPlane';
@@ -109,6 +110,19 @@ const SLIDER_LABEL_PRIMARY_FONT_SIZE = 0.05;
 const SLIDER_LABEL_SECONDARY_FONT_SIZE = 0.035;
 const SLIDER_LABEL_LINE_GAP = 0.008;
 
+// Controller-aim picking (#197). VR-only direct-manipulation affordance
+// alongside the angular sliders: aim a controller at the unit sphere and
+// pull the trigger to land the contact point at the ray–surface
+// intersection; hold to drag. The `vr-` prefix is set by the shell when
+// constructing `VRPointer`s (`shell.ts:'vr-0'/'vr-1'`); pancake mode's
+// `DesktopPointer`s use `'desktop'`/`'mobile'`, so this gate short-
+// circuits there and the mouse cursor remains the sole pancake affordance.
+const VR_POINTER_ID_PREFIX = 'vr-';
+// Haptic pulse on pick start + release — matches the Slider grab/release
+// pulse values so the picking gesture reads as kin to a slider grab.
+const PICK_HAPTIC_AMPLITUDE = 0.5;
+const PICK_HAPTIC_DURATION_MS = 10;
+
 // Tangent-plane size — 0.9 m × 0.9 m on the unit sphere. Reads as "a
 // flat patch tangent to the surface" rather than "a sheet that swallows
 // the surface." Tunable in headset; this is the v0.6 lock.
@@ -169,6 +183,15 @@ const SURFACE_SHADE = /* glsl */ `
 const indicatorWorld = new THREE.Vector3();
 const dirMath: [number, number, number] = [0, 0, 0];
 
+// Controller-aim pick scratch (#197). Reused per pick to keep the
+// per-frame drag path allocation-free. `pickRayOrigin` / `pickRayDirection`
+// hold the pointer's world ray; `pickOriginMath` / `pickDirMath` are the
+// surface-local math-frame versions fed to `raycastImplicit`.
+const pickRayOrigin = new THREE.Vector3();
+const pickRayDirection = new THREE.Vector3();
+const pickOriginMath: [number, number, number] = [0, 0, 0];
+const pickDirMath: [number, number, number] = [0, 0, 0];
+
 // Named handles — initialized in mount, disposed inline in unmount.
 let surfaceMesh: THREE.Mesh | undefined;
 let surfaceMaterial: THREE.ShaderMaterial | undefined;
@@ -184,6 +207,68 @@ let pointers: readonly Pointer[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
 // yaw-billboarding in update().
 let camera: THREE.Camera | undefined;
+// VR pointer currently aim-picking on the surface (#197). Set in
+// `onSelectStart` when sphere-aim lands, cleared in `onSelectEnd`. Used
+// in `update()` to refresh the picked (θ, φ) each frame while the
+// trigger is held — so picking reads as a continuous drag, not a tap.
+let pickingPointer: Pointer | null = null;
+
+// Controller-aim pick (#197). Read `pointer`'s world ray, transform to
+// surface-local math frame, raycast against the same implicit surface the
+// sliders drive (so picking + slider-driven paint stay rigorously in
+// sync), convert the hit direction to (θ, φ), and drive the sliders via
+// `setValue` — which applies the standard snap detents so picking near
+// θ = π/2 lands on the equator exactly the way a slider drag would.
+//
+// Returns whether a hit landed. The caller uses it as the "did picking
+// engage" signal: `onSelectStart` only sets `pickingPointer` on a hit;
+// `update()` ignores miss frames so a controller grazing off the sphere
+// mid-drag freezes the indicator at the last picked pose rather than
+// snapping back to slider defaults.
+function applyControllerAimPick(pointer: Pointer): boolean {
+  if (!thetaSlider || !phiSlider) return false;
+  pointer.getRayOrigin(pickRayOrigin);
+  pointer.getRayDirection(pickRayDirection);
+
+  // World → surface-local world: subtract surface center (points only;
+  // direction vectors are pure rotations, no offset). Then world → math
+  // frame: math (x, y, z) = world (x, −z, y) per `scaffold/math/frames.ts`.
+  const lx = pickRayOrigin.x - SURFACE_CENTER.x;
+  const ly = pickRayOrigin.y - SURFACE_CENTER.y;
+  const lz = pickRayOrigin.z - SURFACE_CENTER.z;
+  pickOriginMath[0] = lx;
+  pickOriginMath[1] = -lz;
+  pickOriginMath[2] = ly;
+  pickDirMath[0] = pickRayDirection.x;
+  pickDirMath[1] = -pickRayDirection.z;
+  pickDirMath[2] = pickRayDirection.y;
+
+  const result = raycastImplicit({
+    f: fJs,
+    gradF: gradJs,
+    origin: pickOriginMath,
+    dir: pickDirMath,
+    bound: BOUND,
+  });
+  if (!result.hit) return false;
+
+  // For the unit sphere `|p| = 1` so `result.point` is already the unit
+  // direction (modulo numerics — `anglesFromDirection` clamps `dir.z`
+  // before `acos`). v0.7+ surfaces would normalize here.
+  const { theta, phi } = anglesFromDirection(result.point);
+  // Yield to a concurrent slider drag by the *other* controller:
+  // `Slider.setValue` rebases `lastPointerAxisX` against the picking
+  // pointer's ray, which would compound the drag's delta from a point
+  // the user never set. Skipping the write on a grabbed slider lets a
+  // user hold the contact point with one hand and fine-tune θ or φ
+  // independently with the other — the pedagogical case the SPEC
+  // promises. The skipped slider's value is whatever the drag is
+  // producing this tick; picking resumes driving it the frame after
+  // the user releases.
+  if (!thetaSlider.isGrabbed) thetaSlider.setValue(theta);
+  if (!phiSlider.isGrabbed) phiSlider.setValue(phi);
+  return true;
+}
 
 // ────────────────────────────────────────────────────────────────────
 // Exhibit
@@ -343,6 +428,17 @@ const tangentPlanesExhibit: Exhibit = {
     thetaSlider.update();
     phiSlider.update();
 
+    // Controller-aim picking refresh (#197). Re-raycast each frame while
+    // the trigger is held so picking reads as a continuous drag rather
+    // than a single tap. Runs after the slider tick so a picked
+    // (θ, φ) overrides any slider-drag delta from a different pointer
+    // on the same frame — the user's most direct gesture wins.
+    // On miss (controller drifted off the sphere mid-drag) we keep the
+    // last picked pose rather than reverting to slider defaults; the
+    // SPEC.md "Indicator hidden on raymarch miss" path still applies to
+    // the rendered indicator if the slider-driven raymarch below misses.
+    if (pickingPointer) applyControllerAimPick(pickingPointer);
+
     // Per-slider value labels (#170). `formatAnglePiFraction` is
     // snap-aware: with PHI_INITIAL = π/4 and PHI_SNAP_POINTS not
     // including π/4, the boot pose renders as "0.25π" not the false-snap
@@ -448,19 +544,46 @@ const tangentPlanesExhibit: Exhibit = {
     worldAxes = undefined;
 
     // 3. Drop external references so a re-mount starts clean. The shell
-    //    removes ctx.group and its descendants automatically.
+    //    removes ctx.group and its descendants automatically. Clear the
+    //    aim-picking handle alongside — the released pointers in step 1
+    //    don't include it (picking doesn't go through Slider's grab table).
     pointers = [];
     camera = undefined;
+    pickingPointer = null;
   },
 
   onSelectStart(pointer: Pointer): boolean {
     if (thetaSlider?.tryGrab(pointer)) return true;
-    return phiSlider?.tryGrab(pointer) ?? false;
+    if (phiSlider?.tryGrab(pointer)) return true;
+
+    // Controller-aim picking (#197). VR-only — pancake mode keeps the
+    // mouse cursor as its sole affordance per SPEC.md, and the
+    // `DesktopPointer.id` ('desktop' / 'mobile') doesn't carry the
+    // `vr-` prefix the shell stamps on VR controllers. Picking is
+    // additive: only reached when neither slider thumb grabbed the
+    // trigger pull, so sliders remain the universal input.
+    if (!pointer.id.startsWith(VR_POINTER_ID_PREFIX)) return false;
+    // First-trigger-wins. `pickingPointer` is a single slot; a second
+    // controller's trigger pulled mid-pick would otherwise overwrite
+    // it, leaving the original controller's `onSelectEnd` unable to
+    // release picking (the identity check would fail). Same semantics
+    // as `Slider.tryGrab`'s `if (this.grabbedBy) return false` —
+    // returns `false` here so the rack / fallthrough sees the gesture
+    // as unclaimed for that controller.
+    if (pickingPointer !== null) return false;
+    if (!applyControllerAimPick(pointer)) return false;
+    pickingPointer = pointer;
+    pointer.pulse(PICK_HAPTIC_AMPLITUDE, PICK_HAPTIC_DURATION_MS);
+    return true;
   },
 
   onSelectEnd(pointer: Pointer) {
     thetaSlider?.releaseFromPointer(pointer);
     phiSlider?.releaseFromPointer(pointer);
+    if (pickingPointer === pointer) {
+      pickingPointer = null;
+      pointer.pulse(PICK_HAPTIC_AMPLITUDE, PICK_HAPTIC_DURATION_MS);
+    }
   },
 };
 

--- a/src/scaffold/math/anglesFromDirection.ts
+++ b/src/scaffold/math/anglesFromDirection.ts
@@ -1,0 +1,46 @@
+import type { MathVec3 } from '@/scaffold/math/frames';
+
+// Inverse of `directionFromAngles` (#197). Given a unit math-frame
+// direction, recover the spherical-coordinate (θ, φ) on the tangent-planes
+// SPEC.md parametrization. Used by the controller-aim picking path: a
+// ray-sphere hit yields a math-frame point on the unit sphere, which we
+// feed through this helper to drive the θ / φ sliders.
+//
+// Math frame (X right, Y forward, Z up; `scaffold/math/frames.ts`):
+//   θ = arccos(z)       ∈ [0, π]    polar angle from +math-Z
+//   φ = atan2(y, x)     ∈ [−π, π]   azimuth in math-XY from +math-X
+//
+// Pole behavior. At `dir = (0, 0, ±1)` (north / south pole), `x = y = 0`
+// and `φ` is mathematically undefined — every φ produces the same world
+// point. `Math.atan2(0, 0)` returns `0` by IEEE 754; we let that through
+// rather than carrying caller-supplied state. The visible consequence is
+// the φ slider snapping to 0 when the user aims exactly at a pole; the
+// indicator + tangent plane don't visibly move, since φ is degenerate
+// there. v0.9-acceptable (the in-headset pick-near-pole case lands close
+// to but not exactly on the pole and reads naturally).
+//
+// `dir.z` may sit a hair outside `[-1, 1]` due to ray-sphere intersection
+// numerics (component magnitudes can drift to ~1 + 1e-16). `Math.acos`
+// returns `NaN` outside that range, which would poison the θ slider; we
+// clamp to keep the contract clean.
+
+export interface SphericalAngles {
+  /** Polar angle from +math-Z, in `[0, π]`. */
+  theta: number;
+  /** Azimuth in math-XY from +math-X, in `[−π, π]`. */
+  phi: number;
+}
+
+/**
+ * Recover `(θ, φ)` from a unit math-frame direction. Pure; no allocations
+ * beyond the returned object literal. Inverse of {@link directionFromAngles}
+ * on the parametrization `(sin θ cos φ, sin θ sin φ, cos θ)`.
+ */
+export function anglesFromDirection(dir: MathVec3): SphericalAngles {
+  // Clamp the z component before `acos`. See header for numerics rationale.
+  const z = Math.min(1, Math.max(-1, dir[2]));
+  return {
+    theta: Math.acos(z),
+    phi: Math.atan2(dir[1], dir[0]),
+  };
+}

--- a/test/scaffold/math/anglesFromDirection.test.ts
+++ b/test/scaffold/math/anglesFromDirection.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { anglesFromDirection } from '../../../src/scaffold/math/anglesFromDirection.ts';
+import { directionFromAngles } from '../../../src/scaffold/math/directionFromAngles.ts';
+
+// Math-frame typo guard for the tangent-planes scene's controller-aim
+// inverse (#197). Pinned at the unit-test level so a transposition (e.g.
+// swapping `atan2(y, x)` for `atan2(x, y)`) fails CI rather than slipping
+// through to a manual headset smoke pass. Mirror of
+// `directionFromAngles.test.ts`'s coverage shape.
+
+describe('anglesFromDirection — math-frame cardinal directions', () => {
+  it('+math-Z (north pole) → θ=0, φ=0 (degenerate)', () => {
+    const { theta, phi } = anglesFromDirection([0, 0, 1]);
+    expect(theta).toBeCloseTo(0, 12);
+    expect(phi).toBeCloseTo(0, 12);
+  });
+
+  it('−math-Z (south pole) → θ=π, φ=0 (degenerate)', () => {
+    const { theta, phi } = anglesFromDirection([0, 0, -1]);
+    expect(theta).toBeCloseTo(Math.PI, 12);
+    expect(phi).toBeCloseTo(0, 12);
+  });
+
+  it('+math-X (right) → θ=π/2, φ=0', () => {
+    const { theta, phi } = anglesFromDirection([1, 0, 0]);
+    expect(theta).toBeCloseTo(Math.PI / 2, 12);
+    expect(phi).toBeCloseTo(0, 12);
+  });
+
+  it('+math-Y (forward) → θ=π/2, φ=π/2', () => {
+    const { theta, phi } = anglesFromDirection([0, 1, 0]);
+    expect(theta).toBeCloseTo(Math.PI / 2, 12);
+    expect(phi).toBeCloseTo(Math.PI / 2, 12);
+  });
+
+  it('−math-X (left) → θ=π/2, φ=π (positive branch of atan2)', () => {
+    const { theta, phi } = anglesFromDirection([-1, 0, 0]);
+    expect(theta).toBeCloseTo(Math.PI / 2, 12);
+    expect(phi).toBeCloseTo(Math.PI, 12);
+  });
+
+  it('−math-Y (back, toward user) → θ=π/2, φ=−π/2', () => {
+    const { theta, phi } = anglesFromDirection([0, -1, 0]);
+    expect(theta).toBeCloseTo(Math.PI / 2, 12);
+    expect(phi).toBeCloseTo(-Math.PI / 2, 12);
+  });
+});
+
+describe('anglesFromDirection — clamping + numerics', () => {
+  it('clamps z slightly above 1 (ray-sphere drift) to θ=0', () => {
+    // Mimics the dir.z = 1 + 1e-16 case that arises from ray-sphere
+    // intersection numerics on a near-pole pick. Without the clamp,
+    // acos(1 + eps) = NaN and the slider would receive NaN.
+    const { theta } = anglesFromDirection([0, 0, 1 + 1e-12]);
+    expect(theta).toBeCloseTo(0, 12);
+    expect(Number.isFinite(theta)).toBe(true);
+  });
+
+  it('clamps z slightly below −1 to θ=π', () => {
+    const { theta } = anglesFromDirection([0, 0, -1 - 1e-12]);
+    expect(theta).toBeCloseTo(Math.PI, 12);
+    expect(Number.isFinite(theta)).toBe(true);
+  });
+});
+
+describe('anglesFromDirection ∘ directionFromAngles round-trip', () => {
+  // Closes the contract: any (θ, φ) inside the open interior of the slider
+  // domain survives a forward-then-inverse trip with no sign / axis swap.
+  // Stays off the poles (where φ is degenerate) and off φ = ±π (where
+  // atan2 picks +π for both ±0 inputs to y).
+  const cases: Array<readonly [string, number, number]> = [
+    ['interior, off-snap', Math.PI / 3, Math.PI / 4],
+    ['equator +X', Math.PI / 2, 0],
+    ['equator +Y', Math.PI / 2, Math.PI / 2],
+    ['equator −Y', Math.PI / 2, -Math.PI / 2],
+    ['polar quadrant', Math.PI / 4, 3 * Math.PI / 4],
+    ['polar quadrant 2', 2 * Math.PI / 3, -3 * Math.PI / 4],
+  ];
+
+  for (const [name, theta0, phi0] of cases) {
+    it(`${name}: (θ=${theta0.toFixed(3)}, φ=${phi0.toFixed(3)}) round-trips`, () => {
+      const dir: [number, number, number] = [0, 0, 0];
+      directionFromAngles(theta0, phi0, dir);
+      const { theta, phi } = anglesFromDirection(dir);
+      expect(theta).toBeCloseTo(theta0, 12);
+      expect(phi).toBeCloseTo(phi0, 12);
+    });
+  }
+});


### PR DESCRIPTION
Closes #197

## Summary

Adds VR-only controller-aim point picking to the tangent-planes scene as
an additional affordance alongside the existing θ/φ sliders. Trigger-pull
on the unit sphere lands the contact point; hold to drag; release ends.
Sliders update via `Slider.setValue` so the standard snap detents apply
during picking, matching slider-drag feel. Pancake mode is unaffected —
the gate is `pointer.id.startsWith('vr-')`, which the shell stamps on
`VRPointer`s only.

Reuses `raycastImplicit` against the same `fJs`/`gradJs` the
slider-driven indicator uses, with a world→math frame transform on the
pointer ray. New `scaffold/math/anglesFromDirection.ts` is the inverse
of `directionFromAngles`; tests cover math-frame cardinals, ray-sphere
clamp numerics, and a round-trip.

Two-controller behavior: picking is a single slot (first-trigger-wins,
mirroring `Slider.tryGrab`), and the per-frame pick refresh skips
`Slider.setValue` on any slider currently grabbed by the *other*
controller — so dragging φ with one hand while aim-picking with the
other works without the pick rebasing the drag's `lastPointerAxisX`
baseline. `SPEC.md` documents the contract.

Pre-merge spar: HOLD on draft → HIGH (slider-fight) + MEDIUM (single-slot
overwrite) + LOW (forward-looking note) raised by the oppositional
reviewer. HIGH + MEDIUM addressed before this PR opened.

## Test plan

- [x] `npm run build` and `npm test` pass locally (428/428 tests green).
- [x] **Cloudflare PR preview, in-headset:** trigger-pull on a point on
      the unit sphere lands the indicator + tangent plane at the aim
      point; both θ and φ slider thumbs jump to match.
- [x] **Continuous drag:** hold the trigger and sweep across the
      surface; the contact point follows the controller; releasing
      ends the gesture.
- [x] **Slider precedence:** triggering on the θ or φ slider thumb
      still grabs the slider (picking does not steal slider grabs).
- [x] **Pancake build / mouse:** controller-aim path is inert; the
      mouse cursor + slider drag are the only affordances.
- [x] **Two-hand (HIGH-finding follow-up):** grab the φ slider with
      one controller, hold the picking trigger with the other; φ slider
      drag continues to work; θ tracks the pick.
- [x] **Two-hand single-slot (MEDIUM-finding follow-up):** pull both
      triggers in sequence — the second one falls through; the first
      controller's release ends picking cleanly.
- [ ] **Near-pole feel:** aim near the north / south pole; verify the
      φ slider's atan2(0,0)→0 behavior reads naturally (or flag if it
      doesn't — that's the open question per `SPEC.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)