### PR TITLE
feat(scaffold): translucentRectTokens — lift locked #113 visual recipe

### DIFF
--- a/src/exhibits/quadrics/SlicingPlane.ts
+++ b/src/exhibits/quadrics/SlicingPlane.ts
@@ -3,6 +3,13 @@ import {
   createTranslucentRect,
   type TranslucentRectHandles,
 } from '@/scaffold/render/TranslucentRect';
+import {
+  LOCKED_113_BODY_ALPHA,
+  LOCKED_113_RIM_ALPHA,
+  LOCKED_113_RIM_WIDTH_DEFAULT,
+  createLocked113BodyColor,
+  createLocked113RimColor,
+} from '@/scaffold/render/translucentRectTokens';
 
 // Translucent slicing-plane meshes for the Cross sections section
 // (#113). Layers above the on-surface intersection ring shipped in
@@ -24,19 +31,13 @@ import {
 // Per-axis rim color differentiation is explicitly out of scope per
 // #113 — the slider thumbs and per-axis on-surface ring colors already
 // carry the per-axis identity.
-
-// Locked #113 visual recipe — keep in sync with
-// src/exhibits/tangent-planes/TangentPlane.ts.
-const PLANE_BODY_COLOR = new THREE.Color(0.34, 0.71, 0.91);
-const PLANE_BODY_ALPHA = 0.10;
-// One step lighter than PLANE_BODY_COLOR / the on-surface ring color
-// so the two glow tiers stay visibly distinct when they overlap (the
-// ring marks the cut on the surface; the rim outlines the cut's own
-// boundary in free space).
-const PLANE_RIM_COLOR = new THREE.Color(0.70, 0.90, 0.99);
-const PLANE_RIM_ALPHA = 0.65;
-// Rim band width in plane-local meters (#113: "outer ~5 cm").
-const PLANE_RIM_WIDTH = 0.05;
+//
+// Visual constants (body color, body alpha, rim color, rim alpha, rim
+// width) come from `scaffold/render/translucentRectTokens.ts` (#201
+// PR 1) — the locked #113 recipe shared with TangentPlane and
+// TaylorOverlay. Factory calls construct a fresh THREE.Color per
+// build so no module-level Color singleton can leak mutation across
+// consumers.
 
 function buildPlaneHandle(
   halfExtent: number,
@@ -44,11 +45,11 @@ function buildPlaneHandle(
 ): TranslucentRectHandles {
   const handle = createTranslucentRect({
     halfExtent,
-    bodyColor: PLANE_BODY_COLOR,
-    bodyAlpha: PLANE_BODY_ALPHA,
-    rimColor: PLANE_RIM_COLOR,
-    rimAlpha: PLANE_RIM_ALPHA,
-    rimWidth: PLANE_RIM_WIDTH,
+    bodyColor: createLocked113BodyColor(),
+    bodyAlpha: LOCKED_113_BODY_ALPHA,
+    rimColor: createLocked113RimColor(),
+    rimAlpha: LOCKED_113_RIM_ALPHA,
+    rimWidth: LOCKED_113_RIM_WIDTH_DEFAULT,
   });
   orient(handle.mesh);
   return handle;

--- a/src/exhibits/saddle-extrema/TaylorOverlay.ts
+++ b/src/exhibits/saddle-extrema/TaylorOverlay.ts
@@ -1,4 +1,10 @@
 import * as THREE from 'three';
+import {
+  LOCKED_113_BODY_ALPHA,
+  LOCKED_113_RIM_ALPHA,
+  createLocked113BodyColor,
+  createLocked113RimColor,
+} from '@/scaffold/render/translucentRectTokens';
 import type { SaddleExtremaPreset } from './presets';
 
 // Local-quadratic-approximation overlay for the saddle / extrema scene
@@ -59,15 +65,15 @@ function computeHalfExtent(preset: SaddleExtremaPreset): number {
 const RES = 49;
 
 // Visual recipe — translucent body + brighter rim, sky-blue per the
-// #113 locked visual language. Same body / rim colors and alphas as
-// TangentPlane.ts and SlicingPlane.ts; rim width tighter (0.015 m on a
-// ~0.30 m half-extent gives 5% rim-to-half-extent ratio, somewhat
-// heavier than the slicing-plane's 1.7% but less heavy than the v1
-// plan's 7%).
-const OVERLAY_BODY_COLOR = new THREE.Color(0.34, 0.71, 0.91);
-const OVERLAY_BODY_ALPHA = 0.10;
-const OVERLAY_RIM_COLOR = new THREE.Color(0.70, 0.90, 0.99);
-const OVERLAY_RIM_ALPHA = 0.65;
+// #113 locked visual language. Body / rim colors and alphas imported
+// from scaffold/render/translucentRectTokens.ts (#201 PR 1); same
+// values as TangentPlane.ts and SlicingPlane.ts. Rim width tighter
+// (0.015 m on a ~0.30 m half-extent gives 5% rim-to-half-extent
+// ratio, somewhat heavier than the slicing-plane's 1.7% but less
+// heavy than the v1 plan's 7%) — pedagogy-driven scene-local
+// override of LOCKED_113_RIM_WIDTH_DEFAULT (0.05 m); the smaller
+// half-extent demands proportionally narrower rim so the patch
+// boundary doesn't dominate the curvature read this overlay teaches.
 const OVERLAY_RIM_WIDTH = 0.015;
 
 // Subtle lambert on the body — body color ranges [0.6, 1.0] × baseColor
@@ -232,10 +238,10 @@ export function createTaylorOverlay(
     uniforms: {
       uHalfExtent: { value: halfExtent },
       uRimWidth: { value: OVERLAY_RIM_WIDTH },
-      uBodyColor: { value: OVERLAY_BODY_COLOR.clone() },
-      uBodyAlpha: { value: OVERLAY_BODY_ALPHA },
-      uRimColor: { value: OVERLAY_RIM_COLOR.clone() },
-      uRimAlpha: { value: OVERLAY_RIM_ALPHA },
+      uBodyColor: { value: createLocked113BodyColor() },
+      uBodyAlpha: { value: LOCKED_113_BODY_ALPHA },
+      uRimColor: { value: createLocked113RimColor() },
+      uRimAlpha: { value: LOCKED_113_RIM_ALPHA },
       uLightDir: { value: opts.lightDir.clone() },
       uLambertAmbient: { value: LAMBERT_AMBIENT },
       uLambertDiffuse: { value: LAMBERT_DIFFUSE },

--- a/src/exhibits/tangent-planes/TangentPlane.ts
+++ b/src/exhibits/tangent-planes/TangentPlane.ts
@@ -1,12 +1,21 @@
 import * as THREE from 'three';
 import { createTranslucentRect } from '@/scaffold/render/TranslucentRect';
+import {
+  LOCKED_113_BODY_ALPHA,
+  LOCKED_113_RIM_ALPHA,
+  LOCKED_113_RIM_WIDTH_DEFAULT,
+  createLocked113BodyColor,
+  createLocked113RimColor,
+} from '@/scaffold/render/translucentRectTokens';
 import type { MathVec3 } from '@/scaffold/math/frames';
 import { poseTangentPlaneMesh } from './poseTangentPlaneMesh';
 
 // Tangent-plane mesh for the tangent-planes scene (#148). A single
 // translucent rectangle anchored at the user-selected surface point,
 // oriented so its normal matches ∇f at that point. Visual treatment
-// mirrors the cross-section slicing-plane recipe locked in #113.
+// mirrors the cross-section slicing-plane recipe locked in #113;
+// visual constants imported from `scaffold/render/translucentRectTokens.ts`
+// (#201 PR 1).
 //
 // Coordinate convention (locked): this wrapper's `group.position` stays
 // at (0, 0, 0). The full world-space transform —
@@ -20,14 +29,6 @@ import { poseTangentPlaneMesh } from './poseTangentPlaneMesh';
 // can't paint a stale construction-time pose between mount and the
 // first update tick. The consumer flips visibility on the first hit
 // frame after calling `setPose`.
-
-// Locked #113 visual recipe — keep in sync with
-// src/exhibits/quadrics/SlicingPlane.ts.
-const PLANE_BODY_COLOR = new THREE.Color(0.34, 0.71, 0.91);
-const PLANE_BODY_ALPHA = 0.10;
-const PLANE_RIM_COLOR = new THREE.Color(0.70, 0.90, 0.99);
-const PLANE_RIM_ALPHA = 0.65;
-const PLANE_RIM_WIDTH = 0.05;
 
 export interface TangentPlaneOptions {
   /**
@@ -77,11 +78,11 @@ export function createTangentPlane(
 ): TangentPlaneHandles {
   const rectHandle = createTranslucentRect({
     halfExtent: opts.halfExtent,
-    bodyColor: PLANE_BODY_COLOR,
-    bodyAlpha: PLANE_BODY_ALPHA,
-    rimColor: PLANE_RIM_COLOR,
-    rimAlpha: PLANE_RIM_ALPHA,
-    rimWidth: PLANE_RIM_WIDTH,
+    bodyColor: createLocked113BodyColor(),
+    bodyAlpha: LOCKED_113_BODY_ALPHA,
+    rimColor: createLocked113RimColor(),
+    rimAlpha: LOCKED_113_RIM_ALPHA,
+    rimWidth: LOCKED_113_RIM_WIDTH_DEFAULT,
   });
 
   const group = new THREE.Group();

--- a/src/scaffold/render/translucentRectTokens.ts
+++ b/src/scaffold/render/translucentRectTokens.ts
@@ -1,0 +1,35 @@
+import * as THREE from 'three';
+
+// Locked #113 translucent-overlay recipe (body at on-surface ring color,
+// rim one tone lighter). Bit-identical across SlicingPlane (quadrics),
+// TangentPlane (tangent-planes), and TaylorOverlay (saddle-extrema).
+// Lifted out of three duplicate const blocks per the extract-on-second-
+// consumer rule for load-bearing scaffold (#201 PR 1).
+//
+// Canonical surface is immutable: RGB tuples (`readonly` via `as const`)
+// plus factory functions. THREE.Color is mutable; exporting `new THREE
+// .Color(...)` as `const` would only freeze the binding, not the object,
+// and any consumer that called `.set()` on the shared instance would
+// silently corrupt every other consumer at runtime with no type error.
+// Factories construct a fresh THREE.Color per call.
+
+export const LOCKED_113_BODY_RGB = [0.34, 0.71, 0.91] as const;
+export const LOCKED_113_RIM_RGB = [0.7, 0.9, 0.99] as const;
+export const LOCKED_113_BODY_ALPHA = 0.1;
+export const LOCKED_113_RIM_ALPHA = 0.65;
+
+// Default rim width for cluster overlays, in plane-local meters. Flat
+// translucent planes (SlicingPlane, TangentPlane) use this verbatim.
+// Curved overlays (TaylorOverlay) override locally to 0.015 m where
+// the smaller half-extent demands proportionally narrower rim — the
+// override site at saddle-extrema/TaylorOverlay.ts carries the
+// curvature-pedagogy rationale.
+export const LOCKED_113_RIM_WIDTH_DEFAULT = 0.05;
+
+export function createLocked113BodyColor(): THREE.Color {
+  return new THREE.Color(...LOCKED_113_BODY_RGB);
+}
+
+export function createLocked113RimColor(): THREE.Color {
+  return new THREE.Color(...LOCKED_113_RIM_RGB);
+}


### PR DESCRIPTION
Refs #201, #188 (v0.9 cross-cluster polish epic).

## Summary

Lifts the body color, body alpha, rim color, rim alpha, and default rim width that were duplicated bit-identical across `SlicingPlane` (quadrics), `TangentPlane` (tangent-planes), and `TaylorOverlay` (saddle-extrema) into `src/scaffold/render/translucentRectTokens.ts`. Three consumers of the locked #113 recipe earn the extraction per the project's load-bearing-scaffold convention. **Visual diff: zero** — RGB/alpha values are bit-identical to the prior per-file locals.

Tokens are exported as immutable RGB tuples + factory functions rather than `new THREE.Color(...)` module-level constants. `THREE.Color` is mutable; exporting an instance as `const` only freezes the binding, not the object, and any future consumer that called `.set()` on the singleton would silently corrupt every other consumer with no type error. This anti-footgun pattern was a three-way convergent finding in the round-1 roundtable plan-review of #201.

`TaylorOverlay` keeps its scene-local `OVERLAY_RIM_WIDTH = 0.015` m, a pedagogy-driven override of the 0.05 m scaffold default — smaller half-extent demands proportionally narrower rim so the patch boundary doesn't dominate the curvature read. The comment at the override site now cross-references `LOCKED_113_RIM_WIDTH_DEFAULT`.

First of six PRs in the #201 consolidation pass (plan in `_private/plans/201-design-language-consolidation.md`, v3 after roundtable + second-Sonnet sanity check).

## Test plan

- [x] `npm run build` (tsc + Vite) — passes.
- [x] `npm test` — 428/428 passing.
- [x] `npm run lint` — clean.
- [x] Cloudflare PR preview: navigate to the quadrics scene, switch to the Cross sections section, and confirm the three slicing planes render with the same translucent-body + brighter-rim look as before. Same check on tangent-planes (the tangent plane mesh) and saddle-extrema (the Taylor overlay patch). No visual delta expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)