### PR TITLE
feat(scaffold): readoutTokens — lift cluster readout typography

### DIFF
--- a/src/exhibits/gradient-levels/GradientLevelsReadout.ts
+++ b/src/exhibits/gradient-levels/GradientLevelsReadout.ts
@@ -2,6 +2,13 @@ import * as THREE from 'three';
 import { Text } from 'troika-three-text';
 import type { MathVec3 } from '@/scaffold/math/frames';
 import {
+  READOUT_FONT_SIZE,
+  READOUT_LINE_PITCH,
+  READOUT_OUTLINE_COLOR,
+  READOUT_OUTLINE_WIDTH,
+  READOUT_SYNC_INTERVAL_MS,
+} from '@/scaffold/ui/readoutTokens';
+import {
   formatGradientLevelsReadout,
   type GradientLevelsReadoutStrings,
 } from './formatGradientLevelsReadout';
@@ -52,8 +59,6 @@ export interface GradientLevelsReadoutOptions {
   fontSize?: number;
 }
 
-const DEFAULT_FONT_SIZE = 0.028;
-
 // Slot widths in em (multiples of fontSize). NUMERIC_SIGNED fits
 // worst-case `−6.00`; NUMERIC_UNSIGNED fits worst-case `10.39`
 // (analytic ceiling — slider-reachable max is ~8.94, see plan §2.1).
@@ -67,18 +72,7 @@ const CLOSE_PAREN_EM = 1.0; // ` )`
 // signs roughly align between the two lines.
 const PREFIX_MAG_EM = 2.8;  // `|∇f| = `
 
-// Vertical gap between the two lines. Mirrors TangentPlaneReadout.
-const LINE_PITCH = 0.06;
-
 const SEPARATOR_COLOR = 0xffffff;
-const OUTLINE_WIDTH = '8%';
-const OUTLINE_COLOR = 0x000000;
-
-// Throttle the troika `.sync()` calls to ≈30 Hz, mirroring
-// `TangentPlaneReadout` and `EquationReadout`. Bounds SDF rebuild work
-// during fast drags. Per-frame head-pose billboarding (faceCamera)
-// still runs every frame so motion smoothness is unaffected.
-const SYNC_INTERVAL_MS = 33;
 
 // Per-axis slot indices for the top-line component triple.
 const AXIS_X = 0;
@@ -111,7 +105,7 @@ export class GradientLevelsReadout {
   private readonly groupWorld = new THREE.Vector3();
 
   constructor(opts: GradientLevelsReadoutOptions) {
-    this.fontSize = opts.fontSize ?? DEFAULT_FONT_SIZE;
+    this.fontSize = opts.fontSize ?? READOUT_FONT_SIZE;
 
     this.group = new THREE.Group();
     this.group.name = 'gradient-levels-readout';
@@ -127,8 +121,8 @@ export class GradientLevelsReadout {
     const closeParenW = CLOSE_PAREN_EM * this.fontSize;
     const prefixMagW = PREFIX_MAG_EM * this.fontSize;
 
-    const topY = LINE_PITCH / 2;
-    const bottomY = -LINE_PITCH / 2;
+    const topY = READOUT_LINE_PITCH / 2;
+    const bottomY = -READOUT_LINE_PITCH / 2;
 
     // ─── Top line ────────────────────────────────────────────────
     // `∇f = ( ` [n_x] ` , ` [n_y] ` , ` [n_z] ` )`
@@ -199,8 +193,8 @@ export class GradientLevelsReadout {
     t.color = color;
     t.anchorX = 'center';
     t.anchorY = 'middle';
-    t.outlineWidth = OUTLINE_WIDTH;
-    t.outlineColor = OUTLINE_COLOR;
+    t.outlineWidth = READOUT_OUTLINE_WIDTH;
+    t.outlineColor = READOUT_OUTLINE_COLOR;
     return t;
   }
 
@@ -210,14 +204,14 @@ export class GradientLevelsReadout {
     t.color = SEPARATOR_COLOR;
     t.anchorX = 'center';
     t.anchorY = 'middle';
-    t.outlineWidth = OUTLINE_WIDTH;
-    t.outlineColor = OUTLINE_COLOR;
+    t.outlineWidth = READOUT_OUTLINE_WIDTH;
+    t.outlineColor = READOUT_OUTLINE_COLOR;
     return t;
   }
 
   /**
    * Update all four numerics from the per-frame raymarch result. Throttled
-   * to ≈30 Hz via SYNC_INTERVAL_MS — mirrors TangentPlaneReadout's cadence
+   * to ≈30 Hz via READOUT_SYNC_INTERVAL_MS — mirrors TangentPlaneReadout's cadence
    * and bounds troika SDF rebuild work during fast drags. Per-slot caching
    * skips the .text + .sync() write when the formatted string hasn't
    * changed.
@@ -231,7 +225,7 @@ export class GradientLevelsReadout {
     if (!this.group.visible) this.group.visible = true;
 
     const now = performance.now();
-    if (now - this.lastSyncMs < SYNC_INTERVAL_MS) return;
+    if (now - this.lastSyncMs < READOUT_SYNC_INTERVAL_MS) return;
     this.lastSyncMs = now;
 
     const strings: GradientLevelsReadoutStrings = formatGradientLevelsReadout(gradient);

--- a/src/exhibits/quadrics/EquationReadout.ts
+++ b/src/exhibits/quadrics/EquationReadout.ts
@@ -1,6 +1,13 @@
 import * as THREE from 'three';
 import { Text } from 'troika-three-text';
 import { formatSignedMagnitude } from '@/scaffold/ui/formatSignedMagnitude';
+import {
+  READOUT_FONT_SIZE,
+  READOUT_LINE_PITCH,
+  READOUT_OUTLINE_COLOR,
+  READOUT_OUTLINE_WIDTH,
+  READOUT_SYNC_INTERVAL_MS,
+} from '@/scaffold/ui/readoutTokens';
 
 // Live equation readout above the slider rack (#58). Two-line layout (#89)
 // renders the full quadric with linear terms:
@@ -42,8 +49,6 @@ export interface EquationReadoutOptions {
   fontSize?: number;
 }
 
-const DEFAULT_FONT_SIZE = 0.028;
-
 // Slot widths in em (multiples of fontSize), tuned to Roboto-ish defaults
 // in troika. NUMERIC fits the worst-case `−N.NN`; SEPARATOR fits a full
 // connector like ` x² + ` / ` z = ` with breathing room; SEPARATOR_TAIL is
@@ -53,20 +58,7 @@ const NUMERIC_SLOT_EM = 2.6;
 const SEPARATOR_SLOT_EM = 2.4;
 const SEPARATOR_TAIL_EM = 1.2;
 
-// Vertical gap between the two lines. Larger than 1× fontSize so the lines
-// read as visually distinct rows; smaller than 2.5× to keep the readout's
-// total height under the gap to the family-classifier label at y=1.5.
-const LINE_PITCH = 0.06;
-
 const SEPARATOR_COLOR = 0xffffff;
-const OUTLINE_WIDTH = '8%';
-const OUTLINE_COLOR = 0x000000;
-
-// Throttle the numeric .sync() calls to ≈30 Hz, mirroring the per-slider
-// value-label cap in #38 (and now retired alongside it). Bounds troika SDF
-// re-build work; head-pose billboarding (faceCamera) still runs every
-// frame so motion smoothness is unaffected.
-const SYNC_INTERVAL_MS = 33;
 
 // Numeric-slot indices in visual reading order. Indexes into numericTexts,
 // numericValues, visibilityMask, and the coefficientColors array.
@@ -117,7 +109,7 @@ export class EquationReadout {
   private readonly groupWorld = new THREE.Vector3();
 
   constructor(opts: EquationReadoutOptions) {
-    this.fontSize = opts.fontSize ?? DEFAULT_FONT_SIZE;
+    this.fontSize = opts.fontSize ?? READOUT_FONT_SIZE;
 
     this.group = new THREE.Group();
     this.group.name = 'equation-readout';
@@ -162,8 +154,8 @@ export class EquationReadout {
     t.color = color;
     t.anchorX = 'center';
     t.anchorY = 'middle';
-    t.outlineWidth = OUTLINE_WIDTH;
-    t.outlineColor = OUTLINE_COLOR;
+    t.outlineWidth = READOUT_OUTLINE_WIDTH;
+    t.outlineColor = READOUT_OUTLINE_COLOR;
     return t;
   }
 
@@ -173,8 +165,8 @@ export class EquationReadout {
     t.color = SEPARATOR_COLOR;
     t.anchorX = 'center';
     t.anchorY = 'middle';
-    t.outlineWidth = OUTLINE_WIDTH;
-    t.outlineColor = OUTLINE_COLOR;
+    t.outlineWidth = READOUT_OUTLINE_WIDTH;
+    t.outlineColor = READOUT_OUTLINE_COLOR;
     return t;
   }
 
@@ -196,8 +188,8 @@ export class EquationReadout {
     const numericW = NUMERIC_SLOT_EM * this.fontSize;
     const separatorW = SEPARATOR_SLOT_EM * this.fontSize;
     const separatorTailW = SEPARATOR_TAIL_EM * this.fontSize;
-    const topY = LINE_PITCH / 2;
-    const bottomY = -LINE_PITCH / 2;
+    const topY = READOUT_LINE_PITCH / 2;
+    const bottomY = -READOUT_LINE_PITCH / 2;
 
     const topVisible = TOP_SLOTS.filter((s) => this.visibilityMask[s]);
     const bottomNonDVisible = BOTTOM_NON_D_SLOTS.filter(
@@ -320,7 +312,7 @@ export class EquationReadout {
     w: number,
   ): void {
     const now = performance.now();
-    if (now - this.lastSyncMs < SYNC_INTERVAL_MS) return;
+    if (now - this.lastSyncMs < READOUT_SYNC_INTERVAL_MS) return;
     this.lastSyncMs = now;
 
     // Indexed in visual reading order [a, b, c, u, v, w, d] to match the

--- a/src/exhibits/saddle-extrema/SaddleExtremaReadout.ts
+++ b/src/exhibits/saddle-extrema/SaddleExtremaReadout.ts
@@ -1,6 +1,13 @@
 import * as THREE from 'three';
 import { Text } from 'troika-three-text';
 import {
+  READOUT_FONT_SIZE,
+  READOUT_LINE_PITCH,
+  READOUT_OUTLINE_COLOR,
+  READOUT_OUTLINE_WIDTH,
+  READOUT_SYNC_INTERVAL_MS,
+} from '@/scaffold/ui/readoutTokens';
+import {
   formatSaddleExtremaReadout,
   type SaddleExtremaReadoutStrings,
 } from './formatSaddleExtremaReadout';
@@ -66,8 +73,6 @@ export interface SaddleExtremaReadoutOptions {
   fontSize?: number;
 }
 
-const DEFAULT_FONT_SIZE = 0.028;
-
 // Slot widths in em (multiples of fontSize). NUMERIC_ENTRY_EM fits
 // worst-case `−12.00` (monkey saddle / quartic at domain corners);
 // NUMERIC_D_EM fits worst-case `−103.68` (monkey saddle at corner
@@ -82,18 +87,7 @@ const TOP_ENTRY_GAP_EM = 1.2;
 // `D = ` on the middle line.
 const PREFIX_D_EM = 2.0;
 
-// Vertical pitch — same as gradient-levels for visual consistency
-// across the cluster's readouts. Three lines ⇒ ±LINE_PITCH around mid.
-const LINE_PITCH = 0.06;
-
 const SEPARATOR_COLOR = 0xffffff;
-const OUTLINE_WIDTH = '8%';
-const OUTLINE_COLOR = 0x000000;
-
-// Throttle troika `.sync()` calls. Bounds SDF rebuild work during fast
-// slider drags. Per-frame head-pose billboarding (faceCamera) still
-// runs every frame so motion smoothness is unaffected.
-const SYNC_INTERVAL_MS = 33;
 
 // Entry-slot index range — `for i = ENTRY_XX; i <= ENTRY_YY` covers
 // [f_xx, f_xy, f_yy] in math reading order. The middle index (f_xy)
@@ -132,7 +126,7 @@ export class SaddleExtremaReadout {
   private readonly groupWorld = new THREE.Vector3();
 
   constructor(opts: SaddleExtremaReadoutOptions) {
-    this.fontSize = opts.fontSize ?? DEFAULT_FONT_SIZE;
+    this.fontSize = opts.fontSize ?? READOUT_FONT_SIZE;
 
     this.group = new THREE.Group();
     this.group.name = 'saddle-extrema-readout';
@@ -147,9 +141,9 @@ export class SaddleExtremaReadout {
     const prefixDW = PREFIX_D_EM * this.fontSize;
     const topGapW = TOP_ENTRY_GAP_EM * this.fontSize;
 
-    const topY = LINE_PITCH;
+    const topY = READOUT_LINE_PITCH;
     const midY = 0;
-    const bottomY = -LINE_PITCH;
+    const bottomY = -READOUT_LINE_PITCH;
 
     // ─── Top line ──────────────────────────────────────────────────
     // `f_xx = ` [n_xx] `   f_xy = ` [n_xy] `   f_yy = ` [n_yy]
@@ -220,8 +214,8 @@ export class SaddleExtremaReadout {
     t.color = color;
     t.anchorX = 'center';
     t.anchorY = 'middle';
-    t.outlineWidth = OUTLINE_WIDTH;
-    t.outlineColor = OUTLINE_COLOR;
+    t.outlineWidth = READOUT_OUTLINE_WIDTH;
+    t.outlineColor = READOUT_OUTLINE_COLOR;
     return t;
   }
 
@@ -231,14 +225,14 @@ export class SaddleExtremaReadout {
     t.color = SEPARATOR_COLOR;
     t.anchorX = 'center';
     t.anchorY = 'middle';
-    t.outlineWidth = OUTLINE_WIDTH;
-    t.outlineColor = OUTLINE_COLOR;
+    t.outlineWidth = READOUT_OUTLINE_WIDTH;
+    t.outlineColor = READOUT_OUTLINE_COLOR;
     return t;
   }
 
   /**
    * Update all five slots from the per-frame Hessian. Throttled to
-   * ≈30 Hz via SYNC_INTERVAL_MS, with per-slot caching so unchanged
+   * ≈30 Hz via READOUT_SYNC_INTERVAL_MS, with per-slot caching so unchanged
    * strings don't re-trigger troika's `.sync()`.
    *
    * On first call, uncloaks `group.visible = true` — the readout
@@ -248,7 +242,7 @@ export class SaddleExtremaReadout {
     if (!this.group.visible) this.group.visible = true;
 
     const now = performance.now();
-    if (now - this.lastSyncMs < SYNC_INTERVAL_MS) return;
+    if (now - this.lastSyncMs < READOUT_SYNC_INTERVAL_MS) return;
     this.lastSyncMs = now;
 
     const s: SaddleExtremaReadoutStrings = formatSaddleExtremaReadout(hessian);

--- a/src/exhibits/tangent-planes/TangentPlaneReadout.ts
+++ b/src/exhibits/tangent-planes/TangentPlaneReadout.ts
@@ -2,6 +2,13 @@ import * as THREE from 'three';
 import { Text } from 'troika-three-text';
 import type { MathVec3 } from '@/scaffold/math/frames';
 import {
+  READOUT_FONT_SIZE,
+  READOUT_LINE_PITCH,
+  READOUT_OUTLINE_COLOR,
+  READOUT_OUTLINE_WIDTH,
+  READOUT_SYNC_INTERVAL_MS,
+} from '@/scaffold/ui/readoutTokens';
+import {
   formatTangentPlaneReadout,
   type TangentPlaneReadoutStrings,
 } from './formatTangentPlaneReadout';
@@ -48,8 +55,6 @@ export interface TangentPlaneReadoutOptions {
   fontSize?: number;
 }
 
-const DEFAULT_FONT_SIZE = 0.028;
-
 // Slot widths in em (multiples of fontSize). NUMERIC fits worst-case
 // `−N.NN`; separator widths are sized to their string content with
 // modest breathing room. Tunable in headset; these are the v0.6 lock.
@@ -63,21 +68,7 @@ const EQ_OPEN_EM = 2.2;           // "n = ( "
 const COMMA_EM = 1.0;             // " , "
 const CLOSE_PAREN_EM = 1.0;       // " )"
 
-// Vertical gap between the two lines. Larger than 1× fontSize so the
-// lines read as visually distinct rows; smaller than 2.5× to keep the
-// readout's total height under the gap to the slider rack at y ≈ 1.07
-// (top of the θ slider).
-const LINE_PITCH = 0.06;
-
 const SEPARATOR_COLOR = 0xffffff;
-const OUTLINE_WIDTH = '8%';
-const OUTLINE_COLOR = 0x000000;
-
-// Throttle the troika `.sync()` calls to ≈30 Hz, mirroring
-// `EquationReadout.ts`. Bounds SDF rebuild work during fast drags;
-// per-frame head-pose billboarding (faceCamera) still runs every frame
-// so motion smoothness is unaffected.
-const SYNC_INTERVAL_MS = 33;
 
 // Per-axis slot indices into `axisColors`. The construction loops walk
 // from AXIS_X through AXIS_Z; the AXIS_Y constant is implicit in that
@@ -118,7 +109,7 @@ export class TangentPlaneReadout {
   private readonly groupWorld = new THREE.Vector3();
 
   constructor(opts: TangentPlaneReadoutOptions) {
-    this.fontSize = opts.fontSize ?? DEFAULT_FONT_SIZE;
+    this.fontSize = opts.fontSize ?? READOUT_FONT_SIZE;
 
     this.group = new THREE.Group();
     this.group.name = 'tangent-plane-readout';
@@ -131,8 +122,8 @@ export class TangentPlaneReadout {
     const commaW = COMMA_EM * this.fontSize;
     const closeParenW = CLOSE_PAREN_EM * this.fontSize;
 
-    const topY = LINE_PITCH / 2;
-    const bottomY = -LINE_PITCH / 2;
+    const topY = READOUT_LINE_PITCH / 2;
+    const bottomY = -READOUT_LINE_PITCH / 2;
 
     // ─── Top line ────────────────────────────────────────────────
     // [n_x] " (x " [x₀] ") + " [n_y] " (y " [y₀] ") + " [n_z] " (z " [z₀] ") = 0"
@@ -236,8 +227,8 @@ export class TangentPlaneReadout {
     t.color = color;
     t.anchorX = 'center';
     t.anchorY = 'middle';
-    t.outlineWidth = OUTLINE_WIDTH;
-    t.outlineColor = OUTLINE_COLOR;
+    t.outlineWidth = READOUT_OUTLINE_WIDTH;
+    t.outlineColor = READOUT_OUTLINE_COLOR;
     return t;
   }
 
@@ -247,14 +238,14 @@ export class TangentPlaneReadout {
     t.color = SEPARATOR_COLOR;
     t.anchorX = 'center';
     t.anchorY = 'middle';
-    t.outlineWidth = OUTLINE_WIDTH;
-    t.outlineColor = OUTLINE_COLOR;
+    t.outlineWidth = READOUT_OUTLINE_WIDTH;
+    t.outlineColor = READOUT_OUTLINE_COLOR;
     return t;
   }
 
   /**
    * Update all nine numerics from the per-frame raymarch result. Throttled
-   * to ≈30 Hz via SYNC_INTERVAL_MS — mirrors EquationReadout's cadence and
+   * to ≈30 Hz via READOUT_SYNC_INTERVAL_MS — mirrors EquationReadout's cadence and
    * bounds troika SDF rebuild work during fast drags. Per-slot caching
    * skips the .text + .sync() write when the formatted string hasn't
    * changed (e.g. between sub-pixel slider motions that round to the
@@ -262,7 +253,7 @@ export class TangentPlaneReadout {
    */
   setValues(point: MathVec3, normal: MathVec3): void {
     const now = performance.now();
-    if (now - this.lastSyncMs < SYNC_INTERVAL_MS) return;
+    if (now - this.lastSyncMs < READOUT_SYNC_INTERVAL_MS) return;
     this.lastSyncMs = now;
 
     const strings: TangentPlaneReadoutStrings = formatTangentPlaneReadout(

--- a/src/scaffold/ui/readoutTokens.ts
+++ b/src/scaffold/ui/readoutTokens.ts
@@ -1,0 +1,30 @@
+// Readout typography + sync — duplicated bit-identical across the four
+// cluster readouts (EquationReadout, TangentPlaneReadout,
+// GradientLevelsReadout, SaddleExtremaReadout). Lifted per the
+// extract-on-Nth-use rule for load-bearing scaffold (#201 PR 2).
+//
+// All four readouts use the same font size, line pitch, outline, and
+// sync throttle so the cluster reads as a coherent UI family across
+// scene swaps via the SceneRack. Future cluster scenes inherit these
+// as the readout-typography template.
+
+// Default fallback font size. Each readout exposes `opts.fontSize?`;
+// when omitted, this is the value applied.
+export const READOUT_FONT_SIZE = 0.028;
+
+// Vertical pitch between adjacent text lines, in meters. 2-line
+// readouts (Equation, TangentPlane, GradientLevels) place rows at
+// ±LINE_PITCH/2; the 3-line readout (SaddleExtrema) places rows at
+// ±LINE_PITCH around midline.
+export const READOUT_LINE_PITCH = 0.06;
+
+// Troika Text outline — an opaque high-contrast band around glyph
+// edges so the readout stays legible against any scene background
+// (#29 rationale).
+export const READOUT_OUTLINE_WIDTH = '8%';
+export const READOUT_OUTLINE_COLOR = 0x000000;
+
+// Re-render throttle. Pre-throttle, troika SDF rebuild cost dominates
+// during fast drags. ≈30 Hz is the cap shared by every readout (#38
+// rationale, originally calibrated on Slider's per-slider label cap).
+export const READOUT_SYNC_INTERVAL_MS = 33;


### PR DESCRIPTION
Refs #201, #188 (v0.9 cross-cluster polish epic). Independent of #215 (PR 1).

## Summary

Lifts the readout typography constants duplicated bit-identical across the four cluster readouts — `EquationReadout` (quadrics), `TangentPlaneReadout`, `GradientLevelsReadout`, and `SaddleExtremaReadout` — into `src/scaffold/ui/readoutTokens.ts`. Four consumers earn the extraction per the load-bearing-scaffold convention.

Five constants lifted:
- `READOUT_FONT_SIZE` (0.028 m) — was `DEFAULT_FONT_SIZE` per file.
- `READOUT_LINE_PITCH` (0.06 m).
- `READOUT_OUTLINE_WIDTH` (`'8%'`).
- `READOUT_OUTLINE_COLOR` (0x000000).
- `READOUT_SYNC_INTERVAL_MS` (33 — ≈30 Hz cap).

`READOUT_` prefix at the imports disambiguates from any unprefixed locals a future scene might introduce and matches the cluster-rack-tokens / translucent-rect-tokens prefix convention.

**Visual diff: zero.** Constants are bit-identical to the prior per-file locals.

PR 2 of 6 in the #201 consolidation pass (plan in `_private/plans/201-design-language-consolidation.md`, v3 after roundtable + second-Sonnet sanity check).

## Test plan

- [x] `npm run build` (tsc + Vite) — passes.
- [x] `npm test` — 428/428 passing.
- [x] `npm run lint` — clean.
- [x] Cloudflare PR preview: navigate to each cluster scene (quadrics, tangent-planes, gradient-levels, saddle-extrema) and confirm each readout renders with the same font / outline / line spacing as before. No visual delta expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)