### PR TITLE
feat(scaffold): clusterRackTokens — lift rack geometry + per-slider labels

### DIFF
--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -10,6 +10,16 @@ import { raycastImplicit } from '@/scaffold/render/raycastImplicit';
 import { formatAnglePiFraction } from '@/scaffold/ui/formatAnglePiFraction';
 import { Label } from '@/scaffold/ui/Label';
 import { Slider } from '@/scaffold/ui/Slider';
+import {
+  GRAB_RADIUS_MULTIPLIER,
+  SLIDER_LABEL_LINE_GAP,
+  SLIDER_LABEL_PRIMARY_FONT_SIZE,
+  SLIDER_LABEL_SECONDARY_FONT_SIZE,
+  SLIDER_LABEL_X_OFFSET,
+  SLIDER_ROW_PITCH,
+  SLIDER_SNAP_DETENT,
+  createSliderRackCenter,
+} from '@/scaffold/ui/clusterRackTokens';
 import { WorldAxes, type AxisName } from '@/scaffold/ui/WorldAxes';
 import {
   BLUISH_GREEN,
@@ -48,7 +58,9 @@ import { BOUND, fJsRaw, gradJs } from './surfaceModel';
 // Match cluster siblings so SceneRack swaps don't visually relocate the
 // surface or the rack.
 const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
-const SLIDER_RACK_CENTER = new THREE.Vector3(0, 1.0, -0.7);
+// Per-file fresh THREE.Vector3 from scaffold/ui/clusterRackTokens
+// (#201 PR 4). Per-scene instance — mutation can't leak across scenes.
+const SLIDER_RACK_CENTER = createSliderRackCenter();
 const AXIS_INDICATOR_POSITION = new THREE.Vector3(0.35, 1.17, -0.7);
 
 // Live readout (#166) — anchored above the three-row slider rack. y bumped
@@ -62,20 +74,15 @@ const READOUT_POSITION = new THREE.Vector3(0, 1.42, -0.7);
 // a one-line "k = N.NN" readout below the k slider; #170 unifies it into
 // the same two-line shape as the new θ/φ labels — same per-row anchor,
 // same fonts. Frees the y = 0.70 slot the old k label occupied.
-const SLIDER_LABEL_X_OFFSET = -0.20;
-const SLIDER_LABEL_PRIMARY_FONT_SIZE = 0.05;
-const SLIDER_LABEL_SECONDARY_FONT_SIZE = 0.035;
-const SLIDER_LABEL_LINE_GAP = 0.008;
+// Imported from scaffold/ui/clusterRackTokens (#201 PR 4).
 
 // Cluster siblings' lighting + base color so the surface reads as a
 // sibling, not as a separate scene's surface.
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
 const BASE_COLOR = new THREE.Color(0.4, 0.7, 0.95);
 
-// Quadrics' design feel ports across the cluster.
-const SLIDER_SNAP_DETENT = 0.05;
-const GRAB_RADIUS_MULTIPLIER = 2.75;
-const SLIDER_ROW_PITCH = 0.14;
+// Quadrics' design feel ports across the cluster — imported from
+// scaffold/ui/clusterRackTokens (#201 PR 4).
 
 // Three-row slider stack centered at SLIDER_RACK_CENTER.y. Top to bottom:
 // θ (point selector, polar), φ (point selector, azimuth), k (level value).

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -22,6 +22,12 @@ import { RendererInfoProbe } from '@/scaffold/perf/RendererInfoProbe';
 import { Section } from '@/scaffold/ui/Section';
 import { SectionTab } from '@/scaffold/ui/SectionTab';
 import { Slider, type ThumbShape } from '@/scaffold/ui/Slider';
+import {
+  GRAB_RADIUS_MULTIPLIER,
+  SLIDER_ROW_PITCH,
+  SLIDER_SNAP_DETENT,
+  createSliderRackCenter,
+} from '@/scaffold/ui/clusterRackTokens';
 import { AxisToggle } from './AxisToggle';
 import { createSlicingPlanes, type SlicingPlanesHandles } from './SlicingPlane';
 import { WorldAxes, type AxisName } from '@/scaffold/ui/WorldAxes';
@@ -38,7 +44,11 @@ import { WorldAxes, type AxisName } from '@/scaffold/ui/WorldAxes';
 // door open for non-rectilinear perspectives once teleportation lets the
 // user self-position.
 const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
-const SLIDER_RACK_CENTER = new THREE.Vector3(0, 1.0, -0.7);
+// Imported as a fresh THREE.Vector3 from scaffold/ui/clusterRackTokens
+// (#201 PR 4) — per-file instance, so mutation in one scene can't leak
+// to another. The shared canonical value is the immutable
+// SLIDER_RACK_CENTER_COORDS tuple.
+const SLIDER_RACK_CENTER = createSliderRackCenter();
 
 // Vertical stacking (top → bottom):
 //   centered column (x = 0):
@@ -222,8 +232,9 @@ const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
 // Slider detent half-width, per SPEC.md "Slider model". Lets the user
 // park exactly on a snap point (degeneracy boundary or canonical-form
 // coordinate) instead of approximating. Passed into every
-// scaffold/ui/Slider construction in this exhibit.
-const SLIDER_SNAP_DETENT = 0.05;
+// scaffold/ui/Slider construction in this exhibit. Imported from
+// scaffold/ui/clusterRackTokens (#201 PR 4) — shared 0.05 m across the
+// four cluster scenes.
 
 // Detent positions for the squared coefficients (a/b/c/d) and the
 // linear-term sliders (u/v/w). 0 keeps every degeneracy boundary
@@ -262,8 +273,9 @@ function easeInOutCubic(t: number): number {
 // consistently across this exhibit's Slider, Preset, and SectionTab
 // constructions so all three feel the same when sweeping the
 // controller across the rack. Formerly hardcoded inside each
-// primitive (#120 made it a required ctor option).
-const GRAB_RADIUS_MULTIPLIER = 2.75;
+// primitive (#120 made it a required ctor option). Imported from
+// scaffold/ui/clusterRackTokens (#201 PR 4) — shared 2.75 across the
+// cluster.
 
 // Vertical stacking pitch for the rack. SPEC pins the rack center but
 // not per-slider positions. Lower bound is set by the slider's grab
@@ -273,8 +285,9 @@ const GRAB_RADIUS_MULTIPLIER = 2.75;
 // midpoint could resolve to either slider). 0.14 leaves ~2.5 mm of
 // clearance — tighter than the original 0.15 (#110 follow-up: headset
 // feedback called the rack overly spread out and asked for a more
-// compact stack), but still above the disjoint-grab floor.
-const SLIDER_ROW_PITCH = 0.14;
+// compact stack), but still above the disjoint-grab floor. Imported
+// from scaffold/ui/clusterRackTokens (#201 PR 4) — shared 0.14 m
+// across the cluster.
 
 // Wong / Okabe-Ito colorblind-safe palette imported from
 // @/scaffold/design/tokens (#120). The fourth slot — yellow on slider

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -12,6 +12,16 @@ import {
 import { Label } from '@/scaffold/ui/Label';
 import { Slider } from '@/scaffold/ui/Slider';
 import {
+  GRAB_RADIUS_MULTIPLIER,
+  SLIDER_LABEL_LINE_GAP,
+  SLIDER_LABEL_PRIMARY_FONT_SIZE,
+  SLIDER_LABEL_SECONDARY_FONT_SIZE,
+  SLIDER_LABEL_X_OFFSET,
+  SLIDER_ROW_PITCH,
+  SLIDER_SNAP_DETENT,
+  createSliderRackCenter,
+} from '@/scaffold/ui/clusterRackTokens';
+import {
   TapButton,
   type TapButtonVisuals,
 } from '@/scaffold/ui/TapButton';
@@ -70,9 +80,11 @@ const READOUT_POSITION = new THREE.Vector3(0, 1.5, -0.7);
 // Slider rack — two-row symmetric straddle around SLIDER_RACK_CENTER. The
 // 3-row top-heavy pattern from gradient-levels (θ/φ/k at [center+pitch,
 // center, center-pitch]) doesn't carry over cleanly to a 2-row rack; the
-// straddle layout reads as balanced.
-const SLIDER_RACK_CENTER = new THREE.Vector3(0, 1.0, -0.7);
-const SLIDER_ROW_PITCH = 0.14;
+// straddle layout reads as balanced. SLIDER_RACK_CENTER / SLIDER_ROW_PITCH
+// imported from scaffold/ui/clusterRackTokens (#201 PR 4) — per-file
+// fresh THREE.Vector3 from the factory so mutation can't leak across
+// scenes.
+const SLIDER_RACK_CENTER = createSliderRackCenter();
 const X_SLIDER_Y = SLIDER_RACK_CENTER.y + SLIDER_ROW_PITCH / 2;
 const Y_SLIDER_Y = SLIDER_RACK_CENTER.y - SLIDER_ROW_PITCH / 2;
 
@@ -83,8 +95,8 @@ const Y_SLIDER_Y = SLIDER_RACK_CENTER.y - SLIDER_ROW_PITCH / 2;
 // origin, so the projected snap set collapses to `[0]` and visible
 // behavior is unchanged from v0.7; future off-origin presets (or
 // user-supplied f(x, y) in v1.x) get correct CP-aware snaps for free.
-const SLIDER_SNAP_DETENT = 0.05;
-const GRAB_RADIUS_MULTIPLIER = 2.75;
+// SLIDER_SNAP_DETENT / GRAB_RADIUS_MULTIPLIER imported from
+// scaffold/ui/clusterRackTokens (#201 PR 4).
 
 // Initial pose — off origin-snap, off endpoints, off both axes,
 // non-equal — so first-frame drag responds in any direction.
@@ -93,11 +105,8 @@ const Y_INITIAL = 0.3;
 
 // Per-slider variable + value label layout — verbatim from gradient-levels'
 // #170 layout. Right-anchored so worst-case secondary text "−1.50" stays
-// clear of the slider thumb at any value.
-const SLIDER_LABEL_X_OFFSET = -0.20;
-const SLIDER_LABEL_PRIMARY_FONT_SIZE = 0.05;
-const SLIDER_LABEL_SECONDARY_FONT_SIZE = 0.035;
-const SLIDER_LABEL_LINE_GAP = 0.008;
+// clear of the slider thumb at any value. Imported from
+// scaffold/ui/clusterRackTokens (#201 PR 4).
 
 // Indicator — verbatim port from cluster siblings for visual consistency.
 const INDICATOR_RADIUS = 0.04;

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -8,6 +8,16 @@ import { createImplicitSurface } from '@/scaffold/render/ImplicitSurface';
 import { formatAnglePiFraction } from '@/scaffold/ui/formatAnglePiFraction';
 import { Label } from '@/scaffold/ui/Label';
 import { Slider } from '@/scaffold/ui/Slider';
+import {
+  GRAB_RADIUS_MULTIPLIER,
+  SLIDER_LABEL_LINE_GAP,
+  SLIDER_LABEL_PRIMARY_FONT_SIZE,
+  SLIDER_LABEL_SECONDARY_FONT_SIZE,
+  SLIDER_LABEL_X_OFFSET,
+  SLIDER_ROW_PITCH,
+  SLIDER_SNAP_DETENT,
+  createSliderRackCenter,
+} from '@/scaffold/ui/clusterRackTokens';
 import { WorldAxes, type AxisName } from '@/scaffold/ui/WorldAxes';
 import {
   BLUISH_GREEN,
@@ -46,7 +56,11 @@ import { TangentPlaneReadout } from './TangentPlaneReadout';
 // relocate the surface. The same arm's-length depth (z = -0.7) carries
 // across all rack tiers (slider rack, SectionTab rack, SceneRack).
 const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
-const SLIDER_RACK_CENTER = new THREE.Vector3(0, 1.0, -0.7);
+// Per-file fresh THREE.Vector3 from scaffold/ui/clusterRackTokens
+// (#201 PR 4). Shared canonical value is the immutable
+// SLIDER_RACK_CENTER_COORDS tuple; the factory builds a fresh instance
+// so mutation in one scene can't leak to another.
+const SLIDER_RACK_CENTER = createSliderRackCenter();
 const AXIS_INDICATOR_POSITION = new THREE.Vector3(0.35, 1.17, -0.7);
 
 // Tangent-plane readout (#149) sits above the slider rack, on the same
@@ -64,10 +78,8 @@ const BOUND = 1.5;
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
 const BASE_COLOR = new THREE.Color(0.4, 0.7, 0.95);
 
-// Quadrics' design feel ports across.
-const SLIDER_SNAP_DETENT = 0.05;
-const GRAB_RADIUS_MULTIPLIER = 2.75;
-const SLIDER_ROW_PITCH = 0.14;
+// Quadrics' design feel ports across — imported from
+// scaffold/ui/clusterRackTokens (#201 PR 4).
 
 // θ ∈ [0, π], snap at the two poles + the equator. φ ∈ [-π, π], snap at
 // the four cardinal compass directions; the ±π double-snap makes the
@@ -105,10 +117,7 @@ const INDICATOR_COLOR = 0xdddddd;
 // thumb at slider min by 0.025 m. Sizes shrunk from the v1 plan
 // values to leave 0.034 m of breathing room between adjacent labels
 // in the 3-row gradient-levels rack — same constants port across.
-const SLIDER_LABEL_X_OFFSET = -0.20;
-const SLIDER_LABEL_PRIMARY_FONT_SIZE = 0.05;
-const SLIDER_LABEL_SECONDARY_FONT_SIZE = 0.035;
-const SLIDER_LABEL_LINE_GAP = 0.008;
+// Imported from scaffold/ui/clusterRackTokens (#201 PR 4).
 
 // Controller-aim picking (#197). VR-only direct-manipulation affordance
 // alongside the angular sliders: aim a controller at the unit sphere and

--- a/src/scaffold/ui/clusterRackTokens.ts
+++ b/src/scaffold/ui/clusterRackTokens.ts
@@ -1,0 +1,37 @@
+import * as THREE from 'three';
+
+// Cluster slider-rack geometry + design feel — duplicated bit-identical
+// across the four cluster scenes' index.ts (quadrics manipulator,
+// tangent-planes, gradient-levels, saddle-extrema). Lifted per the
+// extract-on-Nth-use rule for load-bearing scaffold (#201 PR 4).
+//
+// Future cluster scenes inherit these as the rack template. Scenes
+// pedagogically needing a different feel pass their own constants
+// explicitly — the Slider API requires snapDetent + grabRadiusMultiplier
+// as ctor opts per #120.
+//
+// Canonical surface is immutable: tuple (`readonly` via `as const`) for
+// the rack-center coordinate + factory function for the Vector3
+// instance. THREE.Vector3 has no internal cloning protection at consumer
+// call sites (unlike THREE.Color, which createTranslucentRect clones at
+// its boundary); the factory pattern eliminates the shared-mutable-
+// singleton footgun.
+
+export const SLIDER_RACK_CENTER_COORDS = [0, 1.0, -0.7] as const;
+export const SLIDER_ROW_PITCH = 0.14;
+export const SLIDER_SNAP_DETENT = 0.05;
+export const GRAB_RADIUS_MULTIPLIER = 2.75;
+
+// Per-slider variable + value label layout (#170). Right-anchored so
+// worst-case secondary text "−1.50" stays clear of the slider thumb at
+// any value. Consumers: tangent-planes, gradient-levels, saddle-extrema.
+// Quadrics has no per-slider labels — the equation readout carries the
+// live coefficient values instead.
+export const SLIDER_LABEL_X_OFFSET = -0.2;
+export const SLIDER_LABEL_PRIMARY_FONT_SIZE = 0.05;
+export const SLIDER_LABEL_SECONDARY_FONT_SIZE = 0.035;
+export const SLIDER_LABEL_LINE_GAP = 0.008;
+
+export function createSliderRackCenter(): THREE.Vector3 {
+  return new THREE.Vector3(...SLIDER_RACK_CENTER_COORDS);
+}


### PR DESCRIPTION
Refs #201, #188. Independent of #215 (PR 1) and #216 (PR 2).

## Summary

Lifts the slider-rack geometry + per-slider label config duplicated across the four cluster scenes' `index.ts` into `src/scaffold/ui/clusterRackTokens.ts`. Eight constants — four used by every scene, four used by the three label-bearing scenes (quadrics has no per-slider labels; the EquationReadout carries the live coefficient values).

Constants lifted:
- `SLIDER_RACK_CENTER_COORDS` (readonly tuple `[0, 1.0, -0.7]`) + `createSliderRackCenter()` factory.
- `SLIDER_ROW_PITCH` (0.14 m), `SLIDER_SNAP_DETENT` (0.05), `GRAB_RADIUS_MULTIPLIER` (2.75).
- `SLIDER_LABEL_X_OFFSET` (-0.2 m), `SLIDER_LABEL_PRIMARY_FONT_SIZE` (0.05), `SLIDER_LABEL_SECONDARY_FONT_SIZE` (0.035), `SLIDER_LABEL_LINE_GAP` (0.008).

Same anti-singleton pattern as #215 — the rack-center is exported as an immutable tuple + factory function rather than a `new THREE.Vector3()` module-level constant. Each scene binds a fresh `THREE.Vector3` at module-load via the factory, so a mutation in one scene can't leak to another at runtime.

**Visual diff: zero.** Constants are bit-identical to the prior per-file locals.

PR 4 of 6 in the #201 consolidation pass.

## Test plan

- [x] `npm run build` (tsc + Vite) — passes.
- [x] `npm test` — 428/428 passing.
- [x] `npm run lint` — clean.
- [x] Cloudflare PR preview: navigate to each cluster scene and confirm slider rack positioning, row pitch, snap behavior, and per-slider labels are visually unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)