### PR TITLE
feat(scaffold): Preset.activeEmissive option + saddle-extrema migration

### DIFF
--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -11,10 +11,7 @@ import {
 } from '@/scaffold/design/tokens';
 import { Label } from '@/scaffold/ui/Label';
 import { Slider } from '@/scaffold/ui/Slider';
-import {
-  TapButton,
-  type TapButtonVisuals,
-} from '@/scaffold/ui/TapButton';
+import { Preset } from '@/scaffold/ui/Preset';
 import { WorldAxes } from '@/scaffold/ui/WorldAxes';
 import {
   createCriticalPointMarkers,
@@ -123,19 +120,11 @@ const PRESET_RES = 128;
 // preset is a persistent mode (the surface IS the preset's f), where the
 // manipulator's preset is a one-shot snap-to-pose. Sticky-active reads as
 // "this is the current archetype"; press flash layers on top as tap
-// feedback. Pattern echoes SectionTab (#57): press + active + hover, all
-// three managed by the shared TapButton base.
-const PRESET_BUTTON_VISUALS: TapButtonVisuals = {
-  groupNamePrefix: 'preset',
-  buttonRadius: 0.02,
-  baseColor: 0x44aabb,
-  hoverEmissive: 0x224455,
-  activeEmissive: 0x66ccdd,
-  pressEmissive: 0x88ddff,
-  labelFontSize: 0.022,
-  labelOffsetY: -0.025,
-  labelAnchorY: 'top',
-};
+// feedback. After #201 PR 6 this scene uses Preset with the optional
+// `activeEmissive` field rather than constructing a raw TapButton with
+// its own visuals constant; the shared Preset class owns the cool-blue
+// identity, this scene only overrides the active emissive color.
+const PRESET_ACTIVE_EMISSIVE = 0x66ccdd;
 
 // Local linear-decimal formatter for the per-slider value labels.
 // Identical in shape to gradient-levels' local helper (#170 history);
@@ -162,7 +151,7 @@ let ySlider: Slider | undefined;
 let xLabel: Label | undefined;
 let yLabel: Label | undefined;
 let indicator: THREE.Mesh | undefined;
-let presetButtons: TapButton[] = [];
+let presetButtons: Preset[] = [];
 let activePresetIndex = DEFAULT_PRESET_INDEX;
 let saddleExtremaReadout: SaddleExtremaReadout | undefined;
 let camera: THREE.Camera | undefined;
@@ -351,10 +340,10 @@ const saddleExtremaExhibit: Exhibit = {
     // PRESETS array order. The starter (saddle, DEFAULT_PRESET_INDEX) is
     // marked sticky-active so the user reads which archetype is current.
     presetButtons = PRESETS.map((preset, i) => {
-      const btn = new TapButton({
+      const btn = new Preset({
         name: preset.label,
         grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER,
-        visuals: PRESET_BUTTON_VISUALS,
+        activeEmissive: PRESET_ACTIVE_EMISSIVE,
       });
       btn.group.position.set(
         PRESET_ROW_START_X + i * PRESET_HORIZONTAL_PITCH,

--- a/src/scaffold/ui/Preset.ts
+++ b/src/scaffold/ui/Preset.ts
@@ -14,9 +14,13 @@ import { TapButton, type TapButtonVisuals } from '@/scaffold/ui/TapButton';
 // above).
 //
 // Mechanics (sphere mesh + ray-hit + press-flash + haptic + yaw-billboard
-// label) live in the shared `TapButton` base (#156). This subclass only
-// declares the visual identity (cool blue, no sticky-active) and the two
-// extra fields callers read off the preset (`values`, `linearValues`).
+// label) live in the shared `TapButton` base (#156). `Preset` adds:
+// (a) the cool-blue visual identity used by every preset row in the
+// cluster, (b) two optional caller-read fields (`values`, `linearValues`)
+// for quadrics-style coefficient presets, and (c) an optional
+// `activeEmissive` for sticky-active preset rows (#201 PR 6 — was
+// previously achieved by bypassing Preset and constructing TapButton
+// directly with a custom visuals override in saddle-extrema).
 
 export type PresetValues = readonly [number, number, number, number];
 // Linear-term coefficients (u, v, w) in math frame — see index.ts for the
@@ -26,18 +30,33 @@ export type LinearPresetValues = readonly [number, number, number];
 
 export interface PresetOptions {
   name: string;
-  values: PresetValues;
   grabRadiusMultiplier: number;
+  // Quadrics-style coefficient values (a, b, c, d). Optional so non-
+  // quadrics scenes (saddle-extrema) can use Preset for its visual
+  // identity without surfacing a presets-as-coefficient-tuples model
+  // they don't have. Defaults to (0, 0, 0, 0) — never read by scenes
+  // that don't supply it.
+  values?: PresetValues;
   // Optional. Defaults to (0, 0, 0). Paraboloid uses (0, 0, -1) so that
   // ax² + by² + wz = 0 with a=b=1, w=-1 reads as z = x² + y² (open along
   // +math-Z, the "up" axis under the math-frame convention).
   linearValues?: LinearPresetValues;
+  // Optional sticky-active emissive (#201 PR 6). When supplied, calling
+  // `setActive(true)` on the resulting Preset lights this emissive until
+  // a subsequent `setActive(false)` clears it. Quadrics omits this — its
+  // presets are one-shot snaps; the press flash is the feedback.
+  // Saddle-extrema passes 0x66ccdd — its presets are persistent surface-
+  // family selectors. The scene drives `setActive` state on tap; Preset
+  // does NOT self-toggle.
+  activeEmissive?: number;
 }
 
 // Cool fill so presets read as "tap to apply" rather than "drag" — the
-// slider thumbs use a warm orange for drag affordance. No
-// `activeEmissive`: presets are one-shot, the press flash *is* the
-// feedback.
+// slider thumbs use a warm orange for drag affordance. By default, no
+// `activeEmissive`: presets are one-shot and the press flash IS the
+// feedback. Per-instance `activeEmissive` lights up the sticky-active
+// branch in TapButton's refreshButtonEmissive when supplied via
+// PresetOptions.
 //
 // Smaller font than the tabs to keep adjacent labels from running
 // together in the horizontal preset row introduced in #93. Paired with
@@ -64,9 +83,17 @@ export class Preset extends TapButton {
     super({
       name: opts.name,
       grabRadiusMultiplier: opts.grabRadiusMultiplier,
-      visuals: VISUALS,
+      // Explicit spread when activeEmissive is supplied — keeps the
+      // no-activeEmissive path bit-identical to the prior behavior
+      // (shares the module-level VISUALS constant; no per-instance
+      // allocation). The spread fires once per Preset construct, which
+      // is at scene-mount, not per-frame.
+      visuals:
+        opts.activeEmissive !== undefined
+          ? { ...VISUALS, activeEmissive: opts.activeEmissive }
+          : VISUALS,
     });
-    this.values = opts.values;
+    this.values = opts.values ?? [0, 0, 0, 0];
     this.linearValues = opts.linearValues ?? [0, 0, 0];
   }
 }

--- a/test/scaffold/ui/Preset.test.ts
+++ b/test/scaffold/ui/Preset.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+
+// `troika-three-text` reaches for `self`, a browser-only global, in its
+// UMD `now$1` helper. The default vitest environment is Node, so any
+// `new Text()` blows up at construction time. TapButton creates a
+// `Text` for its label; this test mocks the dep with a minimal mesh-
+// like surrogate matching PointerMigration.test.ts. None of the
+// assertions below touch text rendering, so the stub is faithful enough.
+vi.mock('troika-three-text', () => {
+  class StubText extends THREE.Object3D {
+    text = '';
+    fontSize = 0;
+    color = 0xffffff;
+    anchorX: string | undefined;
+    anchorY: string | undefined;
+    outlineWidth: string | undefined;
+    outlineColor: number | undefined;
+    sync() {}
+    dispose() {}
+  }
+  return { Text: StubText };
+});
+
+import { Preset } from '@/scaffold/ui/Preset';
+
+// Vitest coverage for the `Preset.activeEmissive` option added in #201
+// PR 6. The pre-PR-6 Preset class hardcoded `activeEmissive: undefined`
+// in its module-level VISUALS constant, so saddle-extrema bypassed
+// Preset and constructed TapButton directly to supply its sticky-active
+// emissive. PR 6 makes `activeEmissive` an optional PresetOptions field
+// forwarded into a per-instance visuals spread; saddle-extrema migrates
+// to Preset. Tests cover:
+//
+//   - One-shot Preset (no activeEmissive): setActive(true) flips the
+//     internal flag but `isActive` stays false because there's no active
+//     emissive to display. Matches TapButton's "if you can't show active,
+//     you can't *be* active" contract at TapButton.ts:131-133.
+//   - Sticky Preset (activeEmissive supplied): setActive(true) lights
+//     up isActive; setActive(false) clears it.
+//   - Sibling deactivation pattern (used by saddle-extrema at
+//     index.ts: presetButtons[i].setActive(true) +
+//     setActive(false) on the previous active sibling).
+//   - `values` and `linearValues` default to zero-tuples when omitted —
+//     saddle-extrema doesn't supply them; quadrics still passes its
+//     coefficient values explicitly.
+
+function makeOneShotPreset() {
+  return new Preset({ name: 'one-shot', grabRadiusMultiplier: 2.75 });
+}
+
+function makeStickyPreset() {
+  return new Preset({
+    name: 'sticky',
+    grabRadiusMultiplier: 2.75,
+    activeEmissive: 0x66ccdd,
+  });
+}
+
+describe('Preset.activeEmissive', () => {
+  it('a one-shot Preset (no activeEmissive) never reports isActive even after setActive(true)', () => {
+    const preset = makeOneShotPreset();
+    expect(preset.isActive).toBe(false);
+    preset.setActive(true);
+    expect(preset.isActive).toBe(false);
+  });
+
+  it('a sticky Preset (activeEmissive supplied) toggles isActive via setActive', () => {
+    const preset = makeStickyPreset();
+    expect(preset.isActive).toBe(false);
+    preset.setActive(true);
+    expect(preset.isActive).toBe(true);
+    preset.setActive(false);
+    expect(preset.isActive).toBe(false);
+  });
+
+  it('sibling deactivation: setActive(true) on one + setActive(false) on the other leaves only the first lit', () => {
+    const a = makeStickyPreset();
+    const b = makeStickyPreset();
+    a.setActive(true);
+    b.setActive(true);
+    expect(a.isActive).toBe(true);
+    expect(b.isActive).toBe(true);
+    // Sibling-deactivation pattern: the scene drives state, not Preset.
+    a.setActive(false);
+    expect(a.isActive).toBe(false);
+    expect(b.isActive).toBe(true);
+  });
+
+  it('setActive(true) is idempotent on a sticky Preset already active', () => {
+    const preset = makeStickyPreset();
+    preset.setActive(true);
+    expect(preset.isActive).toBe(true);
+    preset.setActive(true);
+    expect(preset.isActive).toBe(true);
+  });
+
+  it('values defaults to [0,0,0,0] when not supplied (saddle-extrema-style construction)', () => {
+    const preset = makeStickyPreset();
+    expect(preset.values).toEqual([0, 0, 0, 0]);
+    expect(preset.linearValues).toEqual([0, 0, 0]);
+  });
+
+  it('values + linearValues are preserved when supplied (quadrics-style construction)', () => {
+    const preset = new Preset({
+      name: 'quadrics-style',
+      grabRadiusMultiplier: 2.75,
+      values: [1, 1, 1, -1],
+      linearValues: [0, 0, -1],
+    });
+    expect(preset.values).toEqual([1, 1, 1, -1]);
+    expect(preset.linearValues).toEqual([0, 0, -1]);
+  });
+});


### PR DESCRIPTION
Refs #201, #188. Independent of #215/#216/#217.

## Summary

Adds an optional `activeEmissive?: number` field to `PresetOptions`. When supplied, the `Preset` constructor builds a per-instance `TapButtonVisuals` spread (`{ ...VISUALS, activeEmissive: opts.activeEmissive }`) so the wrapped `TapButton`'s sticky-active branch lights up on `setActive(true)`. When omitted (quadrics' use case), the existing module-level `VISUALS` constant is passed through unchanged — the no-activeEmissive path is bit-identical to before.

Saddle-extrema migrates from `new TapButton(PRESET_BUTTON_VISUALS, ...)` to `new Preset({ ..., activeEmissive: 0x66ccdd })` and deletes its local `PRESET_BUTTON_VISUALS` constant. `setActive(true)` / `setActive(false)` are inherited from `TapButton` unchanged — `Preset` does not self-toggle on tap; the scene drives active state (as before).

The previously-required `values: PresetValues` field on `PresetOptions` becomes optional (defaults to `[0, 0, 0, 0]`) so non-quadrics scenes can use `Preset` for its visual identity without surfacing a coefficients-as-tuples model they don't have. Quadrics still passes `values` explicitly; saddle-extrema doesn't.

### Why the explicit spread

v2 of the plan hand-waved "forwards activeEmissive into super(VISUALS)" — the second-Sonnet sanity check on v2 returned HOLD because `Preset.constructor` actually passed the module-level `VISUALS` constant directly. Without an explicit per-instance spread, the new option would compile clean but be silently ignored at runtime. The v3 plan locks the explicit gated spread shown in `Preset.ts:74-80`.

**Visual diff: zero.** Saddle-extrema's resulting `TapButtonVisuals` is bit-identical to its pre-PR-6 `PRESET_BUTTON_VISUALS` local.

PR 6 of 6 in the #201 consolidation pass.

## Test plan

- [x] `npm run build` (tsc + Vite) — passes.
- [x] `npm test` — 434/434 passing (428 prior + 6 new Preset assertions).
- [x] `npm run lint` — clean.
- New `test/scaffold/ui/Preset.test.ts` covers:
  - One-shot Preset (no `activeEmissive`): `setActive(true)` flips the internal flag but `isActive` stays `false` (matches `TapButton`'s "can't show active ⇒ can't *be* active" contract at `TapButton.ts:131-133`).
  - Sticky Preset (`activeEmissive` supplied): `isActive` toggles with `setActive`.
  - Sibling deactivation pattern (the saddle-extrema scene's flow).
  - Idempotent `setActive(true)`.
  - `values` + `linearValues` defaults vs. explicit values.
- [x] Cloudflare PR preview: navigate to saddle-extrema, tap each preset, confirm the active button's cyan emissive matches the pre-PR-6 visual; previously-active sibling deactivates; tapping the already-active preset doesn't thrash visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)