### PR TITLE
docs(design): cluster design-language rules + per-scene alignment

### DIFF
--- a/src/exhibits/gradient-levels/SPEC.md
+++ b/src/exhibits/gradient-levels/SPEC.md
@@ -361,3 +361,41 @@ at the apex. Three concerns:
   non-quadric f presets are a v0.7-polish or v0.8+ idea.
 - **Floor** — the family extends to ±math-Z (vertically); a floor would
   need to be hole-punched. Plain shell-bg surface is cleaner.
+
+## Design-language alignment (#201)
+
+Scene inherits the quadrics-locked design language with one
+intentional architectural departure (opaque raymarched surface vs.
+flat translucent overlays — see exceptions). Rules live in
+`scaffold/design/tokens.ts`'s header.
+
+**Scaffold tokens consumed (post-#201):**
+
+- `scaffold/ui/readoutTokens.ts` (PR 2) — `GradientLevelsReadout`'s
+  font size, line pitch, outline, and 30-Hz sync throttle.
+- `scaffold/ui/clusterRackTokens.ts` (PR 4) — rack center (via
+  `createSliderRackCenter()`), row pitch, snap detent, grab-radius
+  multiplier, and per-slider label (#170) layout.
+- **Does NOT consume `scaffold/render/translucentRectTokens.ts`** —
+  see the architectural exception below.
+
+**Readout visibility-bootstrap policy:** `GradientLevelsReadout`
+boots `group.visible = false` and uncloaks on the first `setValues`
+call. Adopted during the initial-mount design in #166; #201 PR 3
+brought the two earlier readouts in line with this pattern.
+
+**Documented exceptions:**
+
+- **Opaque raymarched surface, NOT a translucent overlay.** The
+  level surface IS the scene's primary geometry, rendered as an
+  opaque raymarched implicit surface via `createImplicitSurface`.
+  The cluster's translucent #113 recipe is for *overlays* on top of
+  another surface (quadrics' slicing planes, tangent-planes' tangent
+  plane, saddle-extrema's Taylor patch). Intentional architectural
+  divergence; not a drift to reconcile.
+- **Neutral-gray slider thumbs (θ/φ/k).** All three are non-axis-
+  coordinate parameters — θ/φ select a point on the active level
+  surface, k sweeps the family. Per the slider tint rule, non-axis-
+  coordinate sliders stay neutral gray (`0xaaaaaa`).
+- **No preset rack.** The f-family is fixed; k is the family
+  parameter as a slider rather than a preset rack.

--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -330,3 +330,48 @@ them.
 - Per-axis labels and *measurement* gridlines (numbered tick marks on
   the world axes). Distinct from v0.1's decorative depth-cue gridlines
   (above) — those are unlabeled and exist purely for parallax.
+
+## Design-language alignment (#201)
+
+The quadrics manipulator is the inherited template for the cluster's
+design language — every other scene's "Design-language alignment"
+section cross-references this one. v0.9 lifted the duplicated locals
+into shared scaffold tokens; the rules are documented in
+`scaffold/design/tokens.ts`'s header comment.
+
+**Scaffold tokens consumed (post-#201):**
+
+- `scaffold/render/translucentRectTokens.ts` (PR 1) — `SlicingPlane`'s
+  body / rim colors, alphas, and rim width come from the locked #113
+  recipe.
+- `scaffold/ui/readoutTokens.ts` (PR 2) — `EquationReadout`'s font
+  size, line pitch, outline, and 30-Hz sync throttle.
+- `scaffold/ui/clusterRackTokens.ts` (PR 4) — `SLIDER_RACK_CENTER`
+  (via `createSliderRackCenter()`), row pitch, snap detent,
+  grab-radius multiplier.
+
+**Readout visibility-bootstrap policy:** `EquationReadout` boots
+`group.visible = false` and uncloaks on the first `setValues` call
+(#201 PR 3). This is the *whole-readout* boot policy. The pre-existing
+**hide-on-zero per-slot reflow** (#95) is a separate axis — per-slot
+conditional visibility based on coefficient zero-ness, fires on every
+`setValues` after bootstrap; unaffected by the boot policy.
+
+**Documented exceptions to the cluster's design-language rules:**
+
+- **No per-slider labels (#170 not applied).** The 10-slider rack
+  (4 squared + 3 linear + 3 cross-section) is dense enough that
+  per-slider labels would crowd the rack; the live equation readout
+  above the rack carries the coefficient values instead. Cluster
+  siblings with 2–3-slider racks use #170 labels.
+- **Axis-colored slider thumbs.** Every slider's value IS a named
+  coefficient on a named axis: `a/b/c` and `u/v/w` are tinted by axis
+  (VERMILLION/BLUISH_GREEN/SKY_BLUE), `d` is YELLOW (the "important
+  math fact at a point" tint applied to the constant term).
+  `x₀/y₀/z₀` cross-section sliders reuse axis tints per axis. Matches
+  the slider tint rule in `tokens.ts`.
+- **Preset row stays one-shot.** Quadrics' presets are snap-to-pose:
+  press flash IS the feedback. `Preset` constructed without
+  `activeEmissive` (#201 PR 6 added the option for sticky-active
+  scenes; quadrics doesn't pass it). Sticky-active is documented in
+  saddle-extrema's "Design-language alignment" section.

--- a/src/exhibits/saddle-extrema/SPEC.md
+++ b/src/exhibits/saddle-extrema/SPEC.md
@@ -669,3 +669,56 @@ resources with the main `graphSurface` mesh.
   lesson; cubic would address the monkey-saddle and quartic-min
   degenerate cases but the visual machinery doubles in size and the
   pedagogical lift is unclear.
+
+## Design-language alignment (#201)
+
+Scene inherits the quadrics-locked design language with two
+intentional pedagogy-driven exceptions (TaylorOverlay rim width and
+Lambert shading — see below). Rules live in
+`scaffold/design/tokens.ts`'s header.
+
+**Scaffold tokens consumed (post-#201):**
+
+- `scaffold/render/translucentRectTokens.ts` (PR 1) —
+  `TaylorOverlay`'s body / rim colors and alphas come from the
+  locked #113 recipe; rim width is scene-local (see exceptions).
+- `scaffold/ui/readoutTokens.ts` (PR 2) — `SaddleExtremaReadout`'s
+  font size, line pitch, outline, and 30-Hz sync throttle.
+- `scaffold/ui/clusterRackTokens.ts` (PR 4) — rack center (via
+  `createSliderRackCenter()`), row pitch, snap detent, grab-radius
+  multiplier, and per-slider label (#170) layout.
+- `scaffold/ui/Preset.ts` (PR 6) — preset row uses `Preset` with the
+  new `activeEmissive` option for sticky-active behavior.
+
+**Readout visibility-bootstrap policy:** `SaddleExtremaReadout`
+boots `group.visible = false` and uncloaks on the first `setValues`
+call. Adopted during the initial-mount design in #181; matches the
+cluster-wide policy locked in #201 PR 3.
+
+**Documented exceptions:**
+
+- **Axis-colored slider thumbs.** x and y are direct math-frame
+  axis-coordinate selectors — the indicator's `(x, y)` IS the slider
+  values. Per the slider tint rule, axis-coordinate sliders get the
+  axis tint: x → VERMILLION, y → BLUISH_GREEN. Matches quadrics'
+  pattern; departs from tangent-planes / gradient-levels' neutral
+  gray (those sliders are point selectors / family parameters, not
+  axis coordinates).
+- **TaylorOverlay rim width 0.015 m** vs. the scaffold default
+  `LOCKED_113_RIM_WIDTH_DEFAULT = 0.05` m. The overlay's half-extent
+  is ~0.30 m (vs. ~3.5 m for the slicing planes); a 0.05 m rim on
+  the smaller patch dominates the curvature read this overlay is
+  designed to teach. Pedagogy-driven exception, documented at the
+  override site (`TaylorOverlay.ts` near `OVERLAY_RIM_WIDTH`).
+- **TaylorOverlay Lambert shading on body.** Body has subtle
+  ambient (0.6) + diffuse (0.4) shading so curvature reads. The
+  cluster's flat translucent overlays (SlicingPlane, TangentPlane)
+  are flat-lit. The overlay's purpose is teaching local *shape*
+  (bowl up / bowl down / saddle / degenerate); flat-lit reads as a
+  uniform tint that hides the very shape the overlay teaches.
+- **Sticky-active preset row.** Saddle-extrema's presets are
+  persistent surface-family selectors (the surface IS the preset's
+  f), not one-shot snaps like quadrics'. `Preset` constructed with
+  `activeEmissive: 0x66ccdd` (#201 PR 6); scene drives
+  `setActive(true)` on tap and `setActive(false)` on the previously-
+  active sibling.

--- a/src/exhibits/tangent-planes/SPEC.md
+++ b/src/exhibits/tangent-planes/SPEC.md
@@ -253,3 +253,36 @@ indicator.
 - **Ray-origin choice for translated quadrics.** Currently fixed at the
   surface-local origin, which works only because the unit sphere
   encloses it. Note for any future surface that doesn't.
+
+## Design-language alignment (#201)
+
+Scene inherits the quadrics-locked design language. Rules live in
+`scaffold/design/tokens.ts`'s header; quadrics' SPEC.md
+"Design-language alignment" section is the source-of-truth template.
+
+**Scaffold tokens consumed (post-#201):**
+
+- `scaffold/render/translucentRectTokens.ts` (PR 1) — `TangentPlane`'s
+  body / rim colors, alphas, and rim width come from the locked #113
+  recipe.
+- `scaffold/ui/readoutTokens.ts` (PR 2) — `TangentPlaneReadout`'s
+  font size, line pitch, outline, and 30-Hz sync throttle.
+- `scaffold/ui/clusterRackTokens.ts` (PR 4) — rack center (via
+  `createSliderRackCenter()`), row pitch, snap detent, grab-radius
+  multiplier, and per-slider label (#170) layout.
+
+**Readout visibility-bootstrap policy:** `TangentPlaneReadout` boots
+`group.visible = false` and uncloaks on the first `setValues` call
+(#201 PR 3). No hide-on-zero reflow — the textbook identity
+`(x − 0.00)` reads correctly at exact zero, so eliding zero terms
+would obscure the form.
+
+**Documented exceptions:**
+
+- **Neutral-gray slider thumbs.** θ and φ are point selectors on a
+  unit sphere — they parameterize the math abstractly, not as axis
+  coordinates. Per the slider tint rule in `tokens.ts`, non-axis-
+  coordinate sliders stay neutral gray (`0xaaaaaa`).
+- **No preset rack.** The surface is fixed (unit sphere); no preset
+  archetypes to select.
+- **No section rack.** Single point-selection lens.

--- a/src/scaffold/design/tokens.ts
+++ b/src/scaffold/design/tokens.ts
@@ -9,6 +9,69 @@
 // quadrics cluster (manipulator, tangent planes, gradient/level
 // surfaces, saddle/extrema). Add more here if a future scene
 // genuinely needs a fifth distinguishable channel.
+//
+// ─────────────────────────────────────────────────────────────────────
+// Design-language rules (#201 — applied across the four cluster
+// scenes and inherited as the template for post-1.0 portfolio
+// additions)
+// ─────────────────────────────────────────────────────────────────────
+//
+// Color convention:
+//   VERMILLION   = math-X axis identity
+//   BLUISH_GREEN = math-Y axis identity
+//   SKY_BLUE     = math-Z axis identity
+//   YELLOW       = "important math fact at a point" — used for scalar
+//                  values that summarize geometric meaning (constant
+//                  terms, magnitudes, classification verdicts, marker
+//                  glyphs).
+//
+// Slider tint rule:
+//   A slider whose value IS the named axis coordinate gets the axis
+//   tint (quadrics' a/b/c → axis colors; saddle-extrema's x/y →
+//   VERMILLION / BLUISH_GREEN). A slider that's a point selector or a
+//   family parameter (tangent-planes' θ/φ; gradient-levels' θ/φ/k)
+//   stays neutral gray (0xaaaaaa). The distinction communicates "this
+//   knob moves THIS axis" vs. "this knob parameterizes the math
+//   abstractly." Per-scene exceptions documented in each scene's
+//   SPEC.md "Design-language alignment" section.
+//
+// Translucent overlay recipe:
+//   See scaffold/render/translucentRectTokens.ts for the locked #113
+//   body+rim recipe (body at on-surface ring color, rim one tone
+//   lighter). Default rim width is the scaffold constant
+//   LOCKED_113_RIM_WIDTH_DEFAULT (0.05 m). Scenes pedagogically
+//   requiring a tighter rim — saddle-extrema's TaylorOverlay (0.015
+//   m on a smaller half-extent so the rim doesn't dominate the
+//   curvature read) — override locally with a cross-reference
+//   comment at the override site.
+//
+// Slider rack geometry + design feel:
+//   See scaffold/ui/clusterRackTokens.ts. Rack center, row pitch,
+//   snap detent, grab-radius multiplier, and per-slider label
+//   (#170) layout are bit-identical across the cluster. The
+//   THREE.Vector3 rack center is exported as an immutable
+//   coordinate tuple + a factory function (no shared mutable
+//   THREE-instance singletons); each scene constructs a fresh
+//   per-file Vector3 from the factory at module-load.
+//
+// Readout typography + bootstrap:
+//   See scaffold/ui/readoutTokens.ts for font size, line pitch,
+//   outline, and 30-Hz sync throttle. All four cluster readouts use
+//   identical values. Visibility-bootstrap policy: boot-hidden,
+//   uncloak after the first real state sync (`setValues`) has run
+//   its layout reflow + an unthrottled `Text.sync()`. Locked in
+//   #201 PR 3.
+//
+// Preset semantics:
+//   `Preset` from scaffold/ui/Preset.ts is one-shot by default
+//   (press flash IS the feedback; quadrics' use case). For
+//   persistent surface-family selectors (saddle-extrema's preset
+//   row), pass `activeEmissive` to `PresetOptions` and have the
+//   owning scene drive `setActive(true)` + `setActive(false)`-on-
+//   sibling. Preset does NOT self-toggle on tap; the scene owns
+//   active-state.
+//
+// ─────────────────────────────────────────────────────────────────────
 
 export const VERMILLION = 0xd55e00;
 export const BLUISH_GREEN = 0x009e73;


### PR DESCRIPTION
Closes #201 (consolidation pass) when merged after PRs 1-4 + 6 land. Doc-only.

## Summary

Documentation pass closing out the #201 cross-cluster design-language consolidation. **Hard stop-rule scope** per the v3 plan §3.5: touches only `scaffold/design/tokens.ts` (one header comment block) + the four scene `SPEC.md` files (one "Design-language alignment" section each). No code changes; no other file edits.

### `tokens.ts` header

New "Design-language rules" section documenting the cluster's shared vocabulary as the inherited template for post-1.0 portfolio additions:

- Color convention (VERMILLION / BLUISH_GREEN / SKY_BLUE / YELLOW).
- Slider tint rule (axis-coordinate sliders get axis tint; point-selectors / family-parameters stay neutral gray).
- Translucent overlay recipe + scene-local rim-width override pattern.
- Slider rack geometry + design feel (immutable tuple + factory pattern).
- Readout typography + visibility-bootstrap policy.
- Preset semantics (one-shot default; sticky-active via `PresetOptions.activeEmissive`).

### Per-scene SPEC.md sections

Each scene gains a `## Design-language alignment (#201)` section listing:

- Which scaffold tokens the scene imports.
- The scene's readout visibility-bootstrap behavior + any per-scene secondary policies.
- Documented intentional exceptions to the cluster's rules.

Quadrics' section is the source-of-truth template; the others cross-reference it.

**Visual diff:** zero (doc-only). PR 5 of 6 in the #201 consolidation pass — ships **last** by sequence per the plan §4. Its content describes the final import surface + method names + Preset API after PRs 1–4 + 6 are settled.

## Test plan

- [x] `npm run build` (tsc + Vite) — passes (doc-only diff).
- [x] `npm run lint` — clean.
- [x] `npm test` — 434/434 passing on prior branches; no test impact here.
- [x] Cloudflare PR preview: no visual change expected.

## Merge sequencing

This PR is intentionally last to land. Merging the prior 5 PRs in any order is fine (none conflict on different regions of overlapping files); this one ships when the rest are settled so the SPEC alignment sections describe what's actually shipped, not a moving target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)