### PR TITLE
feat(staging): lift quadrics floor to StageFloor primitive (#222)

### DIFF
--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -375,3 +375,19 @@ conditional visibility based on coefficient zero-ness, fires on every
   `activeEmissive` (#201 PR 6 added the option for sticky-active
   scenes; quadrics doesn't pass it). Sticky-active is documented in
   saddle-extrema's "Design-language alignment" section.
+
+### Staging (#222 / E1.1)
+
+Floor: shared `StageFloor` primitive from `src/scaffold/staging/`,
+10 × 10 m outer extent, dark navy `0x222244`. Rectangular cutout
+sized to the AABB (`±BOUND = ±3.5 m` in math-frame coords, centered
+on `SURFACE_CENTER.xz`). The cutout exits the outer floor on the
+−Z side; the strip primitive handles this naturally (the "behind"
+strip is degenerate and dropped at `addStrip`'s early-return).
+
+Originally lifted from the per-exhibit `floorMaterial` +
+`floorGeometries` construction at `quadrics/index.ts:806–839` (#125,
+v0.5); refactored into the shared primitive in #222 with zero visual
+change. Future cluster-wide rollout to the other three scenes lives
+in #238 — the cutout-as-projection-aperture vs dipping-hole UX
+decision is owned there, not here.

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -19,6 +19,7 @@ import { Preset, type LinearPresetValues, type PresetValues } from '@/scaffold/u
 import { PresetTween } from '@/scaffold/anim/PresetTween';
 import { createImplicitSurface } from '@/scaffold/render/ImplicitSurface';
 import { RendererInfoProbe } from '@/scaffold/perf/RendererInfoProbe';
+import { createStageFloor, type StageFloorHandles } from '@/scaffold/staging/StageFloor';
 import { Section } from '@/scaffold/ui/Section';
 import { SectionTab } from '@/scaffold/ui/SectionTab';
 import { Slider, type ThumbShape } from '@/scaffold/ui/Slider';
@@ -776,23 +777,20 @@ let presetTween: PresetTween | undefined;
 //
 // Ownership rule: each resource has exactly one disposal owner. Named
 // handles (`material`, `surfaceMesh.geometry`, `doublePlane`, `slicingPlanes`,
-// `floorMaterial`) are NEVER pushed into the generic `ownedDisposables` /
+// `stageFloor`) are NEVER pushed into the generic `ownedDisposables` /
 // `ownedGeometries` / `ownedMaterials` arrays — they're disposed via the
 // dedicated named-handle block in `unmount`. The generic arrays are
 // reserved for resources whose lifecycle is otherwise unmanaged: scaffold
 // primitives that expose `dispose()` (Sliders, Presets, Sections, etc.)
 // flow through `ownedDisposables`; anonymous geometries or materials
 // allocated inline flow through the corresponding `*Geometries` /
-// `*Materials` arrays. `floorMaterial` + `floorGeometries` have their own
-// dedicated handles (one shared material across all strips, one geometry
-// per strip) and are disposed by the named-handle block, not via
-// `ownedMaterials` / `ownedGeometries`.
+// `*Materials` arrays. `stageFloor` is a `StageFloorHandles` whose
+// `dispose()` owns the floor's material + per-strip geometries.
 let ownedDisposables: Array<{ dispose(): void }> = [];
 let ownedGeometries: THREE.BufferGeometry[] = [];
 let ownedMaterials: THREE.Material[] = [];
 let cleanupCallbacks: Array<() => void> = [];
-let floorMaterial: THREE.MeshStandardMaterial | undefined;
-let floorGeometries: THREE.PlaneGeometry[] = [];
+let stageFloor: StageFloorHandles | undefined;
 
 const quadricsExhibit: Exhibit = {
   id: 'quadrics',
@@ -803,40 +801,27 @@ const quadricsExhibit: Exhibit = {
     camera = cam;
     pointers = shellPointers;
 
-    // #125: hole-punch the floor inside the AABB's world-XZ footprint so it
-    // doesn't occlude the lower half of the cube. Math-Z routes to world-Y;
-    // with SURFACE_CENTER.y = 1.5 and BOUND = 3.5, the cube's bottom face sits
-    // at world-Y = -2 while the floor sits at 0, cutting off math-Z ∈
-    // [-3.5, -1.5] (most visible on vertical 2-sheet hyperboloids and 1-sheet
-    // hyperboloids whose axis is math-Z). Strips outside the cube footprint
-    // preserve the ground reference; the rectangle inside is left open.
-    const FLOOR_HALF = 5;
-    floorMaterial = new THREE.MeshStandardMaterial({ color: 0x222244 });
-    const holeMinX = Math.max(SURFACE_CENTER.x - BOUND, -FLOOR_HALF);
-    const holeMaxX = Math.min(SURFACE_CENTER.x + BOUND, FLOOR_HALF);
-    const holeMinZ = Math.max(SURFACE_CENTER.z - BOUND, -FLOOR_HALF);
-    const holeMaxZ = Math.min(SURFACE_CENTER.z + BOUND, FLOOR_HALF);
-    const addFloorStrip = (
-      xMin: number,
-      xMax: number,
-      zMin: number,
-      zMax: number,
-    ): void => {
-      if (xMax <= xMin || zMax <= zMin) return;
-      const stripGeometry = new THREE.PlaneGeometry(xMax - xMin, zMax - zMin);
-      // Push to module-scoped `floorGeometries` so unmount can dispose
-      // each strip's geometry. The shared `floorMaterial` is the named
-      // handle — disposed once, regardless of strip count (#150 §3.5).
-      floorGeometries.push(stripGeometry);
-      const strip = new THREE.Mesh(stripGeometry, floorMaterial!);
-      strip.rotation.x = -Math.PI / 2;
-      strip.position.set((xMin + xMax) / 2, 0, (zMin + zMax) / 2);
-      group.add(strip);
-    };
-    addFloorStrip(-FLOOR_HALF, FLOOR_HALF, holeMaxZ, FLOOR_HALF); // front of cube
-    addFloorStrip(-FLOOR_HALF, FLOOR_HALF, -FLOOR_HALF, holeMinZ); // behind cube
-    addFloorStrip(-FLOOR_HALF, holeMinX, holeMinZ, holeMaxZ); // left of cube
-    addFloorStrip(holeMaxX, FLOOR_HALF, holeMinZ, holeMaxZ); // right of cube
+    // Floor + cutout via the shared `StageFloor` primitive (#222 / E1.1).
+    // The cutout is an AABB-aligned rect around the implicit surface so
+    // the floor doesn't occlude the lower half of the cube. Math-Z routes
+    // to world-Y; with SURFACE_CENTER.y = 1.5 and BOUND = 3.5, the cube's
+    // bottom face sits at world-Y = -2 while the floor sits at 0, cutting
+    // off math-Z ∈ [-3.5, -1.5] (most visible on vertical 2-sheet
+    // hyperboloids and 1-sheet hyperboloids whose axis is math-Z). The
+    // primitive's strip decomposition handles the boundary-exceeding case
+    // naturally (hole z range [-7.5, -0.5] vs floor z range [-5, 5] — the
+    // "behind" strip is degenerate and dropped). See #125 for the original
+    // hole-punch rationale and `_private/plans/222-staging-floor-cutout.md`
+    // for the lift plan.
+    stageFloor = createStageFloor({
+      cutout: {
+        kind: 'rect',
+        centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z],
+        halfExtentX: BOUND,
+        halfExtentZ: BOUND,
+      },
+    });
+    group.add(stageFloor.group);
 
     group.add(new THREE.AmbientLight(0xffffff, 0.4));
     const directional = new THREE.DirectionalLight(0xffffff, 0.8);
@@ -1158,9 +1143,9 @@ const quadricsExhibit: Exhibit = {
     // Register owned scaffold primitives for unmount disposal (#150 §3.5).
     // Per the ownership rule: only primitives go into `ownedDisposables`;
     // the named handles (material, surfaceMesh.geometry, doublePlane,
-    // slicingPlanes, floorMaterial, floorGeometries) are disposed by the
-    // dedicated named-handle block in `unmount`. dSlider aliases sliders[3],
-    // so it's already covered by `...sliders`.
+    // slicingPlanes, stageFloor) are disposed by the dedicated named-handle
+    // block in `unmount`. dSlider aliases sliders[3], so it's already
+    // covered by `...sliders`.
     ownedDisposables.push(
       ...sliders,
       ...linearSliders,
@@ -1384,12 +1369,10 @@ const quadricsExhibit: Exhibit = {
 
     // 3. Named handles — disposed directly, each guarded so a double
     // unmount is safe (DeepSeek #5 / v3-roundtable).
-    if (floorMaterial) {
-      floorMaterial.dispose();
-      floorMaterial = undefined;
+    if (stageFloor) {
+      stageFloor.dispose();
+      stageFloor = undefined;
     }
-    for (const g of floorGeometries) g.dispose();
-    floorGeometries = [];
     if (material) {
       material.dispose();
       material = undefined;

--- a/src/scaffold/staging/StageFloor.ts
+++ b/src/scaffold/staging/StageFloor.ts
@@ -1,0 +1,117 @@
+import * as THREE from 'three';
+
+// Cluster-wide floor primitive for the v1.0 staged-exhibit vocabulary
+// (#221 / E1.1, #222). Lifted from quadrics' resident floor + AABB
+// hole-punch implementation (#125) into the shared `scaffold/staging/`
+// namespace so future cluster scenes can opt in without duplicating
+// the strip-decomposition logic.
+//
+// Implementation strategy: 4-strip-with-clamping. The hole rectangle
+// is clamped to the outer floor's bounds via Math.max/min, then 4
+// strips are constructed around it (front / behind / left / right of
+// hole). Degenerate strips (zero or negative area after clamp) early-
+// return from addStrip. Handles boundary-exceeding cutouts naturally,
+// which `THREE.ShapeGeometry` with hole subtraction would not — earcut
+// requires holes to be strictly interior to the outer contour.
+//
+// Ownership (per `_private/plans/v1.0.md` §4 staging rules): exhibit-
+// owned. Per-scene cutout descriptor; allocated in `mount`, disposed
+// in `unmount`. The shell removes `ctx.group` after `unmount` returns
+// (shell.ts:471–472), so dispose() only releases owned GPU resources;
+// no `scene.remove(...)` calls.
+//
+// Future API extensions tracked in #238 (cluster-wide cutout decision):
+// `kind: 'circle'` descriptor variant + a ShapeGeometry-with-holes
+// code path for strictly-interior cutouts.
+
+export const STAGE_FLOOR_COLOR_RGB = [
+  0x22 / 255,
+  0x22 / 255,
+  0x44 / 255,
+] as const;
+
+export const STAGE_FLOOR_OUTER_HALF_DEFAULT = 5;
+
+/**
+ * Cutout descriptor for the floor. Today's only variant is `rect`;
+ * `circle` will be added via #238 when the tangent-planes /
+ * gradient-levels / saddle-extrema floor question is resolved
+ * (cutout-as-projection-aperture vs dipping-hole).
+ *
+ * Coordinates are in world XZ — the primitive constructs strips
+ * directly in that frame, so callers don't need to reason about any
+ * local-XY-vs-world-XZ rotation. The strips are rotated -π/2 about
+ * world-X to lie on the floor plane.
+ */
+export type StageCutoutDescriptor = {
+  readonly kind: 'rect';
+  readonly centerXZ: readonly [number, number];
+  readonly halfExtentX: number;
+  readonly halfExtentZ: number;
+};
+
+export interface StageFloorOptions {
+  readonly cutout: StageCutoutDescriptor;
+  /** Default `STAGE_FLOOR_OUTER_HALF_DEFAULT` (5 m → 10 × 10 m floor). */
+  readonly outerHalfExtent?: number;
+}
+
+export interface StageFloorHandles {
+  /** Add to the exhibit's group at mount time. */
+  readonly group: THREE.Group;
+  /** Outer half-extent in world units; E1.2 (#223) railing composes against this. */
+  readonly outerHalfExtent: number;
+  /** Disposes owned geometries + material. Exhibit calls in unmount(). */
+  dispose(): void;
+}
+
+export function createStageFloor(opts: StageFloorOptions): StageFloorHandles {
+  const outer = opts.outerHalfExtent ?? STAGE_FLOOR_OUTER_HALF_DEFAULT;
+  const [cx, cz] = opts.cutout.centerXZ;
+  const { halfExtentX, halfExtentZ } = opts.cutout;
+
+  const holeMinX = Math.max(cx - halfExtentX, -outer);
+  const holeMaxX = Math.min(cx + halfExtentX, outer);
+  const holeMinZ = Math.max(cz - halfExtentZ, -outer);
+  const holeMaxZ = Math.min(cz + halfExtentZ, outer);
+
+  const material = new THREE.MeshStandardMaterial({
+    color: new THREE.Color(...STAGE_FLOOR_COLOR_RGB),
+  });
+  const geometries: THREE.PlaneGeometry[] = [];
+  const group = new THREE.Group();
+  group.name = 'stage-floor';
+
+  const addStrip = (
+    xMin: number,
+    xMax: number,
+    zMin: number,
+    zMax: number,
+  ): void => {
+    if (xMax <= xMin || zMax <= zMin) return;
+    const stripGeometry = new THREE.PlaneGeometry(xMax - xMin, zMax - zMin);
+    geometries.push(stripGeometry);
+    const strip = new THREE.Mesh(stripGeometry, material);
+    strip.rotation.x = -Math.PI / 2;
+    strip.position.set((xMin + xMax) / 2, 0, (zMin + zMax) / 2);
+    group.add(strip);
+  };
+
+  addStrip(-outer, outer, holeMaxZ, outer); // front of hole
+  addStrip(-outer, outer, -outer, holeMinZ); // behind hole
+  addStrip(-outer, holeMinX, holeMinZ, holeMaxZ); // left of hole
+  addStrip(holeMaxX, outer, holeMinZ, holeMaxZ); // right of hole
+
+  let disposed = false;
+  return {
+    group,
+    outerHalfExtent: outer,
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      material.dispose();
+      for (const g of geometries) g.dispose();
+      geometries.length = 0;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

First member of the new `src/scaffold/staging/` namespace — the v1.0 staged-exhibit vocabulary (#221 / E1.1, #222). Lifts quadrics' existing 4-strip-with-clamping floor + AABB hole-punch (#125, v0.5) into a shared primitive without changing the visual.

- New `src/scaffold/staging/StageFloor.ts` — factory returning `{ group, outerHalfExtent, dispose }`. Strip-based implementation handles boundary-exceeding cutouts naturally via `Math.max/min` clamping + degenerate-strip early-return.
- `src/exhibits/quadrics/index.ts` — swaps the in-line floor construction + dispose for a single `createStageFloor(...)` call; module-scope `floorMaterial` / `floorGeometries` replaced by a single `stageFloor: StageFloorHandles | undefined` named handle.
- `src/exhibits/quadrics/SPEC.md` — new "Staging (#222 / E1.1)" sub-section under "Design-language alignment."

**Net visual change: zero.** Same color (`0x222244`), same outer extent (10 × 10 m), same strip decomposition, same boundary-exceeding behavior (the "behind" strip is degenerate and dropped per the existing #125 logic).

## Scope

Quadrics only. Cluster-wide rollout to tangent-planes / gradient-levels / saddle-extrema is **deferred to #238**, which owns the cutout-as-projection-aperture vs dipping-hole UX decision. Roundtable on the v1 plan surfaced that the original "cutout = hole through which math dips below floor" premise only unambiguously holds for quadrics (sphere bottom at world Y=0.5 with floor at Y=0; some saddle-extrema presets stay above floor entirely).

The API is forward-designed (`StageCutoutDescriptor` is a sum-type with `kind: 'rect'`) so a future `kind: 'circle'` variant and an interior-hole code path can be added without an API break.

## Test plan

- [x] `npm run build` clean (TypeScript + Vite).
- [x] `npm test -- --run` — 440 tests pass.
- [x] `pre-commit run --all-files` — gitleaks + eslint clean.
- [ ] **Headset smoke (Cloudflare PR preview):** boot to `?exhibit=quadrics` and verify the floor renders identically to current main: dark navy color, hole-punch aligned with the AABB, "behind" strip absent (floor opens to back edge).
- [ ] **Mount → unmount → re-mount leak check:** with `?fps=1` enabled, tether Quest via `chrome://inspect`, note the `[renderer.info]` line after quadrics boots, switch via SceneRack to any other scene, switch back, verify `calls` + `triangles` return to baseline within ±1. `programs` may differ due to shader cache — note but don't gate.
- [ ] **Pancake (desktop) smoke:** default OrbitControls pose at 1920×1080 shows the floor in frame without manual orbit; ≥60fps under normal interaction.
- [ ] **72Hz hold preserved** on Quest 3S.

## Related

- Parent epic: #221 (v1.0 staged-exhibit vocabulary).
- Follow-up: #238 (apply `StageFloor` to remaining three scenes; cutout-UX decision).
- v1.0 master plan + roundtable history captured in `_private/plans/v1.0.md` + `_private/plans/222-staging-floor-cutout.md` (not in repo per the `_private/` gitignore convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)