### PR TITLE
feat(staging): cluster-wide StageFloor + circle cutout (#238)

### DIFF
--- a/src/exhibits/gradient-levels/SPEC.md
+++ b/src/exhibits/gradient-levels/SPEC.md
@@ -359,8 +359,12 @@ at the apex. Three concerns:
   would mean new uniforms + extended exports, not a structural change.
 - **Alternate f presets** — quadric is the natural family for v0.7;
   non-quadric f presets are a v0.7-polish or v0.8+ idea.
-- **Floor** — the family extends to ±math-Z (vertically); a floor would
-  need to be hole-punched. Plain shell-bg surface is cleaner.
+- ~~**Floor** — the family extends to ±math-Z (vertically); a floor would
+  need to be hole-punched. Plain shell-bg surface is cleaner.~~ **Lifted
+  by #238 (E1.1):** floor + cutout shipped via the shared `StageFloor`
+  primitive — see the "Staging (#238 / E1.1)" sub-section under
+  "Design-language alignment" below for the cutout-as-projection-aperture
+  framing.
 
 ## Design-language alignment (#201)
 
@@ -399,3 +403,17 @@ brought the two earlier readouts in line with this pattern.
   coordinate sliders stay neutral gray (`0xaaaaaa`).
 - **No preset rack.** The f-family is fixed; k is the family
   parameter as a slider rather than a preset rack.
+
+### Staging (#238 / E1.1)
+
+Floor: shared `StageFloor` primitive from `scaffold/staging/`,
+cluster-default `outerHalfExtent: 5` (10 × 10 m). Rectangular cutout
+sized to `±BOUND = ±3.0 m` (`kind: 'rect'`, centered on
+`SURFACE_CENTER.xz`); reads as the math-frame domain envelope
+projected onto the floor, per Path A1 (cutout-as-projection-aperture).
+The cutout reaches world Z = −7, beyond the floor's −Z edge at
+−5 — the strip approach's `Math.max/min` clamp truncates the cutout
+to the floor edge, so the floor visibly opens to the back of the
+exhibit (same shape as quadrics' shipped floor). The level surface
+dips below floor for `k ≲ -2.25`; the cutout is static at mount
+(sized to the math envelope, not the current `k`-driven extent).

--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -28,6 +28,10 @@ import {
   VERMILLION,
   YELLOW,
 } from '@/scaffold/design/tokens';
+import {
+  createStageFloor,
+  type StageFloorHandles,
+} from '@/scaffold/staging/StageFloor';
 import { createGradientArrow, type GradientArrowHandles } from './GradientArrow';
 import { GradientLevelsReadout } from './GradientLevelsReadout';
 import { BOUND, fJsRaw, gradJs } from './surfaceModel';
@@ -243,6 +247,7 @@ let thetaLabel: Label | undefined;
 let phiLabel: Label | undefined;
 let kLabel: Label | undefined;
 let worldAxes: WorldAxes | undefined;
+let stageFloor: StageFloorHandles | undefined;
 let pointers: readonly Pointer[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
 // yaw-billboarding in update().
@@ -266,6 +271,22 @@ const gradientLevelsExhibit: Exhibit = {
     const directional = new THREE.DirectionalLight(0xffffff, 0.8);
     directional.position.copy(LIGHT_DIR).multiplyScalar(5);
     group.add(directional);
+
+    // Stage floor with rect cutout sized to the math-frame domain
+    // envelope (#238 / E1.1). Cutout reaches world Z = -7, beyond the
+    // cluster-default floor's −Z edge at -5; strip approach's clamp
+    // truncates the cutout to the floor edge — visually the floor
+    // opens to the back of the exhibit. See `_private/plans/238-
+    // cluster-cutout.md` §1 for the Path A1 framing.
+    stageFloor = createStageFloor({
+      cutout: {
+        kind: 'rect',
+        centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z],
+        halfExtentX: BOUND,
+        halfExtentZ: BOUND,
+      },
+    });
+    group.add(stageFloor.group);
 
     // Implicit-surface mesh + ShaderMaterial via the shared harness. uK
     // is seeded at K_INITIAL so the surface boots at the right pose
@@ -595,6 +616,10 @@ const gradientLevelsExhibit: Exhibit = {
     phiSlider = undefined;
     worldAxes?.dispose();
     worldAxes = undefined;
+    if (stageFloor) {
+      stageFloor.dispose();
+      stageFloor = undefined;
+    }
 
     // 3. Drop external references so a re-mount starts clean. The shell
     //    removes ctx.group and its descendants automatically.

--- a/src/exhibits/saddle-extrema/SPEC.md
+++ b/src/exhibits/saddle-extrema/SPEC.md
@@ -722,3 +722,21 @@ cluster-wide policy locked in #201 PR 3.
   `activeEmissive: 0x66ccdd` (#201 PR 6); scene drives
   `setActive(true)` on tap and `setActive(false)` on the previously-
   active sibling.
+
+### Staging (#238 / E1.1)
+
+Floor: shared `StageFloor` primitive from `scaffold/staging/`,
+cluster-default `outerHalfExtent: 5` (10 × 10 m). Rectangular cutout
+sized to `±STAGE_CUTOUT_HALF` (`kind: 'rect'`, centered on
+`SURFACE_CENTER.xz`); reads as the math-frame domain envelope
+projected onto the floor, per Path A1 (cutout-as-projection-aperture).
+`STAGE_CUTOUT_HALF` is **derived at module scope** from `PRESETS` —
+`Math.max(...presets' domain half-extents)` — so a future preset
+with a wider window automatically widens the cutout at mount.
+Today's value evaluates to `1.5` (driven by the `saddle` preset at
+`±1.5`). The cutout reaches world Z = −5.5, just past the floor's
+−Z edge at −5; strip clamp truncates to the floor edge, so the
+floor visibly opens to the back of the exhibit. Static at mount —
+does not resize on preset change. Three of five presets (inv-
+paraboloid, saddle, monkey-saddle) dip below floor; the other two
+(paraboloid, quartic-min) sit above.

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -24,6 +24,10 @@ import {
 } from '@/scaffold/ui/clusterRackTokens';
 import { WorldAxes } from '@/scaffold/ui/WorldAxes';
 import {
+  createStageFloor,
+  type StageFloorHandles,
+} from '@/scaffold/staging/StageFloor';
+import {
   createCriticalPointMarkers,
   type CriticalPointMarkersHandles,
 } from './CriticalPointMarkers';
@@ -66,6 +70,21 @@ const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
 const AXIS_INDICATOR_POSITION = new THREE.Vector3(0.35, 1.17, -0.7);
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
 const BASE_COLOR = new THREE.Color(0.4, 0.7, 0.95);
+
+// Stage floor cutout half-extent (#238 / E1.1) — derived from the
+// widest preset domain so a future preset with a wider (x, y) window
+// automatically widens the cutout at mount. Today's value evaluates
+// to 1.5 (driven by the `saddle` preset at ±1.5 in `presets.ts:84`).
+const STAGE_CUTOUT_HALF = Math.max(
+  ...PRESETS.map((p) =>
+    Math.max(
+      Math.abs(p.domain.xMin),
+      p.domain.xMax,
+      Math.abs(p.domain.yMin),
+      p.domain.yMax,
+    ),
+  ),
+);
 
 // Classification readout (#181) — three lines (Hessian entries / D /
 // verdict). Anchored above the preset row (preset-row buttons cap at
@@ -161,6 +180,7 @@ let xLabel: Label | undefined;
 let yLabel: Label | undefined;
 let indicator: THREE.Mesh | undefined;
 let presetButtons: Preset[] = [];
+let stageFloor: StageFloorHandles | undefined;
 let activePresetIndex = DEFAULT_PRESET_INDEX;
 let saddleExtremaReadout: SaddleExtremaReadout | undefined;
 let camera: THREE.Camera | undefined;
@@ -196,6 +216,23 @@ const saddleExtremaExhibit: Exhibit = {
     const directional = new THREE.DirectionalLight(0xffffff, 0.8);
     directional.position.copy(LIGHT_DIR).multiplyScalar(5);
     group.add(directional);
+
+    // Stage floor with rect cutout (#238 / E1.1), sized to the widest
+    // preset domain (`STAGE_CUTOUT_HALF` derived from PRESETS — see
+    // module-scope comment). Cutout reaches world Z = -5.5, just past
+    // the cluster-default floor's −Z edge at -5; strip clamp truncates
+    // to the floor edge. Static at mount — does not resize on preset
+    // change. See `_private/plans/238-cluster-cutout.md` §3.4 for the
+    // Path A1 rationale.
+    stageFloor = createStageFloor({
+      cutout: {
+        kind: 'rect',
+        centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z],
+        halfExtentX: STAGE_CUTOUT_HALF,
+        halfExtentZ: STAGE_CUTOUT_HALF,
+      },
+    });
+    group.add(stageFloor.group);
 
     graphSurface = createGraphSurface({
       f: initialPreset.f,
@@ -470,6 +507,10 @@ const saddleExtremaExhibit: Exhibit = {
       indicator.geometry.dispose();
       (indicator.material as THREE.Material).dispose();
       indicator = undefined;
+    }
+    if (stageFloor) {
+      stageFloor.dispose();
+      stageFloor = undefined;
     }
 
     // 3. Drop external references so a re-mount starts clean.

--- a/src/exhibits/tangent-planes/SPEC.md
+++ b/src/exhibits/tangent-planes/SPEC.md
@@ -286,3 +286,21 @@ would obscure the form.
 - **No preset rack.** The surface is fixed (unit sphere); no preset
   archetypes to select.
 - **No section rack.** Single point-selection lens.
+
+### Staging (#238 / E1.1)
+
+Floor: shared `StageFloor` primitive from `scaffold/staging/`,
+**per-scene `outerHalfExtent: 6` (12 × 12 m floor)** so the
+circular cutout fits strictly interior with margin. Dark navy
+`0x222244` color matches the cluster baseline. **Circular cutout
+sized to `BOUND = 1.5 m`** (`kind: 'circle'`, centered on
+`SURFACE_CENTER.xz`); reads as the math-frame domain envelope
+projected onto the floor, per Path A1 (cutout-as-projection-aperture).
+The disk's outer edge sits 0.5 m inside the floor's −Z edge — a
+visible margin that demarcates the scene's exhibit footprint.
+
+Tangent-planes is the only cluster scene with a per-scene floor
+size variation; the other three keep the cluster-default 10 × 10 m
+floor. The variation preserves the cluster-wide cutout-sizing rule
+("math-frame domain envelope projected onto the floor") under
+Path A1 locked in `_private/plans/238-cluster-cutout.md` §3.3.

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -28,6 +28,10 @@ import {
 import { anglesFromDirection } from '@/scaffold/math/anglesFromDirection';
 import { directionFromAngles } from '@/scaffold/math/directionFromAngles';
 import { raycastImplicit } from '@/scaffold/render/raycastImplicit';
+import {
+  createStageFloor,
+  type StageFloorHandles,
+} from '@/scaffold/staging/StageFloor';
 import { createTangentPlane, type TangentPlaneHandles } from './TangentPlane';
 import { TangentPlaneReadout } from './TangentPlaneReadout';
 
@@ -212,6 +216,7 @@ let tangentPlaneReadout: TangentPlaneReadout | undefined;
 let thetaLabel: Label | undefined;
 let phiLabel: Label | undefined;
 let worldAxes: WorldAxes | undefined;
+let stageFloor: StageFloorHandles | undefined;
 let pointers: readonly Pointer[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
 // yaw-billboarding in update().
@@ -297,6 +302,22 @@ const tangentPlanesExhibit: Exhibit = {
     const directional = new THREE.DirectionalLight(0xffffff, 0.8);
     directional.position.copy(LIGHT_DIR).multiplyScalar(5);
     group.add(directional);
+
+    // Stage floor with circular cutout (#238 / E1.1). Per-scene
+    // outerHalfExtent: 6 (12 × 12 m floor) so the BOUND-radius disk fits
+    // strictly interior with 0.5 m margin (|cz|+r = 5.5 < 6). See
+    // `_private/plans/238-cluster-cutout.md` §3.3 for the Path A1
+    // rationale (roundtable-converged on cluster-rule uniformity
+    // over cluster-footprint uniformity).
+    stageFloor = createStageFloor({
+      cutout: {
+        kind: 'circle',
+        centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z],
+        radius: BOUND,
+      },
+      outerHalfExtent: 6,
+    });
+    group.add(stageFloor.group);
 
     // Implicit-surface mesh + ShaderMaterial via the shared harness.
     const surfaceHandles = createImplicitSurface({
@@ -551,6 +572,10 @@ const tangentPlanesExhibit: Exhibit = {
     phiSlider = undefined;
     worldAxes?.dispose();
     worldAxes = undefined;
+    if (stageFloor) {
+      stageFloor.dispose();
+      stageFloor = undefined;
+    }
 
     // 3. Drop external references so a re-mount starts clean. The shell
     //    removes ctx.group and its descendants automatically. Clear the

--- a/src/scaffold/staging/StageFloor.ts
+++ b/src/scaffold/staging/StageFloor.ts
@@ -1,28 +1,32 @@
 import * as THREE from 'three';
 
 // Cluster-wide floor primitive for the v1.0 staged-exhibit vocabulary
-// (#221 / E1.1, #222). Lifted from quadrics' resident floor + AABB
-// hole-punch implementation (#125) into the shared `scaffold/staging/`
-// namespace so future cluster scenes can opt in without duplicating
-// the strip-decomposition logic.
+// (#221 / E1.1). Two cutout-shape code paths, dispatched on
+// `StageCutoutDescriptor.kind`:
 //
-// Implementation strategy: 4-strip-with-clamping. The hole rectangle
-// is clamped to the outer floor's bounds via Math.max/min, then 4
-// strips are constructed around it (front / behind / left / right of
-// hole). Degenerate strips (zero or negative area after clamp) early-
-// return from addStrip. Handles boundary-exceeding cutouts naturally,
-// which `THREE.ShapeGeometry` with hole subtraction would not — earcut
-// requires holes to be strictly interior to the outer contour.
+// - `kind: 'rect'` — 4-strip-with-clamping (#222 lift from quadrics'
+//   #125 implementation). The hole rectangle is clamped to the outer
+//   floor's bounds via Math.max/min, then 4 strips are constructed
+//   around it (front / behind / left / right). Degenerate strips
+//   early-return. Handles boundary-exceeding cutouts naturally. Used
+//   by quadrics, gradient-levels, saddle-extrema.
+// - `kind: 'circle'` — ShapeGeometry-with-hole (#238). Strictly-
+//   interior cutouts only (asserted at construction); tangent contact
+//   with the outer rect degenerates earcut tessellation. Used by
+//   tangent-planes, which opts in to a per-scene `outerHalfExtent: 6`
+//   so its `radius: BOUND = 1.5` disk at `SURFACE_CENTER.z = -4` fits
+//   strictly interior with 0.5m margin.
+//
+// Sign-flip note for circle path: the shape is constructed in local-
+// XY and rotated `-π/2` about world-X to lie on the floor plane. The
+// rotation maps local +Y to world −Z, so a cutout centered at world
+// `(cx, cz)` is constructed at local-XY `(cx, -cz)`.
 //
 // Ownership (per `_private/plans/v1.0.md` §4 staging rules): exhibit-
 // owned. Per-scene cutout descriptor; allocated in `mount`, disposed
 // in `unmount`. The shell removes `ctx.group` after `unmount` returns
 // (shell.ts:471–472), so dispose() only releases owned GPU resources;
 // no `scene.remove(...)` calls.
-//
-// Future API extensions tracked in #238 (cluster-wide cutout decision):
-// `kind: 'circle'` descriptor variant + a ShapeGeometry-with-holes
-// code path for strictly-interior cutouts.
 
 export const STAGE_FLOOR_COLOR_RGB = [
   0x22 / 255,
@@ -33,22 +37,34 @@ export const STAGE_FLOOR_COLOR_RGB = [
 export const STAGE_FLOOR_OUTER_HALF_DEFAULT = 5;
 
 /**
- * Cutout descriptor for the floor. Today's only variant is `rect`;
- * `circle` will be added via #238 when the tangent-planes /
- * gradient-levels / saddle-extrema floor question is resolved
- * (cutout-as-projection-aperture vs dipping-hole).
+ * Cutout descriptor for the floor. Sum-type:
  *
- * Coordinates are in world XZ — the primitive constructs strips
- * directly in that frame, so callers don't need to reason about any
- * local-XY-vs-world-XZ rotation. The strips are rotated -π/2 about
- * world-X to lie on the floor plane.
+ * - `kind: 'rect'` — strip approach (handles both interior and boundary-
+ *   exceeding cutouts via Math.max/min clamp + degenerate-strip early-
+ *   return). Cluster-wide today: quadrics, gradient-levels, saddle-extrema.
+ * - `kind: 'circle'` — ShapeGeometry-with-hole approach. Strictly-interior
+ *   cutouts only (asserted at construction); tangent contact with the
+ *   outer rect degenerates earcut tessellation. Tangent-planes opted in
+ *   under #238's Path A1 (per-scene `outerHalfExtent: 6` so the
+ *   `radius: BOUND = 1.5` disk fits strictly interior with 0.5m margin).
+ *
+ * Coordinates are in world XZ — the primitive applies the local-XY ↔
+ * world-XZ sign-flip internally (the floor plane is laid down by
+ * rotating geometry `-π/2` about world-X, which maps local +Y to
+ * world −Z), so callers don't reason about any rotation themselves.
  */
-export type StageCutoutDescriptor = {
-  readonly kind: 'rect';
-  readonly centerXZ: readonly [number, number];
-  readonly halfExtentX: number;
-  readonly halfExtentZ: number;
-};
+export type StageCutoutDescriptor =
+  | {
+      readonly kind: 'rect';
+      readonly centerXZ: readonly [number, number];
+      readonly halfExtentX: number;
+      readonly halfExtentZ: number;
+    }
+  | {
+      readonly kind: 'circle';
+      readonly centerXZ: readonly [number, number];
+      readonly radius: number;
+    };
 
 export interface StageFloorOptions {
   readonly cutout: StageCutoutDescriptor;
@@ -67,20 +83,48 @@ export interface StageFloorHandles {
 
 export function createStageFloor(opts: StageFloorOptions): StageFloorHandles {
   const outer = opts.outerHalfExtent ?? STAGE_FLOOR_OUTER_HALF_DEFAULT;
-  const [cx, cz] = opts.cutout.centerXZ;
-  const { halfExtentX, halfExtentZ } = opts.cutout;
+
+  const material = new THREE.MeshStandardMaterial({
+    color: new THREE.Color(...STAGE_FLOOR_COLOR_RGB),
+  });
+  const geometries: THREE.BufferGeometry[] = [];
+  const group = new THREE.Group();
+  group.name = 'stage-floor';
+
+  if (opts.cutout.kind === 'rect') {
+    buildRectFloor(opts.cutout, outer, material, geometries, group);
+  } else {
+    buildCircleFloor(opts.cutout, outer, material, geometries, group);
+  }
+
+  let disposed = false;
+  return {
+    group,
+    outerHalfExtent: outer,
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      material.dispose();
+      for (const g of geometries) g.dispose();
+      geometries.length = 0;
+    },
+  };
+}
+
+function buildRectFloor(
+  cutout: Extract<StageCutoutDescriptor, { kind: 'rect' }>,
+  outer: number,
+  material: THREE.Material,
+  geometries: THREE.BufferGeometry[],
+  group: THREE.Group,
+): void {
+  const [cx, cz] = cutout.centerXZ;
+  const { halfExtentX, halfExtentZ } = cutout;
 
   const holeMinX = Math.max(cx - halfExtentX, -outer);
   const holeMaxX = Math.min(cx + halfExtentX, outer);
   const holeMinZ = Math.max(cz - halfExtentZ, -outer);
   const holeMaxZ = Math.min(cz + halfExtentZ, outer);
-
-  const material = new THREE.MeshStandardMaterial({
-    color: new THREE.Color(...STAGE_FLOOR_COLOR_RGB),
-  });
-  const geometries: THREE.PlaneGeometry[] = [];
-  const group = new THREE.Group();
-  group.name = 'stage-floor';
 
   const addStrip = (
     xMin: number,
@@ -101,17 +145,56 @@ export function createStageFloor(opts: StageFloorOptions): StageFloorHandles {
   addStrip(-outer, outer, -outer, holeMinZ); // behind hole
   addStrip(-outer, holeMinX, holeMinZ, holeMaxZ); // left of hole
   addStrip(holeMaxX, outer, holeMinZ, holeMaxZ); // right of hole
+}
 
-  let disposed = false;
-  return {
-    group,
-    outerHalfExtent: outer,
-    dispose(): void {
-      if (disposed) return;
-      disposed = true;
-      material.dispose();
-      for (const g of geometries) g.dispose();
-      geometries.length = 0;
-    },
-  };
+function buildCircleFloor(
+  cutout: Extract<StageCutoutDescriptor, { kind: 'circle' }>,
+  outer: number,
+  material: THREE.Material,
+  geometries: THREE.BufferGeometry[],
+  group: THREE.Group,
+): void {
+  const [cx, cz] = cutout.centerXZ;
+  const { radius } = cutout;
+
+  // Strictly-interior invariant: circle's bounding rect fits inside outer
+  // square. `>=` (not `>`) is load-bearing — equality means the hole vertex
+  // is shared with the outer contour at the tangent point, which earcut
+  // treats as degenerate (zero-area triangles / undefined tessellation).
+  // The v1 roundtable on #238 caught this as a three-way convergent HIGH.
+  if (Math.abs(cx) + radius >= outer || Math.abs(cz) + radius >= outer) {
+    throw new Error(
+      `createStageFloor: circle cutout must be strictly interior to outer ` +
+        `(|cx|+r=${Math.abs(cx) + radius}, |cz|+r=${Math.abs(cz) + radius}, ` +
+        `outer=${outer}). Boundary tangency degenerates earcut. Use ` +
+        `'kind: rect' for boundary-exceeding cutouts, or expand outerHalfExtent.`,
+    );
+  }
+
+  // Build the floor as a ShapeGeometry with a circular hole. The shape is
+  // constructed in local-XY (Z = 0) and then rotated `-π/2` about world-X
+  // to lie on the floor plane. The rotation maps local +Y to world −Z, so
+  // a cutout centered at world `(cx, cz)` maps to local-XY `(cx, -cz)`.
+  // The outer rect is symmetric ±outer, so its world-XZ projection is also
+  // symmetric and needs no sign-flip.
+  const shape = new THREE.Shape();
+  shape.moveTo(-outer, -outer);
+  shape.lineTo(outer, -outer);
+  shape.lineTo(outer, outer);
+  shape.lineTo(-outer, outer);
+  shape.closePath(); // CCW outer
+
+  // Sign-flip: world-Z = cz → local-Y = -cz. `clockwise: true` produces a
+  // CW hole; `ShapeGeometry.addShape` will auto-normalize winding if
+  // needed, but passing the intended convention directly matches earcut's
+  // documented expectations and reads more clearly to future maintainers.
+  const hole = new THREE.Path();
+  hole.absarc(cx, -cz, radius, 0, Math.PI * 2, true);
+  shape.holes.push(hole);
+
+  const geometry = new THREE.ShapeGeometry(shape);
+  geometries.push(geometry);
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.rotation.x = -Math.PI / 2;
+  group.add(mesh);
 }

--- a/test/scaffold/staging/StageFloor.test.ts
+++ b/test/scaffold/staging/StageFloor.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+import { createStageFloor } from '../../../src/scaffold/staging/StageFloor.ts';
+
+describe('createStageFloor (#238 circle path)', () => {
+  describe('kind: circle interior-only invariant', () => {
+    // Mirrors tangent-planes' actual descriptor under Path A1: per-scene
+    // outerHalfExtent: 6 + radius: 1.5 at z=-4. |cz|+r = 5.5 < 6 ✓.
+    it('accepts a circle cutout strictly interior with margin', () => {
+      expect(() =>
+        createStageFloor({
+          cutout: { kind: 'circle', centerXZ: [0, -4], radius: 1.5 },
+          outerHalfExtent: 6,
+        }),
+      ).not.toThrow();
+    });
+
+    // The test that would have caught v1's `>` bug. Exact boundary
+    // tangency (|cz| + r === outer) MUST reject; earcut treats
+    // shared-vertex contact as degenerate.
+    it('rejects a circle cutout exactly touching the outer on -Z', () => {
+      expect(() =>
+        createStageFloor({
+          cutout: { kind: 'circle', centerXZ: [0, -4], radius: 1.0 },
+          // outerHalfExtent defaults to 5 → |cz|+r = 5.0 === outer
+        }),
+      ).toThrow(/strictly interior/);
+    });
+
+    it('rejects a circle cutout that exits the outer on +X', () => {
+      expect(() =>
+        createStageFloor({
+          cutout: { kind: 'circle', centerXZ: [4.5, 0], radius: 1.0 },
+        }),
+      ).toThrow(/strictly interior/);
+    });
+
+    it('rejects a circle cutout that exits the outer on -Z', () => {
+      expect(() =>
+        createStageFloor({
+          cutout: { kind: 'circle', centerXZ: [0, -4], radius: 1.5 },
+          // outerHalfExtent defaults to 5 → |cz|+r = 5.5 > 5
+        }),
+      ).toThrow(/strictly interior/);
+    });
+  });
+
+  // Sign-flip mapping is CPU-side and isolatable; relying on headset
+  // smoke alone for a deterministic coordinate transform would miss a
+  // regression that flips local-Y = +centerZ instead of -centerZ.
+  //
+  // The probe asserts on hole-boundary vertices (which ShapeGeometry
+  // writes at exactly `radius` from the hole center) at both the
+  // correct candidate center (local-Y = -world-Z = +4) and the wrong
+  // candidate center (local-Y = +world-Z = -4). The asymmetry
+  // distinguishes correct from regression.
+  describe('kind: circle sign-flip mapping (local-Y = -world-Z)', () => {
+    it('places the hole boundary at local-XY (cx, -cz), not (cx, +cz)', () => {
+      const handles = createStageFloor({
+        cutout: { kind: 'circle', centerXZ: [0, -4], radius: 1.5 },
+        outerHalfExtent: 6,
+      });
+
+      const meshes: THREE.Mesh[] = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) meshes.push(obj);
+      });
+      expect(meshes.length).toBeGreaterThan(0);
+      const mesh = meshes[0];
+
+      const pos = mesh.geometry.attributes.position;
+      let nearCorrectCenter = 0;
+      let nearWrongCenter = 0;
+      for (let i = 0; i < pos.count; i++) {
+        const lx = pos.getX(i);
+        const ly = pos.getY(i);
+        const dCorrect = Math.hypot(lx - 0, ly - 4); // expected: local +4
+        const dWrong = Math.hypot(lx - 0, ly + 4); // regression: local -4
+        if (dCorrect > 1.2 && dCorrect < 1.8) nearCorrectCenter += 1;
+        if (dWrong > 1.2 && dWrong < 1.8) nearWrongCenter += 1;
+      }
+      expect(nearCorrectCenter).toBeGreaterThan(0); // hole IS at (0, +4)
+      expect(nearWrongCenter).toBe(0); // hole is NOT at (0, -4)
+
+      handles.dispose();
+    });
+  });
+
+  describe('dispose() — circle path', () => {
+    // Three.js dispatches a 'dispose' event on the resource; spying on
+    // that verifies dispose actually runs without poking internal state.
+    // Same pattern as translucentRect.test.ts.
+    it('disposes ShapeGeometry and material exactly once', () => {
+      const handles = createStageFloor({
+        cutout: { kind: 'circle', centerXZ: [0, -4], radius: 1.5 },
+        outerHalfExtent: 6,
+      });
+      const meshes: THREE.Mesh[] = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) meshes.push(obj);
+      });
+      const geomSpy = vi.fn();
+      const matSpy = vi.fn();
+      meshes[0].geometry.addEventListener('dispose', geomSpy);
+      (meshes[0].material as THREE.Material).addEventListener(
+        'dispose',
+        matSpy,
+      );
+      handles.dispose();
+      expect(geomSpy).toHaveBeenCalledTimes(1);
+      expect(matSpy).toHaveBeenCalledTimes(1);
+
+      handles.dispose(); // idempotent — guard against double-dispose
+      expect(geomSpy).toHaveBeenCalledTimes(1);
+      expect(matSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Closes #238

## Summary

Extends `StageFloor` (shipped via #239) with a `kind: 'circle'` cutout descriptor and applies the primitive to tangent-planes, gradient-levels, and saddle-extrema. After this PR, all four cluster scenes share the v1.0 staged-exhibit vocabulary's *stage* layer under a single semantic rule: **cutout = math-frame domain envelope projected onto the floor** (Path A — cutout-as-projection-aperture).

Tangent-planes opts in to a **per-scene 12×12m floor** (`outerHalfExtent: 6`) so the `BOUND = 1.5` radius disk at `SURFACE_CENTER.z = -4` fits strictly interior with 0.5m margin; the other two scenes use the cluster-default 10×10m floor with rect cutouts sized to their math domain envelope. Per-scene floor-size variation is the cost of preserving the cluster-wide cutout-sizing rule, locked in v3 of the plan doc after a `/roundtable-plan-review` cycle and a second-Sonnet sanity pass.

The new `ShapeGeometry`-with-hole code path enforces a strict-interior invariant at construction (`|cx|+r >= outer` rejects — `>=` not `>`, which was the v1 roundtable's three-way convergent HIGH on a real boundary-tangent bug). Sign-flip mapping (local-Y = -world-Z under the `rotation.x = -π/2` floor laying) is unit-tested via boundary-vertex probe.

## Test plan

- [x] `npm run build` clean (TypeScript + Vite).
- [x] `npm test -- --run` — **446 tests pass** (440 prior + 6 new `StageFloor` tests).
- [x] `pre-commit run --all-files` — gitleaks + eslint clean.

**Headset smoke (Cloudflare PR preview):**
- [x] `?exhibit=tangent-planes` — visibly wider 12×12m floor (vs. 10×10m elsewhere); circular cutout `radius=1.5` centered on the sphere; ~0.5m visible margin between cutout boundary and floor's −Z edge.
- [x] `?exhibit=gradient-levels` — 10×10m floor; rect cutout `±3.0m` truncated at floor's −Z edge (floor opens to the back). Sweep `k` slider through full range; surface dips through cutout for `k ≲ -2.25`.
- [x] `?exhibit=saddle-extrema` — 10×10m floor; rect cutout `±1.5m` truncated at floor's −Z edge. Cycle all 5 presets: math dips through cutout for inv-paraboloid / saddle / monkey-saddle; sits above for paraboloid / quartic-min.
- [x] **Mount → unmount → re-mount leak check** per scene (with `?fps=1` + tethered `chrome://inspect`): `[renderer.info] calls + triangles` return to baseline within ±1.
- [ ] **Quest 3S 72Hz hold** preserved across all three scenes.

**Pancake (desktop) smoke:**
- [x] Default OrbitControls pose shows floor + cutout + math in frame at 1920×1080 for each of the three scenes.
- [x] SceneRack switching uninterrupted.
- [x] ≥60fps maintainer-machine.

## Related

- Parent epic: #221 (v1.0 staged-exhibit vocabulary).
- Predecessor: #239 (StageFloor primitive + quadrics lift; merged 2026-05-17).
- Plan doc + roundtable history: `_private/plans/238-cluster-cutout.md` (v1 → REVISE → v2 + Path A1 lock → second-Sonnet REVISE-AGAIN on a real test-heuristic bug → v3 fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)