### PR TITLE
feat(shell): pancake default camera back to z=3 — foreground floor visible (#240)

### DIFF
--- a/src/shell/cameraControls.ts
+++ b/src/shell/cameraControls.ts
@@ -30,7 +30,7 @@ const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
  * 1. `controls.target` set to `SURFACE_CENTER` so user-driven orbit
  *    rotates around the cluster anchor.
  * 2. `camera.position` overrides the unused-in-XR pre-session
- *    `(0, 1.6, 3)` set at `shell.ts:34`. Desktop mode is the first
+ *    `(0, 1.6, 3)` set at `shell.ts:94`. Desktop mode is the first
  *    time the `PerspectiveCamera`'s position matters at render time
  *    — XR renders via an `ArrayCamera` driven by HMD pose, not this
  *    `PerspectiveCamera` (pancake plan v3 §3.3, S5 / G10).
@@ -70,7 +70,16 @@ export function createCameraControls(
   // configuration, not whatever spherical the constructor derived
   // against the default `target = (0, 0, 0)`.
   controls.target.copy(SURFACE_CENTER);
-  camera.position.set(0, 1.6, 0);
+  // Pancake spawn pose (#240). Z = 3 places the camera ~7 m from
+  // `SURFACE_CENTER`, leaving ~1.5 m of foreground floor visible
+  // between the user and quadrics' cutout near-edge (the tightest of
+  // the four cluster scenes' StageFloor cutouts at z = -0.5). Earlier
+  // spawn pose `(0, 1.6, 0)` placed the camera right at the front of
+  // every cutout — no foreground floor on first paint. Z values that
+  // expose foreground depend on the shell's vertical FOV = 75°
+  // (`shell.ts:86`); the math derivation is in
+  // `_private/plans/240-pancake-default-camera.md` §3.
+  camera.position.set(0, 1.6, 3);
   camera.lookAt(SURFACE_CENTER);
 
   // Re-seed OrbitControls' internal `_lastPosition` from the corrected

--- a/test/shell/cameraControls.test.ts
+++ b/test/shell/cameraControls.test.ts
@@ -16,19 +16,19 @@ const makeCamera = (): THREE.PerspectiveCamera =>
   new THREE.PerspectiveCamera(75, 1, 0.1, 100);
 
 describe('createCameraControls', () => {
-  it('orients the camera at (0, 1.6, 0) before the controls take over', () => {
+  it('orients the camera at (0, 1.6, 3) before the controls take over', () => {
     const camera = makeCamera();
-    camera.position.set(0, 1.6, 3); // simulate shell.ts:34's pre-XR default
+    camera.position.set(0, 1.6, 3); // simulate shell.ts:94's pre-XR default
     createCameraControls(camera, null);
     expect(camera.position.x).toBeCloseTo(0);
     expect(camera.position.y).toBeCloseTo(1.6);
-    expect(camera.position.z).toBeCloseTo(0);
+    expect(camera.position.z).toBeCloseTo(3);
   });
 
   it('applies camera.lookAt(SURFACE_CENTER) before the first controls update', () => {
-    // The camera sits at (0, 1.6, 0) and SURFACE_CENTER is (0, 1.5, -4):
-    // forward unit vector is (0, -0.1/r, -4/r) for r = sqrt(0.01 + 16),
-    // i.e., direction ≈ (0, -0.025, -0.9997). The negative-z dominant
+    // The camera sits at (0, 1.6, 3) and SURFACE_CENTER is (0, 1.5, -4):
+    // forward unit vector is (0, -0.1/r, -7/r) for r = sqrt(0.01 + 49),
+    // i.e., direction ≈ (0, -0.014, -0.9999). The negative-z dominant
     // component is what we care about — it confirms lookAt ran (without
     // it, an unrotated camera looks toward +Z).
     const camera = makeCamera();


### PR DESCRIPTION
Closes #240

## Summary

Cluster scenes' StageFloor cutouts (post-#238/#239) hugged the camera's near-edge of the visible frustum at the prior `(0, 1.6, 0)` spawn pose, so first paint showed the math object floating with foreground floor essentially invisible — only the side / far floor wings were in view. Moving the spawn to `(0, 1.6, 3)` puts ~1.35 m of foreground floor between the user and quadrics' cutout near-edge (the tightest case at z=-0.5); the other three scenes show 1.85–3.35 m.

The pose was derived against the shell's actual `PerspectiveCamera(75, …)` FOV at `shell.ts:86`, not the Three.js default 50° the issue body's geometry assumed — the corrected math is in the per-issue plan doc (`_private/plans/240-pancake-default-camera.md` §3). At Z=3 the camera-to-target distance is ~7 m, well inside the existing `[minDistance=1.5, maxDistance=12]` orbit clamps, and each cluster scene's math object subtends 17–71 % of vertical FOV (none crowded, none lost). VR pose is unaffected — XR rendering uses the HMD-driven `ArrayCamera`, not this `PerspectiveCamera`.

Side benefit: `shell.ts:94`'s pre-mode camera position is already `(0, 1.6, 3)`, so the desktop-mode override no longer snaps the camera at mode-resolution.

`/spar`-reviewed: PUSH verdict; the two LOW findings (plan-table footnote on pitch-varies-with-Z; stale `shell.ts:34` JSDoc reference correctly bumped to `:94`) were folded in.

## Test plan

Per CLAUDE.md, the Cloudflare PR preview is the headset surface, but pancake can be smoked on either localhost or the preview.

- [x] **Pancake (laptop browser)** — for each of `?exhibit=quadrics`, `tangent-planes`, `gradient-levels`, `saddle-extrema` on the PR preview:
  - [x] Foreground floor visible between the camera and the cutout near-edge on first paint (no manual orbit required).
  - [x] Math object well-framed (not too small, not crowded).
  - [x] Drag-orbit / scroll-zoom / `controls.reset()` all return to the new spawn pose without surprise.
- [x] **VR (Quest 3S, PR preview URL)** — pose unaffected; 72 Hz hold across the cluster preserved.
- [x] **Automated:** `npm test` (446 tests, all pass; updated `cameraControls.test.ts` spawn-Z assertion is part of the diff), `npm run lint` clean, `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)