### PR TITLE
feat(staging): illusory railing perimeter cluster-wide (#223)

### DIFF
--- a/src/exhibits/gradient-levels/SPEC.md
+++ b/src/exhibits/gradient-levels/SPEC.md
@@ -418,11 +418,15 @@ exhibit (same shape as quadrics' shipped floor). The level surface
 dips below floor for `k ≲ -2.25`; the cutout is static at mount
 (sized to the math envelope, not the current `k`-driven extent).
 
-Railing (#223 / E1.2): shared `StageRailing` primitive from
-`scaffold/staging/`, perimeter at `±5 m` (matching
-`stageFloor.outerHalfExtent`). 4 corner posts + 4 top-rail tubes;
-height 0.9 m; color `0x3a3a55`. The level surface envelope reaches
-`Z ∈ [-7, -1]`; the back railing at z=-5 is inside that range, so
-extreme-`k` level surfaces visibly pass through the back railing
-— accepted by design (railing is the stage boundary, not the math
-envelope). See `_private/plans/223-illusory-railing.md` §3.5.
+Outer railing (#223 / E1.2): shared `StageRailing` primitive from
+`scaffold/staging/`. **`backExtension: 3` (v3 — PR #244 smoke
+feedback):** floor + outer railing extend asymmetrically in the −Z
+direction so the back perimeter sits at world Z = −8, clearing the
+level surface envelope's Z = −7 reach with 1 m margin. 4 corner
+posts + 4 top-rail tubes; height 0.9 m; color `0x3a3a55`. See
+`_private/plans/223-illusory-railing.md` §3.5.
+
+Inner railing (#223 v3): shared `StageInnerRailing` primitive, rect
+path. 4 corner posts at the cutout corners (`±BOUND` from
+`SURFACE_CENTER.xz`) + 4 perimeter tubes. Same height + color as
+the outer railing.

--- a/src/exhibits/gradient-levels/SPEC.md
+++ b/src/exhibits/gradient-levels/SPEC.md
@@ -417,3 +417,12 @@ to the floor edge, so the floor visibly opens to the back of the
 exhibit (same shape as quadrics' shipped floor). The level surface
 dips below floor for `k ≲ -2.25`; the cutout is static at mount
 (sized to the math envelope, not the current `k`-driven extent).
+
+Railing (#223 / E1.2): shared `StageRailing` primitive from
+`scaffold/staging/`, perimeter at `±5 m` (matching
+`stageFloor.outerHalfExtent`). 4 corner posts + 4 top-rail tubes;
+height 0.9 m; color `0x3a3a55`. The level surface envelope reaches
+`Z ∈ [-7, -1]`; the back railing at z=-5 is inside that range, so
+extreme-`k` level surfaces visibly pass through the back railing
+— accepted by design (railing is the stage boundary, not the math
+envelope). See `_private/plans/223-illusory-railing.md` §3.5.

--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -32,6 +32,10 @@ import {
   createStageFloor,
   type StageFloorHandles,
 } from '@/scaffold/staging/StageFloor';
+import {
+  createStageRailing,
+  type StageRailingHandles,
+} from '@/scaffold/staging/StageRailing';
 import { createGradientArrow, type GradientArrowHandles } from './GradientArrow';
 import { GradientLevelsReadout } from './GradientLevelsReadout';
 import { BOUND, fJsRaw, gradJs } from './surfaceModel';
@@ -248,6 +252,7 @@ let phiLabel: Label | undefined;
 let kLabel: Label | undefined;
 let worldAxes: WorldAxes | undefined;
 let stageFloor: StageFloorHandles | undefined;
+let stageRailing: StageRailingHandles | undefined;
 let pointers: readonly Pointer[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
 // yaw-billboarding in update().
@@ -287,6 +292,15 @@ const gradientLevelsExhibit: Exhibit = {
       },
     });
     group.add(stageFloor.group);
+
+    // Stage railing (#223 / E1.2); cluster-default 10 × 10 m perimeter
+    // via stageFloor.outerHalfExtent. Level-surface tongues reach
+    // z = -7 at extreme k, passing through the back railing at z = -5
+    // — accepted by design (plan §3.5).
+    stageRailing = createStageRailing({
+      outerHalfExtent: stageFloor.outerHalfExtent,
+    });
+    group.add(stageRailing.group);
 
     // Implicit-surface mesh + ShaderMaterial via the shared harness. uK
     // is seeded at K_INITIAL so the surface boots at the right pose
@@ -619,6 +633,10 @@ const gradientLevelsExhibit: Exhibit = {
     if (stageFloor) {
       stageFloor.dispose();
       stageFloor = undefined;
+    }
+    if (stageRailing) {
+      stageRailing.dispose();
+      stageRailing = undefined;
     }
 
     // 3. Drop external references so a re-mount starts clean. The shell

--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -36,6 +36,10 @@ import {
   createStageRailing,
   type StageRailingHandles,
 } from '@/scaffold/staging/StageRailing';
+import {
+  createStageInnerRailing,
+  type StageInnerRailingHandles,
+} from '@/scaffold/staging/StageInnerRailing';
 import { createGradientArrow, type GradientArrowHandles } from './GradientArrow';
 import { GradientLevelsReadout } from './GradientLevelsReadout';
 import { BOUND, fJsRaw, gradJs } from './surfaceModel';
@@ -253,6 +257,7 @@ let kLabel: Label | undefined;
 let worldAxes: WorldAxes | undefined;
 let stageFloor: StageFloorHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
+let stageInnerRailing: StageInnerRailingHandles | undefined;
 let pointers: readonly Pointer[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
 // yaw-billboarding in update().
@@ -283,24 +288,32 @@ const gradientLevelsExhibit: Exhibit = {
     // truncates the cutout to the floor edge — visually the floor
     // opens to the back of the exhibit. See `_private/plans/238-
     // cluster-cutout.md` §1 for the Path A1 framing.
+    // backExtension: 3 (v3 — PR #244 smoke feedback). Level-surface
+    // tongues reach world Z = -7 at extreme k; cluster-uniform back-
+    // extension pushes the floor + railing back edge to Z = -8 with
+    // 1 m clearance. See `_private/plans/223-illusory-railing.md` §3.5.
+    const cutoutDescriptor = {
+      kind: 'rect' as const,
+      centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z] as const,
+      halfExtentX: BOUND,
+      halfExtentZ: BOUND,
+    };
     stageFloor = createStageFloor({
-      cutout: {
-        kind: 'rect',
-        centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z],
-        halfExtentX: BOUND,
-        halfExtentZ: BOUND,
-      },
+      cutout: cutoutDescriptor,
+      backExtension: 3,
     });
     group.add(stageFloor.group);
 
-    // Stage railing (#223 / E1.2); cluster-default 10 × 10 m perimeter
-    // via stageFloor.outerHalfExtent. Level-surface tongues reach
-    // z = -7 at extreme k, passing through the back railing at z = -5
-    // — accepted by design (plan §3.5).
     stageRailing = createStageRailing({
       outerHalfExtent: stageFloor.outerHalfExtent,
+      backExtension: stageFloor.backExtension,
     });
     group.add(stageRailing.group);
+
+    // Inner stage railing (#223 v3). Rect path: 4 corner posts at the
+    // cutout corners + 4 perimeter tubes.
+    stageInnerRailing = createStageInnerRailing({ cutout: cutoutDescriptor });
+    group.add(stageInnerRailing.group);
 
     // Implicit-surface mesh + ShaderMaterial via the shared harness. uK
     // is seeded at K_INITIAL so the surface boots at the right pose
@@ -637,6 +650,10 @@ const gradientLevelsExhibit: Exhibit = {
     if (stageRailing) {
       stageRailing.dispose();
       stageRailing = undefined;
+    }
+    if (stageInnerRailing) {
+      stageInnerRailing.dispose();
+      stageInnerRailing = undefined;
     }
 
     // 3. Drop external references so a re-mount starts clean. The shell

--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -392,12 +392,17 @@ change. Future cluster-wide rollout to the other three scenes lives
 in #238 — the cutout-as-projection-aperture vs dipping-hole UX
 decision is owned there, not here.
 
-Railing (#223 / E1.2): shared `StageRailing` primitive from
-`scaffold/staging/`, perimeter at `±5 m` (matching `stageFloor.outerHalfExtent`).
-4 corner posts + 4 top-rail tubes; height 0.9 m; color `0x3a3a55`
-(one tone lighter than the floor). Quadrics' raymarched surface
-envelope (AABB `±BOUND = 3.5` centered at `SURFACE_CENTER`) intersects
-the back railing at extreme parameters — accepted by design (railing
-is the stage boundary, not the math envelope). See
-`_private/plans/223-illusory-railing.md` §3.5 for the per-scene
-math-envelope vs. railing audit.
+Outer railing (#223 / E1.2): shared `StageRailing` primitive from
+`scaffold/staging/`. **`backExtension: 3` (v3 — PR #244 smoke
+feedback):** the floor + outer railing extend asymmetrically in the
+−Z direction so the back perimeter sits at world Z = −8, clearing
+the AABB envelope's Z = −7.5 reach with 0.5 m margin. X stays
+symmetric at ±5. 4 corner posts + 4 top-rail tubes; height 0.9 m;
+color `0x3a3a55`. See `_private/plans/223-illusory-railing.md` §3.5.
+
+Inner railing (#223 v3): shared `StageInnerRailing` primitive,
+circumscribes the cutout. Rect path: 4 corner posts at the AABB
+corners + 4 perimeter tubes scaled to the cutout footprint. Same
+color and dimensions as the outer railing; recognized by *where it
+is* (around the cutout) rather than by visual differentiation.
+Museum-style "protect the exhibit" framing.

--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -391,3 +391,13 @@ v0.5); refactored into the shared primitive in #222 with zero visual
 change. Future cluster-wide rollout to the other three scenes lives
 in #238 — the cutout-as-projection-aperture vs dipping-hole UX
 decision is owned there, not here.
+
+Railing (#223 / E1.2): shared `StageRailing` primitive from
+`scaffold/staging/`, perimeter at `±5 m` (matching `stageFloor.outerHalfExtent`).
+4 corner posts + 4 top-rail tubes; height 0.9 m; color `0x3a3a55`
+(one tone lighter than the floor). Quadrics' raymarched surface
+envelope (AABB `±BOUND = 3.5` centered at `SURFACE_CENTER`) intersects
+the back railing at extreme parameters — accepted by design (railing
+is the stage boundary, not the math envelope). See
+`_private/plans/223-illusory-railing.md` §3.5 for the per-scene
+math-envelope vs. railing audit.

--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -401,8 +401,15 @@ symmetric at ±5. 4 corner posts + 4 top-rail tubes; height 0.9 m;
 color `0x3a3a55`. See `_private/plans/223-illusory-railing.md` §3.5.
 
 Inner railing (#223 v3): shared `StageInnerRailing` primitive,
-circumscribes the cutout. Rect path: 4 corner posts at the AABB
+circumscribes the cutout. Rect path: 4 corner posts at the cutout
 corners + 4 perimeter tubes scaled to the cutout footprint. Same
 color and dimensions as the outer railing; recognized by *where it
 is* (around the cutout) rather than by visual differentiation.
 Museum-style "protect the exhibit" framing.
+
+**`CUTOUT_VISUAL_MARGIN = 1.05` (v4 — PR #244 follow-up smoke).**
+Cutout half-extents (and consequently the inner railing perimeter)
+are scaled 1.05× outward from `SURFACE_CENTER.xz`, so the rendered
+surface doesn't kiss the cutout / railing edge at extreme
+`a/b/c/d` parameters. Preserves the Path A "math envelope projected
+onto floor" framing while adding a small annular breathing margin.

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -20,6 +20,10 @@ import { PresetTween } from '@/scaffold/anim/PresetTween';
 import { createImplicitSurface } from '@/scaffold/render/ImplicitSurface';
 import { RendererInfoProbe } from '@/scaffold/perf/RendererInfoProbe';
 import { createStageFloor, type StageFloorHandles } from '@/scaffold/staging/StageFloor';
+import {
+  createStageRailing,
+  type StageRailingHandles,
+} from '@/scaffold/staging/StageRailing';
 import { Section } from '@/scaffold/ui/Section';
 import { SectionTab } from '@/scaffold/ui/SectionTab';
 import { Slider, type ThumbShape } from '@/scaffold/ui/Slider';
@@ -791,6 +795,7 @@ let ownedGeometries: THREE.BufferGeometry[] = [];
 let ownedMaterials: THREE.Material[] = [];
 let cleanupCallbacks: Array<() => void> = [];
 let stageFloor: StageFloorHandles | undefined;
+let stageRailing: StageRailingHandles | undefined;
 
 const quadricsExhibit: Exhibit = {
   id: 'quadrics',
@@ -822,6 +827,16 @@ const quadricsExhibit: Exhibit = {
       },
     });
     group.add(stageFloor.group);
+
+    // Stage railing (#223 / E1.2). Composes against the floor's
+    // outerHalfExtent; see `_private/plans/223-illusory-railing.md`.
+    // Math envelope intersects the back railing at extreme parameters
+    // — accepted by design (railing is stage boundary, not math
+    // envelope); see plan §3.5.
+    stageRailing = createStageRailing({
+      outerHalfExtent: stageFloor.outerHalfExtent,
+    });
+    group.add(stageRailing.group);
 
     group.add(new THREE.AmbientLight(0xffffff, 0.4));
     const directional = new THREE.DirectionalLight(0xffffff, 0.8);
@@ -1372,6 +1387,10 @@ const quadricsExhibit: Exhibit = {
     if (stageFloor) {
       stageFloor.dispose();
       stageFloor = undefined;
+    }
+    if (stageRailing) {
+      stageRailing.dispose();
+      stageRailing = undefined;
     }
     if (material) {
       material.dispose();

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -825,13 +825,20 @@ const quadricsExhibit: Exhibit = {
     // for the lift plan.
     // backExtension: 3 (v3 — PR #244 smoke feedback). Quadrics' AABB
     // reaches world Z = -7.5; cluster-uniform back-extension pushes
-    // the floor + railing back edge to Z = -8 with 0.5 m clearance.
-    // See `_private/plans/223-illusory-railing.md` §3.5.
+    // the floor + railing back edge to Z = -8. See plan §3.5.
+    //
+    // CUTOUT_VISUAL_MARGIN: 1.05× outward expansion of the cutout
+    // (and consequently the inner railing) so the rendered surface
+    // doesn't kiss the cutout/railing edge at extreme parameters —
+    // PR #244 follow-up smoke. The 1.05× scaling preserves the
+    // "math envelope projected onto floor" framing while adding a
+    // small annular breathing margin.
+    const CUTOUT_VISUAL_MARGIN = 1.05;
     const cutoutDescriptor = {
       kind: 'rect' as const,
       centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z] as const,
-      halfExtentX: BOUND,
-      halfExtentZ: BOUND,
+      halfExtentX: BOUND * CUTOUT_VISUAL_MARGIN,
+      halfExtentZ: BOUND * CUTOUT_VISUAL_MARGIN,
     };
     stageFloor = createStageFloor({
       cutout: cutoutDescriptor,

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -24,6 +24,10 @@ import {
   createStageRailing,
   type StageRailingHandles,
 } from '@/scaffold/staging/StageRailing';
+import {
+  createStageInnerRailing,
+  type StageInnerRailingHandles,
+} from '@/scaffold/staging/StageInnerRailing';
 import { Section } from '@/scaffold/ui/Section';
 import { SectionTab } from '@/scaffold/ui/SectionTab';
 import { Slider, type ThumbShape } from '@/scaffold/ui/Slider';
@@ -796,6 +800,7 @@ let ownedMaterials: THREE.Material[] = [];
 let cleanupCallbacks: Array<() => void> = [];
 let stageFloor: StageFloorHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
+let stageInnerRailing: StageInnerRailingHandles | undefined;
 
 const quadricsExhibit: Exhibit = {
   id: 'quadrics',
@@ -818,25 +823,37 @@ const quadricsExhibit: Exhibit = {
     // "behind" strip is degenerate and dropped). See #125 for the original
     // hole-punch rationale and `_private/plans/222-staging-floor-cutout.md`
     // for the lift plan.
+    // backExtension: 3 (v3 — PR #244 smoke feedback). Quadrics' AABB
+    // reaches world Z = -7.5; cluster-uniform back-extension pushes
+    // the floor + railing back edge to Z = -8 with 0.5 m clearance.
+    // See `_private/plans/223-illusory-railing.md` §3.5.
+    const cutoutDescriptor = {
+      kind: 'rect' as const,
+      centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z] as const,
+      halfExtentX: BOUND,
+      halfExtentZ: BOUND,
+    };
     stageFloor = createStageFloor({
-      cutout: {
-        kind: 'rect',
-        centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z],
-        halfExtentX: BOUND,
-        halfExtentZ: BOUND,
-      },
+      cutout: cutoutDescriptor,
+      backExtension: 3,
     });
     group.add(stageFloor.group);
 
-    // Stage railing (#223 / E1.2). Composes against the floor's
-    // outerHalfExtent; see `_private/plans/223-illusory-railing.md`.
-    // Math envelope intersects the back railing at extreme parameters
-    // — accepted by design (railing is stage boundary, not math
-    // envelope); see plan §3.5.
+    // Outer stage railing (#223 / E1.2). Reads the floor's published
+    // outerHalfExtent + backExtension so railing perimeter matches the
+    // floor edge exactly.
     stageRailing = createStageRailing({
       outerHalfExtent: stageFloor.outerHalfExtent,
+      backExtension: stageFloor.backExtension,
     });
     group.add(stageRailing.group);
+
+    // Inner stage railing (#223 v3 — PR #244 smoke item 2). Museum
+    // "protect the exhibit" framing: keep users from stepping into the
+    // cutout or grabbing at the math surface. Takes the same cutout
+    // descriptor as the floor.
+    stageInnerRailing = createStageInnerRailing({ cutout: cutoutDescriptor });
+    group.add(stageInnerRailing.group);
 
     group.add(new THREE.AmbientLight(0xffffff, 0.4));
     const directional = new THREE.DirectionalLight(0xffffff, 0.8);
@@ -1391,6 +1408,10 @@ const quadricsExhibit: Exhibit = {
     if (stageRailing) {
       stageRailing.dispose();
       stageRailing = undefined;
+    }
+    if (stageInnerRailing) {
+      stageInnerRailing.dispose();
+      stageInnerRailing = undefined;
     }
     if (material) {
       material.dispose();

--- a/src/exhibits/saddle-extrema/SPEC.md
+++ b/src/exhibits/saddle-extrema/SPEC.md
@@ -740,3 +740,11 @@ floor visibly opens to the back of the exhibit. Static at mount —
 does not resize on preset change. Three of five presets (inv-
 paraboloid, saddle, monkey-saddle) dip below floor; the other two
 (paraboloid, quartic-min) sit above.
+
+Railing (#223 / E1.2): shared `StageRailing` primitive from
+`scaffold/staging/`, perimeter at `±5 m` (matching
+`stageFloor.outerHalfExtent`). 4 corner posts + 4 top-rail tubes;
+height 0.9 m; color `0x3a3a55`. The widest preset (`saddle` at
+`±1.5`) reaches `Z = -5.5`, just barely inside the back railing at
+z=-5 — minor envelope intersection accepted by design. See
+`_private/plans/223-illusory-railing.md` §3.5.

--- a/src/exhibits/saddle-extrema/SPEC.md
+++ b/src/exhibits/saddle-extrema/SPEC.md
@@ -750,6 +750,14 @@ tubes; height 0.9 m; color `0x3a3a55`. See
 `_private/plans/223-illusory-railing.md` §3.5.
 
 Inner railing (#223 v3): shared `StageInnerRailing` primitive, rect
-path. 4 corner posts at the cutout corners (`±STAGE_CUTOUT_HALF`
-from `SURFACE_CENTER.xz`) + 4 perimeter tubes. Static at mount —
-sized to the widest preset domain, same as the floor cutout.
+path. 4 corner posts at the cutout corners + 4 perimeter tubes.
+Static at mount — sized to the widest preset domain, same as the
+floor cutout.
+
+**`CUTOUT_VISUAL_MARGIN = 1.05` (v4 — PR #244 follow-up smoke).**
+Cutout half-extents (and consequently the inner railing perimeter)
+are scaled 1.05× outward from `SURFACE_CENTER.xz`, so the `saddle`
+preset's `x² − y²` surface — which reaches the full
+±STAGE_CUTOUT_HALF domain — has a small annular breathing margin
+between math and railing. Other presets at narrower domains get
+the same margin scaled appropriately.

--- a/src/exhibits/saddle-extrema/SPEC.md
+++ b/src/exhibits/saddle-extrema/SPEC.md
@@ -741,10 +741,15 @@ does not resize on preset change. Three of five presets (inv-
 paraboloid, saddle, monkey-saddle) dip below floor; the other two
 (paraboloid, quartic-min) sit above.
 
-Railing (#223 / E1.2): shared `StageRailing` primitive from
-`scaffold/staging/`, perimeter at `±5 m` (matching
-`stageFloor.outerHalfExtent`). 4 corner posts + 4 top-rail tubes;
-height 0.9 m; color `0x3a3a55`. The widest preset (`saddle` at
-`±1.5`) reaches `Z = -5.5`, just barely inside the back railing at
-z=-5 — minor envelope intersection accepted by design. See
+Outer railing (#223 / E1.2): shared `StageRailing` primitive from
+`scaffold/staging/`. **`backExtension: 3` (v3 — PR #244 smoke
+feedback):** cluster-uniform value matches quadrics + gradient-levels;
+the widest preset (`saddle` at `±1.5`) reaches `Z = -5.5`, 2.5 m
+margin to the extended back at z=-8. 4 corner posts + 4 top-rail
+tubes; height 0.9 m; color `0x3a3a55`. See
 `_private/plans/223-illusory-railing.md` §3.5.
+
+Inner railing (#223 v3): shared `StageInnerRailing` primitive, rect
+path. 4 corner posts at the cutout corners (`±STAGE_CUTOUT_HALF`
+from `SURFACE_CENTER.xz`) + 4 perimeter tubes. Static at mount —
+sized to the widest preset domain, same as the floor cutout.

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -28,6 +28,10 @@ import {
   type StageFloorHandles,
 } from '@/scaffold/staging/StageFloor';
 import {
+  createStageRailing,
+  type StageRailingHandles,
+} from '@/scaffold/staging/StageRailing';
+import {
   createCriticalPointMarkers,
   type CriticalPointMarkersHandles,
 } from './CriticalPointMarkers';
@@ -181,6 +185,7 @@ let yLabel: Label | undefined;
 let indicator: THREE.Mesh | undefined;
 let presetButtons: Preset[] = [];
 let stageFloor: StageFloorHandles | undefined;
+let stageRailing: StageRailingHandles | undefined;
 let activePresetIndex = DEFAULT_PRESET_INDEX;
 let saddleExtremaReadout: SaddleExtremaReadout | undefined;
 let camera: THREE.Camera | undefined;
@@ -233,6 +238,15 @@ const saddleExtremaExhibit: Exhibit = {
       },
     });
     group.add(stageFloor.group);
+
+    // Stage railing (#223 / E1.2); cluster-default 10 × 10 m perimeter
+    // via stageFloor.outerHalfExtent. The widest preset (`saddle` at
+    // ±1.5) reaches z = -5.5, just barely past the back railing at
+    // z = -5 — accepted by design (plan §3.5).
+    stageRailing = createStageRailing({
+      outerHalfExtent: stageFloor.outerHalfExtent,
+    });
+    group.add(stageRailing.group);
 
     graphSurface = createGraphSurface({
       f: initialPreset.f,
@@ -511,6 +525,10 @@ const saddleExtremaExhibit: Exhibit = {
     if (stageFloor) {
       stageFloor.dispose();
       stageFloor = undefined;
+    }
+    if (stageRailing) {
+      stageRailing.dispose();
+      stageRailing = undefined;
     }
 
     // 3. Drop external references so a re-mount starts clean.

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -238,11 +238,18 @@ const saddleExtremaExhibit: Exhibit = {
     // value matches quadrics + gradient-levels; the widest preset
     // (`saddle` at ±1.5) reaches z = -5.5, so 2.5 m margin to the
     // extended back at z = -8. See plan §3.5.
+    //
+    // CUTOUT_VISUAL_MARGIN: 1.05× outward expansion of the cutout
+    // (and inner railing) so the rendered surface — especially the
+    // `saddle` preset which reaches the full ±STAGE_CUTOUT_HALF
+    // domain — has a small annular breathing margin between math
+    // and railing. PR #244 follow-up smoke.
+    const CUTOUT_VISUAL_MARGIN = 1.05;
     const cutoutDescriptor = {
       kind: 'rect' as const,
       centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z] as const,
-      halfExtentX: STAGE_CUTOUT_HALF,
-      halfExtentZ: STAGE_CUTOUT_HALF,
+      halfExtentX: STAGE_CUTOUT_HALF * CUTOUT_VISUAL_MARGIN,
+      halfExtentZ: STAGE_CUTOUT_HALF * CUTOUT_VISUAL_MARGIN,
     };
     stageFloor = createStageFloor({
       cutout: cutoutDescriptor,

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -32,6 +32,10 @@ import {
   type StageRailingHandles,
 } from '@/scaffold/staging/StageRailing';
 import {
+  createStageInnerRailing,
+  type StageInnerRailingHandles,
+} from '@/scaffold/staging/StageInnerRailing';
+import {
   createCriticalPointMarkers,
   type CriticalPointMarkersHandles,
 } from './CriticalPointMarkers';
@@ -186,6 +190,7 @@ let indicator: THREE.Mesh | undefined;
 let presetButtons: Preset[] = [];
 let stageFloor: StageFloorHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
+let stageInnerRailing: StageInnerRailingHandles | undefined;
 let activePresetIndex = DEFAULT_PRESET_INDEX;
 let saddleExtremaReadout: SaddleExtremaReadout | undefined;
 let camera: THREE.Camera | undefined;
@@ -229,24 +234,32 @@ const saddleExtremaExhibit: Exhibit = {
     // to the floor edge. Static at mount — does not resize on preset
     // change. See `_private/plans/238-cluster-cutout.md` §3.4 for the
     // Path A1 rationale.
+    // backExtension: 3 (v3 — PR #244 smoke feedback). Cluster-uniform
+    // value matches quadrics + gradient-levels; the widest preset
+    // (`saddle` at ±1.5) reaches z = -5.5, so 2.5 m margin to the
+    // extended back at z = -8. See plan §3.5.
+    const cutoutDescriptor = {
+      kind: 'rect' as const,
+      centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z] as const,
+      halfExtentX: STAGE_CUTOUT_HALF,
+      halfExtentZ: STAGE_CUTOUT_HALF,
+    };
     stageFloor = createStageFloor({
-      cutout: {
-        kind: 'rect',
-        centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z],
-        halfExtentX: STAGE_CUTOUT_HALF,
-        halfExtentZ: STAGE_CUTOUT_HALF,
-      },
+      cutout: cutoutDescriptor,
+      backExtension: 3,
     });
     group.add(stageFloor.group);
 
-    // Stage railing (#223 / E1.2); cluster-default 10 × 10 m perimeter
-    // via stageFloor.outerHalfExtent. The widest preset (`saddle` at
-    // ±1.5) reaches z = -5.5, just barely past the back railing at
-    // z = -5 — accepted by design (plan §3.5).
     stageRailing = createStageRailing({
       outerHalfExtent: stageFloor.outerHalfExtent,
+      backExtension: stageFloor.backExtension,
     });
     group.add(stageRailing.group);
+
+    // Inner stage railing (#223 v3). Rect path; perimeter follows the
+    // widest-preset cutout footprint at ±STAGE_CUTOUT_HALF.
+    stageInnerRailing = createStageInnerRailing({ cutout: cutoutDescriptor });
+    group.add(stageInnerRailing.group);
 
     graphSurface = createGraphSurface({
       f: initialPreset.f,
@@ -529,6 +542,10 @@ const saddleExtremaExhibit: Exhibit = {
     if (stageRailing) {
       stageRailing.dispose();
       stageRailing = undefined;
+    }
+    if (stageInnerRailing) {
+      stageInnerRailing.dispose();
+      stageInnerRailing = undefined;
     }
 
     // 3. Drop external references so a re-mount starts clean.

--- a/src/exhibits/tangent-planes/SPEC.md
+++ b/src/exhibits/tangent-planes/SPEC.md
@@ -304,3 +304,11 @@ size variation; the other three keep the cluster-default 10 × 10 m
 floor. The variation preserves the cluster-wide cutout-sizing rule
 ("math-frame domain envelope projected onto the floor") under
 Path A1 locked in `_private/plans/238-cluster-cutout.md` §3.3.
+
+Railing (#223 / E1.2): shared `StageRailing` primitive from
+`scaffold/staging/`, perimeter at `±6 m` (matching the per-scene
+`stageFloor.outerHalfExtent`). 4 corner posts + 4 top-rail tubes;
+height 0.9 m; color `0x3a3a55`. The sphere envelope (`Z ∈ [-5, -3]`)
+sits strictly inside the railing perimeter — no math-envelope
+intersection in this scene (the only cluster scene that's clean on
+this dimension). See `_private/plans/223-illusory-railing.md` §3.5.

--- a/src/exhibits/tangent-planes/SPEC.md
+++ b/src/exhibits/tangent-planes/SPEC.md
@@ -305,10 +305,16 @@ floor. The variation preserves the cluster-wide cutout-sizing rule
 ("math-frame domain envelope projected onto the floor") under
 Path A1 locked in `_private/plans/238-cluster-cutout.md` §3.3.
 
-Railing (#223 / E1.2): shared `StageRailing` primitive from
+Outer railing (#223 / E1.2): shared `StageRailing` primitive from
 `scaffold/staging/`, perimeter at `±6 m` (matching the per-scene
-`stageFloor.outerHalfExtent`). 4 corner posts + 4 top-rail tubes;
-height 0.9 m; color `0x3a3a55`. The sphere envelope (`Z ∈ [-5, -3]`)
-sits strictly inside the railing perimeter — no math-envelope
-intersection in this scene (the only cluster scene that's clean on
-this dimension). See `_private/plans/223-illusory-railing.md` §3.5.
+`stageFloor.outerHalfExtent`). **TP is the only cluster scene without
+a v3 back-extension** — its sphere envelope (`Z ∈ [-5, -3]`) sits
+strictly inside the railing perimeter already. 4 corner posts + 4
+top-rail tubes; height 0.9 m; color `0x3a3a55`. See
+`_private/plans/223-illusory-railing.md` §3.5.
+
+Inner railing (#223 v3): shared `StageInnerRailing` primitive, circle
+path. 8 evenly-spaced posts around the cutout circumference (radius
+`BOUND = 1.5`) + 1 `TorusGeometry` top-rail. Same height + color as
+the outer railing. The torus provides a clean curved top rail without
+piecewise approximation.

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -32,6 +32,10 @@ import {
   createStageFloor,
   type StageFloorHandles,
 } from '@/scaffold/staging/StageFloor';
+import {
+  createStageRailing,
+  type StageRailingHandles,
+} from '@/scaffold/staging/StageRailing';
 import { createTangentPlane, type TangentPlaneHandles } from './TangentPlane';
 import { TangentPlaneReadout } from './TangentPlaneReadout';
 
@@ -217,6 +221,7 @@ let thetaLabel: Label | undefined;
 let phiLabel: Label | undefined;
 let worldAxes: WorldAxes | undefined;
 let stageFloor: StageFloorHandles | undefined;
+let stageRailing: StageRailingHandles | undefined;
 let pointers: readonly Pointer[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
 // yaw-billboarding in update().
@@ -318,6 +323,16 @@ const tangentPlanesExhibit: Exhibit = {
       outerHalfExtent: 6,
     });
     group.add(stageFloor.group);
+
+    // Stage railing (#223 / E1.2). Per-scene 12 × 12 m perimeter
+    // (inherits the per-scene outerHalfExtent: 6 from the floor); see
+    // `_private/plans/223-illusory-railing.md`. TP's sphere envelope is
+    // strictly inside the railing perimeter (no math-envelope
+    // intersection — plan §3.5).
+    stageRailing = createStageRailing({
+      outerHalfExtent: stageFloor.outerHalfExtent,
+    });
+    group.add(stageRailing.group);
 
     // Implicit-surface mesh + ShaderMaterial via the shared harness.
     const surfaceHandles = createImplicitSurface({
@@ -575,6 +590,10 @@ const tangentPlanesExhibit: Exhibit = {
     if (stageFloor) {
       stageFloor.dispose();
       stageFloor = undefined;
+    }
+    if (stageRailing) {
+      stageRailing.dispose();
+      stageRailing = undefined;
     }
 
     // 3. Drop external references so a re-mount starts clean. The shell

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -36,6 +36,10 @@ import {
   createStageRailing,
   type StageRailingHandles,
 } from '@/scaffold/staging/StageRailing';
+import {
+  createStageInnerRailing,
+  type StageInnerRailingHandles,
+} from '@/scaffold/staging/StageInnerRailing';
 import { createTangentPlane, type TangentPlaneHandles } from './TangentPlane';
 import { TangentPlaneReadout } from './TangentPlaneReadout';
 
@@ -222,6 +226,7 @@ let phiLabel: Label | undefined;
 let worldAxes: WorldAxes | undefined;
 let stageFloor: StageFloorHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
+let stageInnerRailing: StageInnerRailingHandles | undefined;
 let pointers: readonly Pointer[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
 // yaw-billboarding in update().
@@ -314,25 +319,33 @@ const tangentPlanesExhibit: Exhibit = {
     // `_private/plans/238-cluster-cutout.md` §3.3 for the Path A1
     // rationale (roundtable-converged on cluster-rule uniformity
     // over cluster-footprint uniformity).
+    // TP is the only cluster scene without a v3 back-extension — its
+    // sphere envelope is strictly inside the railing perimeter already
+    // (plan §3.5). The per-scene `outerHalfExtent: 6` (vs cluster
+    // default 5) remains the per-scene variation under Path A1.
+    const cutoutDescriptor = {
+      kind: 'circle' as const,
+      centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z] as const,
+      radius: BOUND,
+    };
     stageFloor = createStageFloor({
-      cutout: {
-        kind: 'circle',
-        centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z],
-        radius: BOUND,
-      },
+      cutout: cutoutDescriptor,
       outerHalfExtent: 6,
     });
     group.add(stageFloor.group);
 
-    // Stage railing (#223 / E1.2). Per-scene 12 × 12 m perimeter
-    // (inherits the per-scene outerHalfExtent: 6 from the floor); see
-    // `_private/plans/223-illusory-railing.md`. TP's sphere envelope is
-    // strictly inside the railing perimeter (no math-envelope
-    // intersection — plan §3.5).
+    // Outer stage railing (#223 / E1.2). 12 × 12 m perimeter via the
+    // per-scene outerHalfExtent: 6.
     stageRailing = createStageRailing({
       outerHalfExtent: stageFloor.outerHalfExtent,
+      backExtension: stageFloor.backExtension,
     });
     group.add(stageRailing.group);
+
+    // Inner stage railing (#223 v3). Circle path: 8 posts around the
+    // sphere's domain circle (radius BOUND = 1.5) + 1 torus top-rail.
+    stageInnerRailing = createStageInnerRailing({ cutout: cutoutDescriptor });
+    group.add(stageInnerRailing.group);
 
     // Implicit-surface mesh + ShaderMaterial via the shared harness.
     const surfaceHandles = createImplicitSurface({
@@ -594,6 +607,10 @@ const tangentPlanesExhibit: Exhibit = {
     if (stageRailing) {
       stageRailing.dispose();
       stageRailing = undefined;
+    }
+    if (stageInnerRailing) {
+      stageInnerRailing.dispose();
+      stageInnerRailing = undefined;
     }
 
     // 3. Drop external references so a re-mount starts clean. The shell

--- a/src/scaffold/staging/StageFloor.ts
+++ b/src/scaffold/staging/StageFloor.ts
@@ -35,6 +35,7 @@ export const STAGE_FLOOR_COLOR_RGB = [
 ] as const;
 
 export const STAGE_FLOOR_OUTER_HALF_DEFAULT = 5;
+export const STAGE_FLOOR_BACK_EXTENSION_DEFAULT = 0;
 
 /**
  * Cutout descriptor for the floor. Sum-type:
@@ -70,6 +71,14 @@ export interface StageFloorOptions {
   readonly cutout: StageCutoutDescriptor;
   /** Default `STAGE_FLOOR_OUTER_HALF_DEFAULT` (5 m → 10 × 10 m floor). */
   readonly outerHalfExtent?: number;
+  /**
+   * Optional asymmetric extension of the floor's −Z edge (math-Y positive
+   * direction). Lets a scene push the back of the floor past the math
+   * envelope without inflating all four edges. Default 0 (symmetric).
+   * See `_private/plans/223-illusory-railing.md` §3.5 for the per-scene
+   * rationale + Brad's PR #244 smoke feedback.
+   */
+  readonly backExtension?: number;
 }
 
 export interface StageFloorHandles {
@@ -77,12 +86,15 @@ export interface StageFloorHandles {
   readonly group: THREE.Group;
   /** Outer half-extent in world units; E1.2 (#223) railing composes against this. */
   readonly outerHalfExtent: number;
+  /** Back extension (−Z direction) in world units; E1.2 railing reads this. */
+  readonly backExtension: number;
   /** Disposes owned geometries + material. Exhibit calls in unmount(). */
   dispose(): void;
 }
 
 export function createStageFloor(opts: StageFloorOptions): StageFloorHandles {
   const outer = opts.outerHalfExtent ?? STAGE_FLOOR_OUTER_HALF_DEFAULT;
+  const back = opts.backExtension ?? STAGE_FLOOR_BACK_EXTENSION_DEFAULT;
 
   const material = new THREE.MeshStandardMaterial({
     color: new THREE.Color(...STAGE_FLOOR_COLOR_RGB),
@@ -92,15 +104,16 @@ export function createStageFloor(opts: StageFloorOptions): StageFloorHandles {
   group.name = 'stage-floor';
 
   if (opts.cutout.kind === 'rect') {
-    buildRectFloor(opts.cutout, outer, material, geometries, group);
+    buildRectFloor(opts.cutout, outer, back, material, geometries, group);
   } else {
-    buildCircleFloor(opts.cutout, outer, material, geometries, group);
+    buildCircleFloor(opts.cutout, outer, back, material, geometries, group);
   }
 
   let disposed = false;
   return {
     group,
     outerHalfExtent: outer,
+    backExtension: back,
     dispose(): void {
       if (disposed) return;
       disposed = true;
@@ -114,6 +127,7 @@ export function createStageFloor(opts: StageFloorOptions): StageFloorHandles {
 function buildRectFloor(
   cutout: Extract<StageCutoutDescriptor, { kind: 'rect' }>,
   outer: number,
+  back: number,
   material: THREE.Material,
   geometries: THREE.BufferGeometry[],
   group: THREE.Group,
@@ -121,9 +135,12 @@ function buildRectFloor(
   const [cx, cz] = cutout.centerXZ;
   const { halfExtentX, halfExtentZ } = cutout;
 
+  // Asymmetric outer rect: X stays ±outer; Z spans [-outer-back, +outer].
+  const outerMinZ = -outer - back;
+
   const holeMinX = Math.max(cx - halfExtentX, -outer);
   const holeMaxX = Math.min(cx + halfExtentX, outer);
-  const holeMinZ = Math.max(cz - halfExtentZ, -outer);
+  const holeMinZ = Math.max(cz - halfExtentZ, outerMinZ);
   const holeMaxZ = Math.min(cz + halfExtentZ, outer);
 
   const addStrip = (
@@ -142,7 +159,7 @@ function buildRectFloor(
   };
 
   addStrip(-outer, outer, holeMaxZ, outer); // front of hole
-  addStrip(-outer, outer, -outer, holeMinZ); // behind hole
+  addStrip(-outer, outer, outerMinZ, holeMinZ); // behind hole (extended)
   addStrip(-outer, holeMinX, holeMinZ, holeMaxZ); // left of hole
   addStrip(holeMaxX, outer, holeMinZ, holeMaxZ); // right of hole
 }
@@ -150,6 +167,7 @@ function buildRectFloor(
 function buildCircleFloor(
   cutout: Extract<StageCutoutDescriptor, { kind: 'circle' }>,
   outer: number,
+  back: number,
   material: THREE.Material,
   geometries: THREE.BufferGeometry[],
   group: THREE.Group,
@@ -158,16 +176,25 @@ function buildCircleFloor(
   const { radius } = cutout;
 
   // Strictly-interior invariant: circle's bounding rect fits inside outer
-  // square. `>=` (not `>`) is load-bearing — equality means the hole vertex
-  // is shared with the outer contour at the tangent point, which earcut
+  // rect. The outer X extents are symmetric `±outer`; the outer Z extents
+  // are asymmetric `[-outer - back, +outer]` (v3 back-extension). The
+  // `>=` (not `>`) is load-bearing — equality means the hole vertex is
+  // shared with the outer contour at the tangent point, which earcut
   // treats as degenerate (zero-area triangles / undefined tessellation).
   // The v1 roundtable on #238 caught this as a three-way convergent HIGH.
-  if (Math.abs(cx) + radius >= outer || Math.abs(cz) + radius >= outer) {
+  if (
+    Math.abs(cx) + radius >= outer ||
+    cz + radius >= outer ||
+    cz - radius <= -outer - back
+  ) {
     throw new Error(
       `createStageFloor: circle cutout must be strictly interior to outer ` +
-        `(|cx|+r=${Math.abs(cx) + radius}, |cz|+r=${Math.abs(cz) + radius}, ` +
-        `outer=${outer}). Boundary tangency degenerates earcut. Use ` +
-        `'kind: rect' for boundary-exceeding cutouts, or expand outerHalfExtent.`,
+        `(cx=${cx}, cz=${cz}, r=${radius}; outer=${outer}, back=${back}; ` +
+        `X: |cx|+r=${Math.abs(cx) + radius} vs outer; ` +
+        `front: cz+r=${cz + radius} vs outer; ` +
+        `back: cz-r=${cz - radius} vs -outer-back=${-outer - back}). ` +
+        `Boundary tangency degenerates earcut. Use 'kind: rect' for ` +
+        `boundary-exceeding cutouts, or expand outerHalfExtent / backExtension.`,
     );
   }
 
@@ -175,18 +202,20 @@ function buildCircleFloor(
   // constructed in local-XY (Z = 0) and then rotated `-π/2` about world-X
   // to lie on the floor plane. The rotation maps local +Y to world −Z, so
   // a cutout centered at world `(cx, cz)` maps to local-XY `(cx, -cz)`.
-  // The outer rect is symmetric ±outer, so its world-XZ projection is also
-  // symmetric and needs no sign-flip.
+  // World-Z range `[-outer-back, +outer]` maps to local-Y `[-outer, +outer+back]`.
+  // X is symmetric and needs no sign-flip.
+  const localYMin = -outer; // world-Z = +outer
+  const localYMax = outer + back; // world-Z = -outer - back
   const shape = new THREE.Shape();
-  shape.moveTo(-outer, -outer);
-  shape.lineTo(outer, -outer);
-  shape.lineTo(outer, outer);
-  shape.lineTo(-outer, outer);
+  shape.moveTo(-outer, localYMin);
+  shape.lineTo(outer, localYMin);
+  shape.lineTo(outer, localYMax);
+  shape.lineTo(-outer, localYMax);
   shape.closePath(); // CCW outer
 
   // Sign-flip: world-Z = cz → local-Y = -cz. `clockwise: true` produces a
-  // CW hole; `ShapeGeometry.addShape` will auto-normalize winding if
-  // needed, but passing the intended convention directly matches earcut's
+  // CW hole; `ShapeGeometry.addShape` auto-normalizes winding either way
+  // but passing the intended convention directly matches earcut's
   // documented expectations and reads more clearly to future maintainers.
   const hole = new THREE.Path();
   hole.absarc(cx, -cz, radius, 0, Math.PI * 2, true);

--- a/src/scaffold/staging/StageInnerRailing.ts
+++ b/src/scaffold/staging/StageInnerRailing.ts
@@ -1,0 +1,204 @@
+import * as THREE from 'three';
+import {
+  STAGE_RAILING_COLOR_RGB,
+  type StageRailingHandles,
+} from '@/scaffold/staging/StageRailing';
+import type { StageCutoutDescriptor } from '@/scaffold/staging/StageFloor';
+
+// Cluster-wide INNER railing primitive for the v1.0 staged-exhibit
+// vocabulary (#221 / E1.2 / v3 add). Circumscribes the cutout per
+// scene — museum "protect the exhibit" framing: keep users from
+// stepping into the floor cutout or grabbing at the math surface.
+// Brad's PR #244 smoke feedback (item 2) introduced this primitive.
+//
+// Takes the same `StageCutoutDescriptor` sum type the floor consumes,
+// and dispatches by `kind`:
+//
+// - `kind: 'rect'` — 4 corner posts at the cutout corners + 4 perimeter
+//   top-rail tubes. Mirrors `StageRailing`'s geometry pattern; the only
+//   difference is the perimeter shape (cutout footprint vs. outer rect)
+//   and the orientation of the tubes (cutout's halfExtentX/Z drive the
+//   tube lengths, not the floor's outerHalfExtent).
+// - `kind: 'circle'` — N evenly-spaced posts around the circumference
+//   + 1 TorusGeometry top-rail. The torus is a single curved geometry
+//   instance; piecewise CylinderGeometry segments would multiply
+//   geometry / dispose surface for no visual gain.
+//
+// Cluster-uniform visual vocabulary with the outer railing: same color,
+// same POST_HEIGHT, same POST_RADIUS, same TUBE_RADIUS. The inner is
+// recognized by *where it is* (around the cutout, not the perimeter),
+// not by being a different visual material. Color and palette tokens
+// are shared with `StageRailing` via import.
+//
+// Input-inertness: same as the outer railing. The cluster has no
+// scene-traversal raycasters (see `StageRailing.ts` header for sources);
+// inner railing meshes are invisible to all picking systems by
+// construction.
+//
+// Ownership: exhibit-owned per `v1.0.md` §4. Same lifecycle as
+// `createStageRailing` — `mount()` calls the factory; `unmount()` calls
+// `dispose()`.
+
+const POST_HEIGHT = 0.9;
+const POST_RADIUS = 0.04;
+const TUBE_RADIUS = 0.03;
+const CIRCLE_POST_COUNT = 8;
+const TORUS_RADIAL_SEGMENTS = 8;
+const TORUS_TUBULAR_SEGMENTS = 32;
+
+export interface StageInnerRailingOptions {
+  /**
+   * Cutout descriptor — same sum type the floor consumes. Each scene
+   * typically passes the same descriptor it passed to `createStageFloor`.
+   */
+  readonly cutout: StageCutoutDescriptor;
+}
+
+// Re-export the outer-railing handle shape — public surface is
+// identical (group + dispose), so a separate type would be cosmetic.
+export type StageInnerRailingHandles = StageRailingHandles;
+
+export function createStageInnerRailing(
+  opts: StageInnerRailingOptions,
+): StageInnerRailingHandles {
+  const material = new THREE.MeshStandardMaterial({
+    color: new THREE.Color(...STAGE_RAILING_COLOR_RGB),
+  });
+  const geometries: THREE.BufferGeometry[] = [];
+  const group = new THREE.Group();
+  group.name = 'stage-inner-railing';
+
+  if (opts.cutout.kind === 'rect') {
+    buildRectInner(opts.cutout, material, geometries, group);
+  } else {
+    buildCircleInner(opts.cutout, material, geometries, group);
+  }
+
+  let disposed = false;
+  return {
+    group,
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      material.dispose();
+      for (const g of geometries) g.dispose();
+      geometries.length = 0;
+    },
+  };
+}
+
+function buildRectInner(
+  cutout: Extract<StageCutoutDescriptor, { kind: 'rect' }>,
+  material: THREE.Material,
+  geometries: THREE.BufferGeometry[],
+  group: THREE.Group,
+): void {
+  const [cx, cz] = cutout.centerXZ;
+  const { halfExtentX, halfExtentZ } = cutout;
+
+  // 4 corner posts at the cutout corners.
+  const postGeom = new THREE.CylinderGeometry(
+    POST_RADIUS,
+    POST_RADIUS,
+    POST_HEIGHT,
+    8,
+    1,
+    true, // openEnded — same rationale as outer railing
+  );
+  geometries.push(postGeom);
+  const corners: readonly (readonly [number, number])[] = [
+    [cx - halfExtentX, cz - halfExtentZ],
+    [cx + halfExtentX, cz - halfExtentZ],
+    [cx + halfExtentX, cz + halfExtentZ],
+    [cx - halfExtentX, cz + halfExtentZ],
+  ];
+  for (const [px, pz] of corners) {
+    const post = new THREE.Mesh(postGeom, material);
+    post.position.set(px, POST_HEIGHT / 2, pz);
+    group.add(post);
+  }
+
+  // 4 perimeter top-rail tubes. Front/back span world-X with length
+  // 2·halfExtentX; left/right span world-Z with length 2·halfExtentZ.
+  // Two CylinderGeometry instances — same X-spanning vs Z-spanning
+  // split as the outer railing.
+  const tubeGeomXSpan = new THREE.CylinderGeometry(
+    TUBE_RADIUS,
+    TUBE_RADIUS,
+    halfExtentX * 2,
+    8,
+    1,
+    true,
+  );
+  geometries.push(tubeGeomXSpan);
+  const tubeGeomZSpan = new THREE.CylinderGeometry(
+    TUBE_RADIUS,
+    TUBE_RADIUS,
+    halfExtentZ * 2,
+    8,
+    1,
+    true,
+  );
+  geometries.push(tubeGeomZSpan);
+  const yAxis = new THREE.Vector3(0, 1, 0);
+  const addTube = (
+    geom: THREE.BufferGeometry,
+    midX: number,
+    midZ: number,
+    sideDirection: THREE.Vector3,
+  ): void => {
+    const tube = new THREE.Mesh(geom, material);
+    tube.position.set(midX, POST_HEIGHT, midZ);
+    tube.quaternion.setFromUnitVectors(yAxis, sideDirection);
+    group.add(tube);
+  };
+  addTube(tubeGeomXSpan, cx, cz + halfExtentZ, new THREE.Vector3(1, 0, 0)); // front
+  addTube(tubeGeomXSpan, cx, cz - halfExtentZ, new THREE.Vector3(1, 0, 0)); // back
+  addTube(tubeGeomZSpan, cx + halfExtentX, cz, new THREE.Vector3(0, 0, 1)); // right
+  addTube(tubeGeomZSpan, cx - halfExtentX, cz, new THREE.Vector3(0, 0, 1)); // left
+}
+
+function buildCircleInner(
+  cutout: Extract<StageCutoutDescriptor, { kind: 'circle' }>,
+  material: THREE.Material,
+  geometries: THREE.BufferGeometry[],
+  group: THREE.Group,
+): void {
+  const [cx, cz] = cutout.centerXZ;
+  const { radius } = cutout;
+
+  // N evenly-spaced posts around the circumference.
+  const postGeom = new THREE.CylinderGeometry(
+    POST_RADIUS,
+    POST_RADIUS,
+    POST_HEIGHT,
+    8,
+    1,
+    true,
+  );
+  geometries.push(postGeom);
+  for (let i = 0; i < CIRCLE_POST_COUNT; i++) {
+    const angle = (i / CIRCLE_POST_COUNT) * Math.PI * 2;
+    const px = cx + radius * Math.cos(angle);
+    const pz = cz + radius * Math.sin(angle);
+    const post = new THREE.Mesh(postGeom, material);
+    post.position.set(px, POST_HEIGHT / 2, pz);
+    group.add(post);
+  }
+
+  // Top-rail as a single torus. TorusGeometry's default orientation has
+  // the ring in the XY plane (axis along +Z). Rotate -π/2 about world-X
+  // to lay it in the XZ plane (axis along +Y) — matches the world-up
+  // orientation the cutout occupies.
+  const torusGeom = new THREE.TorusGeometry(
+    radius,
+    TUBE_RADIUS,
+    TORUS_RADIAL_SEGMENTS,
+    TORUS_TUBULAR_SEGMENTS,
+  );
+  geometries.push(torusGeom);
+  const torus = new THREE.Mesh(torusGeom, material);
+  torus.position.set(cx, POST_HEIGHT, cz);
+  torus.rotation.x = -Math.PI / 2;
+  group.add(torus);
+}

--- a/src/scaffold/staging/StageRailing.ts
+++ b/src/scaffold/staging/StageRailing.ts
@@ -1,0 +1,146 @@
+import * as THREE from 'three';
+
+// Cluster-wide illusory railing primitive for the v1.0 staged-exhibit
+// vocabulary (#221 / E1.2). Composes against
+// `StageFloorHandles.outerHalfExtent` (StageFloor.ts:79); each scene
+// calls both factories in mount() and disposes both in unmount(). See
+// `_private/plans/223-illusory-railing.md` for the design rationale,
+// roundtable findings, and per-scene math-envelope audit.
+//
+// Geometry: 4 corner posts + 4 perimeter top-rail tubes. All eight
+// meshes share a single `MeshStandardMaterial` and two `BufferGeometry`
+// instances (one post geometry, one tube geometry). Static — no
+// per-frame work.
+//
+// Tube orientation uses `quaternion.setFromUnitVectors(localY, side)`
+// rather than two-axis Euler rotation — the three-way convergent v1
+// roundtable HIGH (Sonnet F1 + GPT F5 + DeepSeek F1) flagged that an
+// Euler approach with a wrong comment was visually correct but
+// fragile under future edits; the quaternion form makes the intent
+// (*orient cylinder's local +Y at this world-space side direction*)
+// literal in code with no Euler-order mental model required.
+//
+// Both posts and tubes use `openEnded: true` (GPT F7). The post's
+// bottom cap would otherwise sit coplanar with the floor at Y=0
+// (z-fighting risk in VR); the tube end caps are structurally
+// occluded by the corner posts they meet.
+//
+// Input-inertness: railing meshes are invisible to the cluster's
+// picking systems by construction. Math-object picking uses
+// `raycastImplicit` (CPU raymarch against an implicit function), UI
+// primitives use analytic `raySphereHit` against known centers, and
+// `DesktopPointer.raycaster` only reads `.ray` fields — never calls
+// `intersectObjects`. No scene-traversal raycaster exists today, so
+// the railing meshes silently stay out of the way.
+//
+// Visual-only: no physics, no collider, no camera clamp. Pancake
+// camera envelope is owned by `cameraControls.ts` (#192); future FPS
+// clamp is #242.
+//
+// Ownership: exhibit-owned per `v1.0.md` §4. Each scene's `mount()`
+// calls `createStageRailing()`; `unmount()` calls `dispose()`. The
+// shell removes `ctx.group` after `unmount` returns
+// (shell.ts:471–472), so `dispose()` only releases owned GPU
+// resources; no `scene.remove(...)` calls.
+
+export const STAGE_RAILING_COLOR_RGB = [
+  0x3a / 255,
+  0x3a / 255,
+  0x55 / 255,
+] as const;
+
+const POST_HEIGHT = 0.9;
+const POST_RADIUS = 0.04;
+const TUBE_RADIUS = 0.03;
+
+export interface StageRailingOptions {
+  /** Required. Same value the scene passed to `createStageFloor`. */
+  readonly outerHalfExtent: number;
+}
+
+export interface StageRailingHandles {
+  /** Add to the exhibit's group at mount time. */
+  readonly group: THREE.Group;
+  /** Disposes owned geometries + material. Exhibit calls in unmount(). */
+  dispose(): void;
+}
+
+export function createStageRailing(
+  opts: StageRailingOptions,
+): StageRailingHandles {
+  const outer = opts.outerHalfExtent;
+
+  const material = new THREE.MeshStandardMaterial({
+    color: new THREE.Color(...STAGE_RAILING_COLOR_RGB),
+  });
+  const geometries: THREE.BufferGeometry[] = [];
+  const group = new THREE.Group();
+  group.name = 'stage-railing';
+
+  // 4 corner posts. CylinderGeometry default axis is +Y — upright
+  // posts need no rotation, just translate so the bottom sits on the
+  // floor plane at Y = 0.
+  const postGeom = new THREE.CylinderGeometry(
+    POST_RADIUS,
+    POST_RADIUS,
+    POST_HEIGHT,
+    8,
+    1,
+    true, // openEnded — bottom cap would be coplanar with floor
+  );
+  geometries.push(postGeom);
+  const postCorners: readonly (readonly [number, number])[] = [
+    [-outer, -outer],
+    [outer, -outer],
+    [outer, outer],
+    [-outer, outer],
+  ];
+  for (const [px, pz] of postCorners) {
+    const post = new THREE.Mesh(postGeom, material);
+    post.position.set(px, POST_HEIGHT / 2, pz);
+    group.add(post);
+  }
+
+  // 4 perimeter top-rail tubes. Tube center sits at Y = POST_HEIGHT,
+  // so the rail centerline rests at post-cap height (rail top at
+  // POST_HEIGHT + TUBE_RADIUS, slightly overhanging post tops — the
+  // standard museum top-rail-on-post geometry). Local +Y is the
+  // cylinder's long axis; the quaternion orients it along the side.
+  const sideLength = outer * 2;
+  const tubeGeom = new THREE.CylinderGeometry(
+    TUBE_RADIUS,
+    TUBE_RADIUS,
+    sideLength,
+    8,
+    1,
+    true, // openEnded — end caps occluded by corner posts
+  );
+  geometries.push(tubeGeom);
+  const yAxis = new THREE.Vector3(0, 1, 0);
+  const addTube = (
+    midX: number,
+    midZ: number,
+    sideDirection: THREE.Vector3,
+  ): void => {
+    const tube = new THREE.Mesh(tubeGeom, material);
+    tube.position.set(midX, POST_HEIGHT, midZ);
+    tube.quaternion.setFromUnitVectors(yAxis, sideDirection);
+    group.add(tube);
+  };
+  addTube(0, outer, new THREE.Vector3(1, 0, 0)); // front (z=+outer), spans X
+  addTube(0, -outer, new THREE.Vector3(1, 0, 0)); // back (z=-outer), spans X
+  addTube(outer, 0, new THREE.Vector3(0, 0, 1)); // right (x=+outer), spans Z
+  addTube(-outer, 0, new THREE.Vector3(0, 0, 1)); // left (x=-outer), spans Z
+
+  let disposed = false;
+  return {
+    group,
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      material.dispose();
+      for (const g of geometries) g.dispose();
+      geometries.length = 0;
+    },
+  };
+}

--- a/src/scaffold/staging/StageRailing.ts
+++ b/src/scaffold/staging/StageRailing.ts
@@ -8,8 +8,12 @@ import * as THREE from 'three';
 // roundtable findings, and per-scene math-envelope audit.
 //
 // Geometry: 4 corner posts + 4 perimeter top-rail tubes. All eight
-// meshes share a single `MeshStandardMaterial` and two `BufferGeometry`
-// instances (one post geometry, one tube geometry). Static — no
+// meshes share a single `MeshStandardMaterial`. Three `BufferGeometry`
+// instances: one shared by the four posts; one shared by the two
+// X-spanning tubes (front + back, length `2*outer`); one shared by
+// the two Z-spanning tubes (left + right, length `2*outer + back`).
+// When `backExtension = 0` the two tube geometries describe the same
+// shape but stay as separate instances for simplicity. Static — no
 // per-frame work.
 //
 // Tube orientation uses `quaternion.setFromUnitVectors(localY, side)`
@@ -56,6 +60,13 @@ const TUBE_RADIUS = 0.03;
 export interface StageRailingOptions {
   /** Required. Same value the scene passed to `createStageFloor`. */
   readonly outerHalfExtent: number;
+  /**
+   * Optional asymmetric extension of the railing's −Z edge (math-Y
+   * positive direction). Mirrors `StageFloorOptions.backExtension` —
+   * scenes that pass back-extension to the floor pass the same value
+   * here so the railing perimeter follows the floor edge. Default 0.
+   */
+  readonly backExtension?: number;
 }
 
 export interface StageRailingHandles {
@@ -69,6 +80,11 @@ export function createStageRailing(
   opts: StageRailingOptions,
 ): StageRailingHandles {
   const outer = opts.outerHalfExtent;
+  const back = opts.backExtension ?? 0;
+
+  // Asymmetric outer rect: X stays ±outer; Z spans [-outer-back, +outer].
+  // Front edge at z = +outer; back edge at z = -outer - back.
+  const zBack = -outer - back;
 
   const material = new THREE.MeshStandardMaterial({
     color: new THREE.Color(...STAGE_RAILING_COLOR_RGB),
@@ -77,9 +93,8 @@ export function createStageRailing(
   const group = new THREE.Group();
   group.name = 'stage-railing';
 
-  // 4 corner posts. CylinderGeometry default axis is +Y — upright
-  // posts need no rotation, just translate so the bottom sits on the
-  // floor plane at Y = 0.
+  // 4 corner posts at the asymmetric rect corners. CylinderGeometry
+  // default axis is +Y — upright posts need no rotation, just translate.
   const postGeom = new THREE.CylinderGeometry(
     POST_RADIUS,
     POST_RADIUS,
@@ -90,8 +105,8 @@ export function createStageRailing(
   );
   geometries.push(postGeom);
   const postCorners: readonly (readonly [number, number])[] = [
-    [-outer, -outer],
-    [outer, -outer],
+    [-outer, zBack],
+    [outer, zBack],
     [outer, outer],
     [-outer, outer],
   ];
@@ -101,36 +116,52 @@ export function createStageRailing(
     group.add(post);
   }
 
-  // 4 perimeter top-rail tubes. Tube center sits at Y = POST_HEIGHT,
-  // so the rail centerline rests at post-cap height (rail top at
-  // POST_HEIGHT + TUBE_RADIUS, slightly overhanging post tops — the
-  // standard museum top-rail-on-post geometry). Local +Y is the
-  // cylinder's long axis; the quaternion orients it along the side.
-  const sideLength = outer * 2;
-  const tubeGeom = new THREE.CylinderGeometry(
+  // 4 perimeter top-rail tubes. Front/back tubes span world-X with
+  // length 2·outer; left/right tubes span world-Z with length
+  // 2·outer + back (longer when back-extended). Two CylinderGeometry
+  // instances: one for the X-spanning tubes (front+back share length)
+  // and one for the Z-spanning tubes (left+right share length).
+  //
+  // Tube center sits at Y = POST_HEIGHT so the rail centerline rests
+  // at post-cap height. Local +Y is the cylinder's long axis; the
+  // quaternion orients it along the side.
+  const tubeGeomXSpan = new THREE.CylinderGeometry(
     TUBE_RADIUS,
     TUBE_RADIUS,
-    sideLength,
+    outer * 2,
     8,
     1,
-    true, // openEnded — end caps occluded by corner posts
+    true,
   );
-  geometries.push(tubeGeom);
+  geometries.push(tubeGeomXSpan);
+  const tubeGeomZSpan = new THREE.CylinderGeometry(
+    TUBE_RADIUS,
+    TUBE_RADIUS,
+    outer * 2 + back,
+    8,
+    1,
+    true,
+  );
+  geometries.push(tubeGeomZSpan);
   const yAxis = new THREE.Vector3(0, 1, 0);
   const addTube = (
+    geom: THREE.BufferGeometry,
     midX: number,
     midZ: number,
     sideDirection: THREE.Vector3,
   ): void => {
-    const tube = new THREE.Mesh(tubeGeom, material);
+    const tube = new THREE.Mesh(geom, material);
     tube.position.set(midX, POST_HEIGHT, midZ);
     tube.quaternion.setFromUnitVectors(yAxis, sideDirection);
     group.add(tube);
   };
-  addTube(0, outer, new THREE.Vector3(1, 0, 0)); // front (z=+outer), spans X
-  addTube(0, -outer, new THREE.Vector3(1, 0, 0)); // back (z=-outer), spans X
-  addTube(outer, 0, new THREE.Vector3(0, 0, 1)); // right (x=+outer), spans Z
-  addTube(-outer, 0, new THREE.Vector3(0, 0, 1)); // left (x=-outer), spans Z
+  // Z-spanning tubes (left/right) midpoints sit at (zBack + outer)/2
+  // = -back/2 — back-of-center when back > 0, exactly 0 when back = 0.
+  const zSpanMid = (zBack + outer) / 2;
+  addTube(tubeGeomXSpan, 0, outer, new THREE.Vector3(1, 0, 0)); // front (z=+outer)
+  addTube(tubeGeomXSpan, 0, zBack, new THREE.Vector3(1, 0, 0)); // back (z=-outer-back)
+  addTube(tubeGeomZSpan, outer, zSpanMid, new THREE.Vector3(0, 0, 1)); // right
+  addTube(tubeGeomZSpan, -outer, zSpanMid, new THREE.Vector3(0, 0, 1)); // left
 
   let disposed = false;
   return {

--- a/test/scaffold/staging/StageFloor.test.ts
+++ b/test/scaffold/staging/StageFloor.test.ts
@@ -86,6 +86,81 @@ describe('createStageFloor (#238 circle path)', () => {
     });
   });
 
+  // v3 back-extension (PR #244 smoke): asymmetric Z extent so the floor
+  // clears math envelopes that reach past the symmetric outerHalfExtent
+  // on the −Z side without inflating all four edges. Affects the
+  // strictly-interior invariant and the outer rect vertex layout.
+  describe('backExtension (v3 — asymmetric −Z extension)', () => {
+    it('handle exposes backExtension default 0 when not passed', () => {
+      const handles = createStageFloor({
+        cutout: { kind: 'rect', centerXZ: [0, -4], halfExtentX: 3, halfExtentZ: 3 },
+      });
+      expect(handles.backExtension).toBe(0);
+      handles.dispose();
+    });
+
+    it('handle exposes backExtension when passed', () => {
+      const handles = createStageFloor({
+        cutout: { kind: 'rect', centerXZ: [0, -4], halfExtentX: 3, halfExtentZ: 3 },
+        backExtension: 3,
+      });
+      expect(handles.backExtension).toBe(3);
+      handles.dispose();
+    });
+
+    it('rect path: back-extension expands the −Z floor reach without affecting X', () => {
+      const handles = createStageFloor({
+        cutout: { kind: 'rect', centerXZ: [0, -4], halfExtentX: 3, halfExtentZ: 3 },
+        outerHalfExtent: 5,
+        backExtension: 3,
+      });
+      const meshes: THREE.Mesh[] = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) meshes.push(obj);
+      });
+      // The "behind" strip should reach z = -outer - back = -8.
+      // Each strip is rotated -π/2 about world-X; center.z is in world.
+      let foundBackStrip = false;
+      for (const m of meshes) {
+        if (m.position.z < -5) foundBackStrip = true;
+      }
+      expect(foundBackStrip).toBe(true);
+      handles.dispose();
+    });
+
+    it('circle path: back-extension expands strictly-interior allowance on −Z', () => {
+      // Without back-extension this would fail (|cz|+r = 5.5 >= 5).
+      // With backExtension: 3, the back edge moves to -8; cz - r = -5.5 > -8 ✓.
+      expect(() =>
+        createStageFloor({
+          cutout: { kind: 'circle', centerXZ: [0, -4], radius: 1.5 },
+          outerHalfExtent: 5,
+          backExtension: 3,
+        }),
+      ).not.toThrow();
+    });
+
+    it('circle path: still rejects circle exceeding the extended back edge', () => {
+      expect(() =>
+        createStageFloor({
+          cutout: { kind: 'circle', centerXZ: [0, -7], radius: 1.5 },
+          outerHalfExtent: 5,
+          backExtension: 3, // back at -8; cz - r = -8.5 <= -8 → reject
+        }),
+      ).toThrow(/strictly interior/);
+    });
+
+    it('circle path: still rejects circle exceeding the front edge regardless of back-extension', () => {
+      expect(() =>
+        createStageFloor({
+          cutout: { kind: 'circle', centerXZ: [0, 4], radius: 1.5 },
+          outerHalfExtent: 5,
+          backExtension: 10, // huge back, but front still bounded at +5
+        }),
+      ).toThrow(/strictly interior/);
+    });
+  });
+
   describe('dispose() — circle path', () => {
     // Three.js dispatches a 'dispose' event on the resource; spying on
     // that verifies dispose actually runs without poking internal state.

--- a/test/scaffold/staging/StageInnerRailing.test.ts
+++ b/test/scaffold/staging/StageInnerRailing.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+import { createStageInnerRailing } from '../../../src/scaffold/staging/StageInnerRailing.ts';
+
+describe('createStageInnerRailing (#223 v3 — inner railing)', () => {
+  describe('rect cutout: 4 corner posts + 4 perimeter tubes', () => {
+    it('builds exactly 8 meshes for a rect cutout', () => {
+      const handles = createStageInnerRailing({
+        cutout: {
+          kind: 'rect',
+          centerXZ: [0, -4],
+          halfExtentX: 3.5,
+          halfExtentZ: 3.5,
+        },
+      });
+      const meshes: THREE.Mesh[] = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) meshes.push(obj);
+      });
+      expect(meshes).toHaveLength(8);
+      handles.dispose();
+    });
+
+    it('places posts at the cutout corners', () => {
+      const cx = 0;
+      const cz = -4;
+      const hx = 3.5;
+      const hz = 3.5;
+      const handles = createStageInnerRailing({
+        cutout: { kind: 'rect', centerXZ: [cx, cz], halfExtentX: hx, halfExtentZ: hz },
+      });
+
+      // Walk meshes; posts have height < tube height (posts at Y=0.45,
+      // tubes at Y=0.9). Posts are at the 4 cutout corners.
+      const postPositions: Array<readonly [number, number]> = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh && obj.position.y < 0.5) {
+          postPositions.push([obj.position.x, obj.position.z]);
+        }
+      });
+      expect(postPositions).toHaveLength(4);
+      const expectedCorners: ReadonlyArray<readonly [number, number]> = [
+        [cx - hx, cz - hz],
+        [cx + hx, cz - hz],
+        [cx + hx, cz + hz],
+        [cx - hx, cz + hz],
+      ];
+      for (const [ex, ez] of expectedCorners) {
+        expect(
+          postPositions.some(
+            ([x, z]) => Math.abs(x - ex) < 1e-9 && Math.abs(z - ez) < 1e-9,
+          ),
+        ).toBe(true);
+      }
+      handles.dispose();
+    });
+
+    // Three-way convergent HIGH from v1 roundtable applies to the
+    // inner railing's rect path too — same quaternion-based orientation
+    // is used; same world-axis assertion catches any regression.
+    it('orients tubes correctly per side (rect cutout)', () => {
+      const handles = createStageInnerRailing({
+        cutout: { kind: 'rect', centerXZ: [0, -4], halfExtentX: 3, halfExtentZ: 3 },
+      });
+      handles.group.updateMatrixWorld(true);
+
+      const yLocal = new THREE.Vector3(0, 1, 0);
+      handles.group.traverse((obj) => {
+        if (!(obj instanceof THREE.Mesh)) return;
+        if (obj.position.y < 0.5) return; // posts, not tubes
+
+        const worldAxis = yLocal.clone().applyQuaternion(obj.quaternion);
+        expect(Math.abs(worldAxis.y)).toBeLessThan(1e-9);
+
+        // Front/back tubes span world-X; left/right span world-Z.
+        // Position discriminator: tube at non-cutout-z midpoint = side
+        // tube (left/right). Tube at non-cutout-x midpoint = front/back.
+        const p = obj.position;
+        // Front/back tube: x at center, z at cutout edge.
+        if (Math.abs(p.x - 0) < 1e-9) {
+          // X-spanning tube (front or back)
+          expect(Math.abs(worldAxis.x)).toBeCloseTo(1, 9);
+          expect(Math.abs(worldAxis.z)).toBeLessThan(1e-9);
+        } else {
+          // Z-spanning tube (left or right)
+          expect(Math.abs(worldAxis.z)).toBeCloseTo(1, 9);
+          expect(Math.abs(worldAxis.x)).toBeLessThan(1e-9);
+        }
+      });
+      handles.dispose();
+    });
+  });
+
+  describe('circle cutout: 8 posts + 1 torus top-rail', () => {
+    it('builds 8 posts + 1 torus (9 meshes total) for a circle cutout', () => {
+      const handles = createStageInnerRailing({
+        cutout: { kind: 'circle', centerXZ: [0, -4], radius: 1.5 },
+      });
+      const meshes: THREE.Mesh[] = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) meshes.push(obj);
+      });
+      expect(meshes).toHaveLength(9);
+      handles.dispose();
+    });
+
+    it('places 8 posts evenly around the cutout circumference', () => {
+      const cx = 0;
+      const cz = -4;
+      const radius = 1.5;
+      const handles = createStageInnerRailing({
+        cutout: { kind: 'circle', centerXZ: [cx, cz], radius },
+      });
+
+      // Walk posts (Y < 0.5); each should be at radius distance from
+      // (cx, cz).
+      const distances: number[] = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh && obj.position.y < 0.5) {
+          const dx = obj.position.x - cx;
+          const dz = obj.position.z - cz;
+          distances.push(Math.sqrt(dx * dx + dz * dz));
+        }
+      });
+      expect(distances).toHaveLength(8);
+      for (const d of distances) {
+        expect(d).toBeCloseTo(radius, 9);
+      }
+      handles.dispose();
+    });
+
+    it('places the torus at the cutout center at Y = POST_HEIGHT, axis along world +Y', () => {
+      const cx = 0;
+      const cz = -4;
+      const handles = createStageInnerRailing({
+        cutout: { kind: 'circle', centerXZ: [cx, cz], radius: 1.5 },
+      });
+
+      // The torus is the mesh with Y ~= 0.9 (post tops).
+      let torus: THREE.Mesh | undefined;
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh && obj.position.y > 0.5) {
+          torus = obj;
+        }
+      });
+      expect(torus).toBeDefined();
+      expect(torus!.position.x).toBeCloseTo(cx, 9);
+      expect(torus!.position.z).toBeCloseTo(cz, 9);
+      expect(torus!.position.y).toBeCloseTo(0.9, 9);
+
+      // After rotation.x = -π/2, the torus's local +Z (default ring
+      // axis) should map to world +Y. Verify by transforming +Z through
+      // the mesh's quaternion.
+      torus!.updateMatrixWorld(true);
+      const zLocal = new THREE.Vector3(0, 0, 1);
+      const worldAxis = zLocal.applyQuaternion(torus!.quaternion);
+      expect(Math.abs(worldAxis.y)).toBeCloseTo(1, 9);
+      handles.dispose();
+    });
+  });
+
+  describe('dispose()', () => {
+    it('rect path: shares one material across all 8 meshes', () => {
+      const handles = createStageInnerRailing({
+        cutout: { kind: 'rect', centerXZ: [0, -4], halfExtentX: 3, halfExtentZ: 3 },
+      });
+      const meshes: THREE.Mesh[] = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) meshes.push(obj);
+      });
+      const material = meshes[0].material as THREE.Material;
+      for (const m of meshes) expect(m.material).toBe(material);
+      handles.dispose();
+    });
+
+    it('circle path: shares one material across all 9 meshes', () => {
+      const handles = createStageInnerRailing({
+        cutout: { kind: 'circle', centerXZ: [0, -4], radius: 1.5 },
+      });
+      const meshes: THREE.Mesh[] = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) meshes.push(obj);
+      });
+      const material = meshes[0].material as THREE.Material;
+      for (const m of meshes) expect(m.material).toBe(material);
+      handles.dispose();
+    });
+
+    it('disposes material + geometries exactly once, idempotent (rect)', () => {
+      const handles = createStageInnerRailing({
+        cutout: { kind: 'rect', centerXZ: [0, -4], halfExtentX: 3, halfExtentZ: 3 },
+      });
+      const meshes: THREE.Mesh[] = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) meshes.push(obj);
+      });
+      const material = meshes[0].material as THREE.Material;
+      const matSpy = vi.fn();
+      material.addEventListener('dispose', matSpy);
+
+      const uniqueGeoms = new Set<THREE.BufferGeometry>();
+      for (const m of meshes) uniqueGeoms.add(m.geometry);
+      // 1 post geom + 2 tube geoms (X-spanning + Z-spanning) = 3
+      expect(uniqueGeoms.size).toBe(3);
+      const geomSpies = new Map<
+        THREE.BufferGeometry,
+        ReturnType<typeof vi.fn>
+      >();
+      for (const g of uniqueGeoms) {
+        const spy = vi.fn();
+        g.addEventListener('dispose', spy);
+        geomSpies.set(g, spy);
+      }
+
+      handles.dispose();
+      expect(matSpy).toHaveBeenCalledTimes(1);
+      for (const spy of geomSpies.values()) {
+        expect(spy).toHaveBeenCalledTimes(1);
+      }
+
+      handles.dispose(); // idempotent
+      expect(matSpy).toHaveBeenCalledTimes(1);
+      for (const spy of geomSpies.values()) {
+        expect(spy).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it('disposes material + geometries exactly once, idempotent (circle)', () => {
+      const handles = createStageInnerRailing({
+        cutout: { kind: 'circle', centerXZ: [0, -4], radius: 1.5 },
+      });
+      const meshes: THREE.Mesh[] = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) meshes.push(obj);
+      });
+      const material = meshes[0].material as THREE.Material;
+      const matSpy = vi.fn();
+      material.addEventListener('dispose', matSpy);
+
+      const uniqueGeoms = new Set<THREE.BufferGeometry>();
+      for (const m of meshes) uniqueGeoms.add(m.geometry);
+      // 1 post geom + 1 torus geom = 2
+      expect(uniqueGeoms.size).toBe(2);
+      const geomSpies = new Map<
+        THREE.BufferGeometry,
+        ReturnType<typeof vi.fn>
+      >();
+      for (const g of uniqueGeoms) {
+        const spy = vi.fn();
+        g.addEventListener('dispose', spy);
+        geomSpies.set(g, spy);
+      }
+
+      handles.dispose();
+      expect(matSpy).toHaveBeenCalledTimes(1);
+      for (const spy of geomSpies.values()) {
+        expect(spy).toHaveBeenCalledTimes(1);
+      }
+
+      handles.dispose(); // idempotent
+      expect(matSpy).toHaveBeenCalledTimes(1);
+      for (const spy of geomSpies.values()) {
+        expect(spy).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+});

--- a/test/scaffold/staging/StageRailing.test.ts
+++ b/test/scaffold/staging/StageRailing.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+import { createStageRailing } from '../../../src/scaffold/staging/StageRailing.ts';
+
+describe('createStageRailing (#223)', () => {
+  describe('geometry — 4 posts + 4 tubes', () => {
+    it('builds exactly 8 meshes inside the group', () => {
+      const handles = createStageRailing({ outerHalfExtent: 5 });
+      const meshes: THREE.Mesh[] = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) meshes.push(obj);
+      });
+      expect(meshes).toHaveLength(8);
+      handles.dispose();
+    });
+
+    it('places corner posts at (±outer, height/2, ±outer)', () => {
+      const outer = 5;
+      const handles = createStageRailing({ outerHalfExtent: outer });
+
+      // Corner posts: 4 meshes with |x| ≈ |z| ≈ outer.
+      const cornerPositions: Array<readonly [number, number, number]> = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) {
+          const p = obj.position;
+          if (
+            Math.abs(Math.abs(p.x) - outer) < 1e-9 &&
+            Math.abs(Math.abs(p.z) - outer) < 1e-9
+          ) {
+            cornerPositions.push([p.x, p.y, p.z] as const);
+          }
+        }
+      });
+      expect(cornerPositions).toHaveLength(4);
+      // All four corners present
+      for (const sx of [-1, 1]) {
+        for (const sz of [-1, 1]) {
+          expect(
+            cornerPositions.some(
+              ([x, , z]) => Math.sign(x) === sx && Math.sign(z) === sz,
+            ),
+          ).toBe(true);
+        }
+      }
+      // All four posts at the same height
+      const ys = cornerPositions.map(([, y]) => y);
+      expect(new Set(ys).size).toBe(1);
+      handles.dispose();
+    });
+
+    it('places top-rail tubes at y = POST_HEIGHT (above corner posts)', () => {
+      const outer = 5;
+      const handles = createStageRailing({ outerHalfExtent: outer });
+
+      const tubeYs: number[] = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) {
+          const p = obj.position;
+          // Tubes sit at midpoints of sides: one of (x, z) is 0, the
+          // other is ±outer.
+          const xZero = Math.abs(p.x) < 1e-9;
+          const zZero = Math.abs(p.z) < 1e-9;
+          if (xZero || zZero) tubeYs.push(p.y);
+        }
+      });
+      expect(tubeYs).toHaveLength(4);
+      // All tubes at the same height
+      expect(new Set(tubeYs).size).toBe(1);
+      // Tubes strictly above corner posts (posts at height/2, tubes at height).
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) {
+          const p = obj.position;
+          const isCorner =
+            Math.abs(Math.abs(p.x) - outer) < 1e-9 &&
+            Math.abs(Math.abs(p.z) - outer) < 1e-9;
+          if (isCorner) expect(tubeYs[0]).toBeGreaterThan(p.y);
+        }
+      });
+      handles.dispose();
+    });
+  });
+
+  // Three-way convergent HIGH from v1 roundtable (Sonnet F1 + GPT F5 +
+  // DeepSeek F1): tube *orientation* is the regression class to defend
+  // against. Position-only tests would have passed even if all four
+  // tubes were oriented identically. After updateMatrixWorld(true),
+  // transform the cylinder's local +Y axis through the mesh's quaternion;
+  // the result is the tube's long axis in world space. Front / back tubes
+  // must span world-X (zero Y, zero Z); right / left tubes must span
+  // world-Z (zero Y, zero X). The quaternion approach in StageRailing.ts
+  // makes orientation literal in the construction code; this test catches
+  // any future regression to wrong-axis orientation.
+  describe('orientation — tubes aligned with their sides', () => {
+    it('front + back tubes span world-X, right + left tubes span world-Z', () => {
+      const outer = 5;
+      const handles = createStageRailing({ outerHalfExtent: outer });
+
+      // Force matrixWorld up-to-date — meshes have just been added to a
+      // detached Group, so matrixWorld is identity until we update.
+      handles.group.updateMatrixWorld(true);
+
+      const yLocal = new THREE.Vector3(0, 1, 0);
+      handles.group.traverse((obj) => {
+        if (!(obj instanceof THREE.Mesh)) return;
+        const p = obj.position;
+        const isTube =
+          (Math.abs(p.x) < 1e-9 &&
+            Math.abs(Math.abs(p.z) - outer) < 1e-9) ||
+          (Math.abs(p.z) < 1e-9 && Math.abs(Math.abs(p.x) - outer) < 1e-9);
+        if (!isTube) return;
+
+        // Cylinder's local +Y is its long axis. Transform to world via
+        // the mesh's quaternion (no translation contribution to a
+        // direction vector).
+        const worldAxis = yLocal.clone().applyQuaternion(obj.quaternion);
+
+        // Tube is horizontal — Y component should be ~0.
+        expect(Math.abs(worldAxis.y)).toBeLessThan(1e-9);
+
+        // Front (z = +outer) and back (z = -outer) tubes span world-X.
+        // Right (x = +outer) and left (x = -outer) tubes span world-Z.
+        // Tolerance-based discriminator (per second-Sonnet NEW LOW):
+        // construction sets midpoints to literal 0, so exact equality
+        // holds today, but a tolerance removes the implicit "we promise
+        // midpoints are exactly 0" coupling against future drift.
+        const spansX = Math.abs(p.z) > 1e-6;
+        if (spansX) {
+          expect(Math.abs(worldAxis.x)).toBeCloseTo(1, 9);
+          expect(Math.abs(worldAxis.z)).toBeLessThan(1e-9);
+        } else {
+          expect(Math.abs(worldAxis.z)).toBeCloseTo(1, 9);
+          expect(Math.abs(worldAxis.x)).toBeLessThan(1e-9);
+        }
+      });
+      handles.dispose();
+    });
+  });
+
+  describe('scales with outerHalfExtent', () => {
+    it('honors per-scene outerHalfExtent: 6 (tangent-planes)', () => {
+      const handles = createStageRailing({ outerHalfExtent: 6 });
+      let foundFar = false;
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) {
+          if (Math.abs(obj.position.x) > 5.5) foundFar = true;
+          if (Math.abs(obj.position.z) > 5.5) foundFar = true;
+        }
+      });
+      expect(foundFar).toBe(true);
+      handles.dispose();
+    });
+  });
+
+  describe('dispose()', () => {
+    // Material-sharing assertion (Sonnet F3): v1 test grabbed
+    // meshes[0].material and asserted its spy fires once, but didn't
+    // verify meshes[1..7] used the same material instance. A
+    // copy-paste implementation that allocated a new material per mesh
+    // would leak 7 materials silently.
+    it('shares one material + two geometries across all 8 meshes', () => {
+      const handles = createStageRailing({ outerHalfExtent: 5 });
+      const meshes: THREE.Mesh[] = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) meshes.push(obj);
+      });
+      expect(meshes).toHaveLength(8);
+
+      const material = meshes[0].material as THREE.Material;
+      for (const m of meshes) expect(m.material).toBe(material);
+
+      const uniqueGeoms = new Set<THREE.BufferGeometry>();
+      for (const m of meshes) uniqueGeoms.add(m.geometry);
+      expect(uniqueGeoms.size).toBe(2);
+
+      handles.dispose();
+    });
+
+    // Three.js dispatches a 'dispose' event on the resource; spying on
+    // that verifies dispose actually runs without poking internal state.
+    // Same pattern as StageFloor.test.ts circle path.
+    it('disposes shared material + geometries exactly once, idempotent', () => {
+      const handles = createStageRailing({ outerHalfExtent: 5 });
+      const meshes: THREE.Mesh[] = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) meshes.push(obj);
+      });
+      const material = meshes[0].material as THREE.Material;
+      const matSpy = vi.fn();
+      material.addEventListener('dispose', matSpy);
+
+      const uniqueGeoms = new Set<THREE.BufferGeometry>();
+      for (const m of meshes) uniqueGeoms.add(m.geometry);
+      const geomSpies = new Map<
+        THREE.BufferGeometry,
+        ReturnType<typeof vi.fn>
+      >();
+      for (const g of uniqueGeoms) {
+        const spy = vi.fn();
+        g.addEventListener('dispose', spy);
+        geomSpies.set(g, spy);
+      }
+
+      handles.dispose();
+      expect(matSpy).toHaveBeenCalledTimes(1);
+      for (const spy of geomSpies.values()) {
+        expect(spy).toHaveBeenCalledTimes(1);
+      }
+
+      handles.dispose(); // idempotent — guard against double-dispose
+      expect(matSpy).toHaveBeenCalledTimes(1);
+      for (const spy of geomSpies.values()) {
+        expect(spy).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+});

--- a/test/scaffold/staging/StageRailing.test.ts
+++ b/test/scaffold/staging/StageRailing.test.ts
@@ -136,6 +136,103 @@ describe('createStageRailing (#223)', () => {
     });
   });
 
+  // v3 back-extension: railing's −Z edge moves to -outer-back. Posts
+  // at zBack on the back corners; Z-spanning tubes are longer than
+  // X-spanning tubes when back > 0. Mirrors StageFloor's API.
+  describe('backExtension (v3 — asymmetric −Z extension)', () => {
+    it('places back-corner posts at z = -outer-back', () => {
+      const outer = 5;
+      const back = 3;
+      const handles = createStageRailing({
+        outerHalfExtent: outer,
+        backExtension: back,
+      });
+      const backCorners: number[] = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) {
+          const p = obj.position;
+          // Back-corner posts have |x|=outer AND z<-outer.
+          if (
+            Math.abs(Math.abs(p.x) - outer) < 1e-9 &&
+            p.z < -outer + 1e-9
+          ) {
+            backCorners.push(p.z);
+          }
+        }
+      });
+      // 2 back corners
+      expect(backCorners).toHaveLength(2);
+      // Both at z = -outer - back = -8
+      for (const z of backCorners) {
+        expect(z).toBeCloseTo(-outer - back, 9);
+      }
+      handles.dispose();
+    });
+
+    it('keeps front-corner posts at z = +outer (X-edge symmetry preserved)', () => {
+      const outer = 5;
+      const handles = createStageRailing({
+        outerHalfExtent: outer,
+        backExtension: 3,
+      });
+      const frontCorners: number[] = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) {
+          const p = obj.position;
+          if (
+            Math.abs(Math.abs(p.x) - outer) < 1e-9 &&
+            Math.abs(p.z - outer) < 1e-9
+          ) {
+            frontCorners.push(p.z);
+          }
+        }
+      });
+      expect(frontCorners).toHaveLength(2);
+      handles.dispose();
+    });
+
+    it('Z-spanning side tubes are length 2·outer + back (longer than X-spanning)', () => {
+      const outer = 5;
+      const back = 3;
+      const handles = createStageRailing({
+        outerHalfExtent: outer,
+        backExtension: back,
+      });
+
+      // Walk tube geometries; each cylinder's length is the second arg
+      // of its `parameters`.
+      const tubeLengths = new Set<number>();
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) {
+          const geom = obj.geometry as THREE.CylinderGeometry;
+          const params = geom.parameters as { height: number };
+          // Posts have height POST_HEIGHT = 0.9; tubes are longer.
+          if (params.height > 1) tubeLengths.add(params.height);
+        }
+      });
+      expect(tubeLengths.has(outer * 2)).toBe(true); // X-spanning
+      expect(tubeLengths.has(outer * 2 + back)).toBe(true); // Z-spanning
+      handles.dispose();
+    });
+
+    it('handle defaults: omitting backExtension behaves like back=0', () => {
+      const handles = createStageRailing({ outerHalfExtent: 5 });
+      // Should still build 8 meshes; back posts at z=-5 (not -outer-back).
+      const meshes: THREE.Mesh[] = [];
+      handles.group.traverse((obj) => {
+        if (obj instanceof THREE.Mesh) meshes.push(obj);
+      });
+      expect(meshes).toHaveLength(8);
+
+      let anyAtBack = false;
+      for (const m of meshes) {
+        if (Math.abs(m.position.z - -5) < 1e-9) anyAtBack = true;
+      }
+      expect(anyAtBack).toBe(true);
+      handles.dispose();
+    });
+  });
+
   describe('scales with outerHalfExtent', () => {
     it('honors per-scene outerHalfExtent: 6 (tangent-planes)', () => {
       const handles = createStageRailing({ outerHalfExtent: 6 });
@@ -170,7 +267,8 @@ describe('createStageRailing (#223)', () => {
 
       const uniqueGeoms = new Set<THREE.BufferGeometry>();
       for (const m of meshes) uniqueGeoms.add(m.geometry);
-      expect(uniqueGeoms.size).toBe(2);
+      // v3: one post geom + two tube geoms (X-spanning + Z-spanning).
+      expect(uniqueGeoms.size).toBe(3);
 
       handles.dispose();
     });


### PR DESCRIPTION
Closes #223

## Summary

Adds `createStageRailing` as the second member of `src/scaffold/staging/` (after `StageFloor` from #239/#241) and integrates it into all four cluster scenes. Each scene's `mount()` instantiates the railing adjacent to its existing `stageFloor`, composing against the floor's published `outerHalfExtent` handle (the seam #238 specifically added for this PR). Tangent-planes gets a 12 × 12 m railing perimeter (matching its per-scene `outerHalfExtent: 6`); the other three keep cluster-default 10 × 10 m. Geometry is 4 corner posts + 4 top-rail tubes at 0.9 m height, color `0x3a3a55` (one tone lighter than the floor); all eight meshes share one `MeshStandardMaterial` and two `BufferGeometry` instances.

Tube orientation uses `quaternion.setFromUnitVectors(localY, sideDirection)` rather than two-axis Euler rotation — the three-way convergent v1-roundtable HIGH flagged that the Euler approach was visually correct only because cylinders are symmetric, and the quaternion form makes the intent literal in code with no Euler-order mental model. Vitest covers world-axis alignment per side. Math envelope intersects the back railing in 3 of 4 scenes — accepted by design (railing is the stage boundary, not the math envelope, same framing as the floor's cutout exiting the −Z edge per #238); smoke watchpoints in the plan §6 actively monitor "math escaping its frame" vs "geometry intersection bug" with documented fall-back paths.

Plan-doc + roundtable review: `_private/plans/223-illusory-railing.md` v2. v1 of the plan ran `/roundtable-plan-review` (Sonnet via `oppositional-reviewer` + GPT-5.5 Pro + DeepSeek V4 Pro); all three returned REVISE with the convergent HIGH on orientation, three solo HIGHs from GPT (math-envelope intersection, VR locomotion infeasibility, raycaster steals picks), and smaller items. v2 folded them in; second-Sonnet sanity check returned PROCEED with one new LOW (test discriminator floating-point fragility) folded in pre-commit. The "raycaster steals picks" finding was a DISAGREE in net based on source-read — the cluster has zero `Raycaster.intersectObjects` calls (math picking uses `raycastImplicit`, UI uses `raySphereHit`), so railing meshes are input-inert by construction.

## Test plan

- [x] `npm run build` clean (TypeScript + Vite production build)
- [x] `npx vitest run` — full suite: 32/32 test files, 453/453 tests pass (7 new tests for `StageRailing`)
- [x] `pre-commit run --all-files` clean (gitleaks + ESLint + standard fixers)
- [x] **Cloudflare PR preview — VR (Quest 3S):**
  - Each scene (`?exhibit=quadrics`, `?exhibit=tangent-planes`, `?exhibit=gradient-levels`, `?exhibit=saddle-extrema`): from default headset pose at XR origin, observe the railing perimeter in peripheral view. Lean ±0.5 m physically; perimeter remains anchored in world (parallax confirms).
  - **Math-envelope intersection watch** on quadrics (sweep `a/b/c/d` through extremes), gradient-levels (sweep `k`), saddle-extrema (cycle all 5 presets) — record whether the math passing through the back railing reads as "math escaping its frame" (acceptable, no action) or as "geometry intersection bug" (escalate to plan §6.x fall-back paths: kick-rail height, larger `outerHalfExtent`, or per-scene material variation).
  - TP `?exhibit=tangent-planes`: railing at `±6 m` visibly larger than the other three scenes; sphere envelope is strictly inside (no math-envelope intersection here).
  - **Mount-leak cycle:** with `?fps=1`, tether `chrome://inspect`. For each scene, note `[renderer.info]` baseline; switch via SceneRack; switch back; verify `calls` + `triangles` return within ±1. Confirm both `stage-floor` and `stage-railing` groups appear under each scene's group in the Three.js inspector.
  - With FpsOverlay enabled, confirm 72 Hz hold across all four scenes.
- [x] **Cloudflare PR preview — pancake (desktop Chrome at 1920 × 1080):**
  - Each scene's default OrbitControls pose shows math + floor + railing in frame without manual orbit. Camera at `(0, 1.6, +3)` is inside the railing perimeter at spawn.
  - **Scroll-out clipping watch:** scroll to `maxDistance` = 12; camera passes through the front railing; record whether the pass-through reads as a defect or is invisible against the void backdrop.
  - Orbit to the back of the math object; verify the math-envelope intersection from this view reads as expected.
  - ≥60 fps under normal interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)