### PR TITLE
feat(staging): environment surround — gradient dome + linear fog (#224)

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,11 +7,11 @@
     <title>geometer — geometric reasoning in VR</title>
     <style>
       /* `background` is the pre-canvas-paint colour; kept equal to the
-         environment gradient's horizon stop (ENVIRONMENT_HORIZON_RGB =
-         0x111122 in src/scaffold/staging/Environment.ts, also the
-         'flat'-mode background) so there is no flash on first paint
-         (#224 / E1.3 §4.3). If that stop ever changes, change this too. */
-      body { margin: 0; font-family: system-ui, sans-serif; background: #111122; color: #ddd; }
+         shipped flat-mode environment tone (ENVIRONMENT_FLAT_BG_RGB =
+         0x1a1a2e in src/scaffold/staging/Environment.ts) so there is no
+         flash on first paint (#224 / E1.3 §4.3, post-#245 smoke). If
+         that constant changes, change this too. */
+      body { margin: 0; font-family: system-ui, sans-serif; background: #1a1a2e; color: #ddd; }
       #app { padding: 1rem; max-width: 600px; }
       h1 { margin-top: 0; }
       a { color: #66ccff; }

--- a/index.html
+++ b/index.html
@@ -6,6 +6,11 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>geometer — geometric reasoning in VR</title>
     <style>
+      /* `background` is the pre-canvas-paint colour; kept equal to the
+         environment gradient's horizon stop (ENVIRONMENT_HORIZON_RGB =
+         0x111122 in src/scaffold/staging/Environment.ts, also the
+         'flat'-mode background) so there is no flash on first paint
+         (#224 / E1.3 §4.3). If that stop ever changes, change this too. */
       body { margin: 0; font-family: system-ui, sans-serif; background: #111122; color: #ddd; }
       #app { padding: 1rem; max-width: 600px; }
       h1 { margin-top: 0; }

--- a/index.html
+++ b/index.html
@@ -8,10 +8,10 @@
     <style>
       /* `background` is the pre-canvas-paint colour; kept equal to the
          shipped flat-mode environment tone (ENVIRONMENT_FLAT_BG_RGB =
-         0x0d0d17 in src/scaffold/staging/Environment.ts; darkness
-         binary-search round 2) so there is no flash on first paint
+         0x07070c in src/scaffold/staging/Environment.ts; darkness
+         binary-search round 3) so there is no flash on first paint
          (#224 / E1.3 §4.3). If that constant changes, change this too. */
-      body { margin: 0; font-family: system-ui, sans-serif; background: #0d0d17; color: #ddd; }
+      body { margin: 0; font-family: system-ui, sans-serif; background: #07070c; color: #ddd; }
       #app { padding: 1rem; max-width: 600px; }
       h1 { margin-top: 0; }
       a { color: #66ccff; }

--- a/index.html
+++ b/index.html
@@ -8,10 +8,10 @@
     <style>
       /* `background` is the pre-canvas-paint colour; kept equal to the
          shipped flat-mode environment tone (ENVIRONMENT_FLAT_BG_RGB =
-         0x020203 in src/scaffold/staging/Environment.ts; darkness
-         binary-search round 5) so there is no flash on first paint
+         0x010102 in src/scaffold/staging/Environment.ts; darkness
+         binary-search round 6) so there is no flash on first paint
          (#224 / E1.3 §4.3). If that constant changes, change this too. */
-      body { margin: 0; font-family: system-ui, sans-serif; background: #020203; color: #ddd; }
+      body { margin: 0; font-family: system-ui, sans-serif; background: #010102; color: #ddd; }
       #app { padding: 1rem; max-width: 600px; }
       h1 { margin-top: 0; }
       a { color: #66ccff; }

--- a/index.html
+++ b/index.html
@@ -8,10 +8,10 @@
     <style>
       /* `background` is the pre-canvas-paint colour; kept equal to the
          shipped flat-mode environment tone (ENVIRONMENT_FLAT_BG_RGB =
-         0x1a1a2e in src/scaffold/staging/Environment.ts) so there is no
-         flash on first paint (#224 / E1.3 §4.3, post-#245 smoke). If
-         that constant changes, change this too. */
-      body { margin: 0; font-family: system-ui, sans-serif; background: #1a1a2e; color: #ddd; }
+         0x0d0d17 in src/scaffold/staging/Environment.ts; darkness
+         binary-search round 2) so there is no flash on first paint
+         (#224 / E1.3 §4.3). If that constant changes, change this too. */
+      body { margin: 0; font-family: system-ui, sans-serif; background: #0d0d17; color: #ddd; }
       #app { padding: 1rem; max-width: 600px; }
       h1 { margin-top: 0; }
       a { color: #66ccff; }

--- a/index.html
+++ b/index.html
@@ -8,10 +8,10 @@
     <style>
       /* `background` is the pre-canvas-paint colour; kept equal to the
          shipped flat-mode environment tone (ENVIRONMENT_FLAT_BG_RGB =
-         0x040406 in src/scaffold/staging/Environment.ts; darkness
-         binary-search round 4) so there is no flash on first paint
+         0x020203 in src/scaffold/staging/Environment.ts; darkness
+         binary-search round 5) so there is no flash on first paint
          (#224 / E1.3 §4.3). If that constant changes, change this too. */
-      body { margin: 0; font-family: system-ui, sans-serif; background: #040406; color: #ddd; }
+      body { margin: 0; font-family: system-ui, sans-serif; background: #020203; color: #ddd; }
       #app { padding: 1rem; max-width: 600px; }
       h1 { margin-top: 0; }
       a { color: #66ccff; }

--- a/index.html
+++ b/index.html
@@ -8,10 +8,10 @@
     <style>
       /* `background` is the pre-canvas-paint colour; kept equal to the
          shipped flat-mode environment tone (ENVIRONMENT_FLAT_BG_RGB =
-         0x07070c in src/scaffold/staging/Environment.ts; darkness
-         binary-search round 3) so there is no flash on first paint
+         0x040406 in src/scaffold/staging/Environment.ts; darkness
+         binary-search round 4) so there is no flash on first paint
          (#224 / E1.3 §4.3). If that constant changes, change this too. */
-      body { margin: 0; font-family: system-ui, sans-serif; background: #07070c; color: #ddd; }
+      body { margin: 0; font-family: system-ui, sans-serif; background: #040406; color: #ddd; }
       #app { padding: 1rem; max-width: 600px; }
       h1 { margin-top: 0; }
       a { color: #66ccff; }

--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -33,6 +33,10 @@ import {
   type StageFloorHandles,
 } from '@/scaffold/staging/StageFloor';
 import {
+  createContrastPit,
+  type ContrastPitHandles,
+} from '@/scaffold/staging/ContrastPit';
+import {
   createStageRailing,
   type StageRailingHandles,
 } from '@/scaffold/staging/StageRailing';
@@ -256,6 +260,7 @@ let phiLabel: Label | undefined;
 let kLabel: Label | undefined;
 let worldAxes: WorldAxes | undefined;
 let stageFloor: StageFloorHandles | undefined;
+let contrastPit: ContrastPitHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
 let stageInnerRailing: StageInnerRailingHandles | undefined;
 let pointers: readonly Pointer[] = [];
@@ -303,6 +308,12 @@ const gradientLevelsExhibit: Exhibit = {
       backExtension: 3,
     });
     group.add(stageFloor.group);
+
+    // Sub-floor vantablack contrast pit (#224 / E1.3, PR #245 smoke
+    // iter 5). Sized to the SAME cutout as the floor → exactly under
+    // the hole, contained wherever the cutout is. Exhibit-owned.
+    contrastPit = createContrastPit({ cutout: cutoutDescriptor });
+    group.add(contrastPit.group);
 
     stageRailing = createStageRailing({
       outerHalfExtent: stageFloor.outerHalfExtent,
@@ -646,6 +657,10 @@ const gradientLevelsExhibit: Exhibit = {
     if (stageFloor) {
       stageFloor.dispose();
       stageFloor = undefined;
+    }
+    if (contrastPit) {
+      contrastPit.dispose();
+      contrastPit = undefined;
     }
     if (stageRailing) {
       stageRailing.dispose();

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -21,6 +21,10 @@ import { createImplicitSurface } from '@/scaffold/render/ImplicitSurface';
 import { RendererInfoProbe } from '@/scaffold/perf/RendererInfoProbe';
 import { createStageFloor, type StageFloorHandles } from '@/scaffold/staging/StageFloor';
 import {
+  createContrastPit,
+  type ContrastPitHandles,
+} from '@/scaffold/staging/ContrastPit';
+import {
   createStageRailing,
   type StageRailingHandles,
 } from '@/scaffold/staging/StageRailing';
@@ -799,6 +803,7 @@ let ownedGeometries: THREE.BufferGeometry[] = [];
 let ownedMaterials: THREE.Material[] = [];
 let cleanupCallbacks: Array<() => void> = [];
 let stageFloor: StageFloorHandles | undefined;
+let contrastPit: ContrastPitHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
 let stageInnerRailing: StageInnerRailingHandles | undefined;
 
@@ -845,6 +850,15 @@ const quadricsExhibit: Exhibit = {
       backExtension: 3,
     });
     group.add(stageFloor.group);
+
+    // Sub-floor vantablack contrast pit (#224 / E1.3, PR #245 smoke
+    // iter 5). Sized to the SAME cutout as the floor → exactly under
+    // the hole, so it always covers the cutout and is always
+    // contained wherever the cutout is (resolves the tangent-planes
+    // overhang vs quadrics deep-cutout conflict). Exhibit-owned, like
+    // the floor + railings.
+    contrastPit = createContrastPit({ cutout: cutoutDescriptor });
+    group.add(contrastPit.group);
 
     // Outer stage railing (#223 / E1.2). Reads the floor's published
     // outerHalfExtent + backExtension so railing perimeter matches the
@@ -1411,6 +1425,10 @@ const quadricsExhibit: Exhibit = {
     if (stageFloor) {
       stageFloor.dispose();
       stageFloor = undefined;
+    }
+    if (contrastPit) {
+      contrastPit.dispose();
+      contrastPit = undefined;
     }
     if (stageRailing) {
       stageRailing.dispose();

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -28,6 +28,10 @@ import {
   type StageFloorHandles,
 } from '@/scaffold/staging/StageFloor';
 import {
+  createContrastPit,
+  type ContrastPitHandles,
+} from '@/scaffold/staging/ContrastPit';
+import {
   createStageRailing,
   type StageRailingHandles,
 } from '@/scaffold/staging/StageRailing';
@@ -189,6 +193,7 @@ let yLabel: Label | undefined;
 let indicator: THREE.Mesh | undefined;
 let presetButtons: Preset[] = [];
 let stageFloor: StageFloorHandles | undefined;
+let contrastPit: ContrastPitHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
 let stageInnerRailing: StageInnerRailingHandles | undefined;
 let activePresetIndex = DEFAULT_PRESET_INDEX;
@@ -256,6 +261,12 @@ const saddleExtremaExhibit: Exhibit = {
       backExtension: 3,
     });
     group.add(stageFloor.group);
+
+    // Sub-floor vantablack contrast pit (#224 / E1.3, PR #245 smoke
+    // iter 5). Sized to the SAME cutout as the floor → exactly under
+    // the hole, contained wherever the cutout is. Exhibit-owned.
+    contrastPit = createContrastPit({ cutout: cutoutDescriptor });
+    group.add(contrastPit.group);
 
     stageRailing = createStageRailing({
       outerHalfExtent: stageFloor.outerHalfExtent,
@@ -545,6 +556,10 @@ const saddleExtremaExhibit: Exhibit = {
     if (stageFloor) {
       stageFloor.dispose();
       stageFloor = undefined;
+    }
+    if (contrastPit) {
+      contrastPit.dispose();
+      contrastPit = undefined;
     }
     if (stageRailing) {
       stageRailing.dispose();

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -33,6 +33,10 @@ import {
   type StageFloorHandles,
 } from '@/scaffold/staging/StageFloor';
 import {
+  createContrastPit,
+  type ContrastPitHandles,
+} from '@/scaffold/staging/ContrastPit';
+import {
   createStageRailing,
   type StageRailingHandles,
 } from '@/scaffold/staging/StageRailing';
@@ -225,6 +229,7 @@ let thetaLabel: Label | undefined;
 let phiLabel: Label | undefined;
 let worldAxes: WorldAxes | undefined;
 let stageFloor: StageFloorHandles | undefined;
+let contrastPit: ContrastPitHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
 let stageInnerRailing: StageInnerRailingHandles | undefined;
 let pointers: readonly Pointer[] = [];
@@ -333,6 +338,12 @@ const tangentPlanesExhibit: Exhibit = {
       outerHalfExtent: 6,
     });
     group.add(stageFloor.group);
+
+    // Sub-floor vantablack contrast pit (#224 / E1.3, PR #245 smoke
+    // iter 5). Sized to the SAME cutout as the floor → exactly under
+    // the hole, contained wherever the cutout is. Exhibit-owned.
+    contrastPit = createContrastPit({ cutout: cutoutDescriptor });
+    group.add(contrastPit.group);
 
     // Outer stage railing (#223 / E1.2). 12 × 12 m perimeter via the
     // per-scene outerHalfExtent: 6.
@@ -603,6 +614,10 @@ const tangentPlanesExhibit: Exhibit = {
     if (stageFloor) {
       stageFloor.dispose();
       stageFloor = undefined;
+    }
+    if (contrastPit) {
+      contrastPit.dispose();
+      contrastPit = undefined;
     }
     if (stageRailing) {
       stageRailing.dispose();

--- a/src/scaffold/staging/ContrastPit.ts
+++ b/src/scaffold/staging/ContrastPit.ts
@@ -1,0 +1,137 @@
+import * as THREE from 'three';
+import type { StageCutoutDescriptor } from './StageFloor';
+
+// Sub-floor "vantablack" contrast pit for the v1.0 staged-exhibit
+// vocabulary (#224 / E1.3, PR #245 smoke iter 5). A pure-black box
+// directly BELOW the StageFloor cutout: looking down through the
+// cutout (where the math surface dips) reveals purposeful pure
+// black, maximising surface contrast, while at eye level / above
+// only the near-black background skybox shows ("obscures the
+// skybox only in the downward direction" — Brad's clarification).
+//
+// EXHIBIT-OWNED, per-scene — same ownership + lifecycle as
+// StageFloor / StageRailing / StageInnerRailing (allocated in
+// `mount`, disposed in `unmount`). It was briefly a single
+// shell-owned box folded into Environment, but PR #245 smoke
+// surfaced that one uniformly-sized box cannot be both contained
+// under tangent-planes' shallow floor (back edge world Z = −6, no
+// backExtension) AND cover quadrics' deep cutout (reaches world
+// Z ≈ −7.7). Sizing the pit to **each scene's own cutout
+// footprint** resolves it by construction: the pit is exactly the
+// hole, so it always covers the cutout and is always contained
+// wherever the cutout is (the cluster's cutouts are within their
+// floors by StageFloor's own clamp/interior invariants).
+//
+// Pass the SAME `StageCutoutDescriptor` the scene gives
+// `createStageFloor`. Rect → rect pit; circle → the circle's
+// bounding-box rect pit (the opaque floor hides the corners; only
+// the circular hole is seen). 5 faces — bottom + 4 walls, OPEN
+// TOP: the StageFloor + its cutout are the lid you peer down
+// through. Walls run from just below the floor down `depth`.
+//
+// Three.js export discipline (v1.0.md §4 / feedback_threejs_token_
+// exports_immutable): colour is an immutable RGB tuple + factory.
+
+/** Pure black, on purpose ("vantablack"). Tuple+factory per the
+ *  export discipline even though it's 0,0,0. */
+export const CONTRAST_PIT_COLOR_RGB = [0, 0, 0] as const;
+
+/** Pit floor depth below `topY`, world units. Clears the deepest
+ *  cluster dip (quadrics' cube bottom at world-Y ≈ −2) with margin.
+ *  First-pass smoke-tunable (feedback_staging_dimensions_first_pass). */
+export const CONTRAST_PIT_DEPTH_DEFAULT = 3;
+
+/** Pit top, world Y. A hair below the StageFloor (Y = 0) so the
+ *  open top never z-fights the floor. */
+export const CONTRAST_PIT_TOP_Y_DEFAULT = -0.02;
+
+export interface ContrastPitOptions {
+  /** The SAME cutout the scene passes to `createStageFloor`. */
+  readonly cutout: StageCutoutDescriptor;
+  /** Floor-to-pit-bottom depth. Default `CONTRAST_PIT_DEPTH_DEFAULT`. */
+  readonly depth?: number;
+  /** Pit top, world Y. Default `CONTRAST_PIT_TOP_Y_DEFAULT`. */
+  readonly topY?: number;
+}
+
+export interface ContrastPitHandles {
+  /** Add to the exhibit's group at mount time. */
+  readonly group: THREE.Group;
+  /** Disposes owned geometries + material. Exhibit calls in unmount(). */
+  dispose(): void;
+}
+
+/** Half-extents of the pit's XZ footprint, derived from the cutout. */
+function footprint(cutout: StageCutoutDescriptor): {
+  cx: number;
+  cz: number;
+  halfX: number;
+  halfZ: number;
+} {
+  const [cx, cz] = cutout.centerXZ;
+  if (cutout.kind === 'rect') {
+    return { cx, cz, halfX: cutout.halfExtentX, halfZ: cutout.halfExtentZ };
+  }
+  // circle → bounding-box rect (radius on each axis); the opaque
+  // floor hides the corners, only the circular hole is seen.
+  return { cx, cz, halfX: cutout.radius, halfZ: cutout.radius };
+}
+
+export function createContrastPit(
+  opts: ContrastPitOptions,
+): ContrastPitHandles {
+  const { cx, cz, halfX, halfZ } = footprint(opts.cutout);
+  const depth = opts.depth ?? CONTRAST_PIT_DEPTH_DEFAULT;
+  const topY = opts.topY ?? CONTRAST_PIT_TOP_Y_DEFAULT;
+  const botY = topY - depth;
+  const midY = topY - depth / 2;
+
+  const material = new THREE.MeshBasicMaterial({
+    color: new THREE.Color(...CONTRAST_PIT_COLOR_RGB),
+    side: THREE.DoubleSide,
+    fog: false,
+  });
+  const geometries: THREE.PlaneGeometry[] = [];
+  const group = new THREE.Group();
+  group.name = 'contrast-pit';
+
+  // Per-face geometry (sizes differ), one shared material — the
+  // StageFloor shared-material pattern. PlaneGeometry default lies
+  // in XY (normal +Z); rotate to seat each face.
+  const addFace = (
+    w: number,
+    h: number,
+    pos: readonly [number, number, number],
+    rot: readonly [number, number, number],
+  ): void => {
+    const g = new THREE.PlaneGeometry(w, h);
+    geometries.push(g);
+    const mesh = new THREE.Mesh(g, material);
+    mesh.position.set(pos[0], pos[1], pos[2]);
+    mesh.rotation.set(rot[0], rot[1], rot[2]);
+    mesh.name = 'contrast-pit-face';
+    group.add(mesh);
+  };
+
+  // bottom carpet — horizontal, full footprint.
+  addFace(2 * halfX, 2 * halfZ, [cx, botY, cz], [-Math.PI / 2, 0, 0]);
+  // ±Z walls — span X × depth.
+  addFace(2 * halfX, depth, [cx, midY, cz + halfZ], [0, 0, 0]); // +Z (user)
+  addFace(2 * halfX, depth, [cx, midY, cz - halfZ], [0, 0, 0]); // −Z (back)
+  // ±X walls — span Z × depth.
+  addFace(2 * halfZ, depth, [cx + halfX, midY, cz], [0, Math.PI / 2, 0]);
+  addFace(2 * halfZ, depth, [cx - halfX, midY, cz], [0, Math.PI / 2, 0]);
+  // Open top — the StageFloor cutout is the lid.
+
+  let disposed = false;
+  return {
+    group,
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      material.dispose();
+      for (const g of geometries) g.dispose();
+      geometries.length = 0;
+    },
+  };
+}

--- a/src/scaffold/staging/Environment.ts
+++ b/src/scaffold/staging/Environment.ts
@@ -123,14 +123,35 @@ export const ENVIRONMENT_FLAT_BG_RGB = [0x0d / 255, 0x0d / 255, 0x17 / 255] as c
 export const ENVIRONMENT_CONTRAST_BOX_RGB = [0, 0, 0] as const;
 
 /**
- * Half-extent of the shell-owned contrast box, world units. Sized
- * to enclose the LARGEST cluster focal volume — quadrics' raymarch
- * AABB, `BOUND = 3.5` — plus ~1 m margin (Brad: shell-owned, one
- * box sized to the biggest scene). The smaller-surface scenes get a
- * looser but still fully-black frame, which is fine. First-pass
- * smoke-tunable (feedback_staging_dimensions_first_pass).
+ * Half-extent of the shell-owned contrast box, world units.
+ *
+ * Orientation is world-correct (verified against frames.ts:16
+ * `math→world (X,Z,−Y)` + quadrics/index.ts:816 "Math-Z routes to
+ * world-Y; cube bottom at world-Y −2"): the box is world-axis-
+ * aligned, concentric with the raymarch cube at SURFACE_CENTER, and
+ * its bottom face IS world-down. The PR#245-smoke "bottom points
+ * into the distance" report is a *size* artefact, not a rotation
+ * bug — at 4.5 (a 9 m cube around a ~2–4 m surface, camera ~7 m
+ * away) the bottom is a huge horizontal plane that recedes ~9 m in
+ * perspective, and the near-enclosing black dominates the FOV so
+ * the off-black background can't be judged.
+ *
+ * **Box-size binary search** (same loop as the darkness search;
+ * Brad's call each round):
+ *
+ *   bounds  = [ 1.5 (tight, surface may poke out a touch)  ..
+ *               4.5 (round-1 — judged too cavernous) ]
+ *   round 2 = midpoint(4.5, 1.5) = 3.0                  ← CURRENT
+ *
+ * Next step: still cavernous → midpoint(3.0, 1.5) ≈ 2.25; surface
+ * pokes out / want more margin → midpoint(3.0, 4.5) ≈ 3.75. Keep
+ * the converging bounds here each round (feedback_staging_
+ * dimensions_first_pass). Note quadrics' raymarch AABB is
+ * BOUND = 3.5, so below 3.5 the most extreme hyperboloids can
+ * extend past the box on some axes — acceptable per-iteration;
+ * widen if Brad wants zero poke-out.
  */
-export const ENVIRONMENT_CONTRAST_BOX_HALF_EXTENT = 4.5;
+export const ENVIRONMENT_CONTRAST_BOX_HALF_EXTENT = 3.0;
 
 /**
  * Focal-volume centre, world space. Duplicated here (rather than

--- a/src/scaffold/staging/Environment.ts
+++ b/src/scaffold/staging/Environment.ts
@@ -99,17 +99,17 @@ export const ENVIRONMENT_HORIZON_RGB = [0x11 / 255, 0x11 / 255, 0x22 / 255] as c
  * on darkness** against in-headset smoke (Brad's call each round):
  *
  *   bounds  = [ 0x000000 (darker, "vantablack")  ..
- *               0x07070c (lighter, round-3 — bracket upper) ]
- *   round 4 = midpoint(0x07070c, 0x000000)        = 0x040406  ← CURRENT
+ *               0x040406 (lighter, round-4 — bracket upper) ]
+ *   round 5 = midpoint(0x040406, 0x000000)        = 0x020203  ← CURRENT
  *
- * Next step rule: if round 4 still too light → midpoint(0x040406,
- * 0x000000) ≈ 0x020203; if too dark → midpoint(0x040406, 0x07070c)
- * ≈ 0x050509. Keep the converging bounds in this comment each
+ * Next step rule: if round 5 still too light → midpoint(0x020203,
+ * 0x000000) ≈ 0x010102; if too dark → midpoint(0x020203, 0x040406)
+ * ≈ 0x030305. Keep the converging bounds in this comment each
  * round (feedback_staging_dimensions_first_pass — smoke-tunable
  * value, locked intent). Kept distinct from the gradient horizon
  * stop so the two tune independently.
  */
-export const ENVIRONMENT_FLAT_BG_RGB = [0x04 / 255, 0x04 / 255, 0x06 / 255] as const;
+export const ENVIRONMENT_FLAT_BG_RGB = [0x02 / 255, 0x02 / 255, 0x03 / 255] as const;
 
 /** Dome radius (world units). Default; overridable within invariants. */
 export const ENVIRONMENT_RADIUS_DEFAULT = 40;

--- a/src/scaffold/staging/Environment.ts
+++ b/src/scaffold/staging/Environment.ts
@@ -1,0 +1,364 @@
+import * as THREE from 'three';
+
+// Cluster-wide environment surround for the v1.0 staged-exhibit
+// vocabulary (#221 / E1.3). Replaces the flat `scene.background =
+// 0x111122` void (shell.ts:83) with a baked, static environment so
+// each scene reads as "a dim room with this exhibit on a lit stage"
+// rather than "an object in infinite black space."
+//
+// Ownership (per `_private/plans/v1.0.md` §4 staging rules): SHELL-
+// OWNED singleton. Constructed once at the shell's scene seam,
+// persists across every SceneRack switch (added to `scene`, never to
+// a per-exhibit group, so shell.ts:472's `scene.remove(ctx.group)`
+// never touches it). Torn down on HMR via a `disposers[]` closure
+// pushed AFTER the renderer disposer so LIFO drains env GPU resources
+// (dome geo/mat + gradient DataTexture) BEFORE renderer.dispose()
+// frees the GL context (#224 plan §3.4 — two-way roundtable HIGH).
+//
+// ── Core / richness split (#224 plan §1) ─────────────────────────
+// `mode: 'dome'` (default) = gradient sky dome + linear fog. The
+// "stage spotlight" read is delivered entirely by baked gradients —
+// ZERO lights are added (Quest 3S fragment-shader budget; per-scene
+// AmbientLight+DirectionalLight pairs are untouched). `mode: 'flat'`
+// = a tuned solid horizon-tone background + no fog ≈ today's cost;
+// the Quest-72Hz core degrade tier (regression ⇒ degrade, never
+// defer, per v1.0.md §3). `richness` (default FALSE for v1 —
+// atmosphere is the first cut, v1.0.md §2) opts in to dim distant-
+// detail slabs at the fog boundary.
+//
+// ── Fog model: LOCKED linear THREE.Fog (#224 plan §3.2) ──────────
+// Three-vendor roundtable converged on linear over FogExp2: linear
+// fog applies ZERO attenuation for distance < `near`, making "the
+// stage stays crisp" a hard, provable invariant rather than a
+// density-tuning hope (FogExp2 cannot be crisp@14m AND heavy@40m at
+// radius 40 simultaneously). `fogNear` is asserted ≥ MAX_STAGE_REACH.
+//
+// ── scene.fog material audit (#224 plan §3.5, as amended at
+//    implementation after reading the UI code) ──────────────────
+// `scene.fog` is global. The audit's enforcement mechanism is the
+// `fogNear` invariant itself, NOT scattered per-material `fog:false`
+// flags:
+//   • Near-field UI — SceneTab/TapButton, troika readouts, Slider,
+//     SectionTab, Label, WorldAxes — all sit near SURFACE_CENTER,
+//     ≤ ~12 m from any reachable camera (OrbitControls maxDistance
+//     = 12, cameraControls.ts:61). With linear fog and
+//     fogNear ≥ 14, fog factor is provably 0 for them. No flag
+//     needed; the invariant covers all present AND future cluster
+//     UI (nothing to forget when a 5th scene lands).
+//   • `TranslucentRect` overlays are a ShaderMaterial with no fog
+//     uniforms/chunks → structurally fog-immune regardless of
+//     scene.fog. No flag needed.
+//   • `StageFloor` / `StageRailing` MeshStandardMaterial KEEP the
+//     Three.js default `fog: true` — gentle atmospheric recession
+//     of the stage edges past `fogNear` is the desired read.
+//   • The dome opts OUT (`fog:false`) — it is the fog backdrop,
+//     not fogged geometry.
+//   • `SceneRack` is the one element that can marginally exceed
+//     `fogNear` in an extreme orbit pose (~15 m, ~4% imperceptible
+//     fade) AND is persistent shell-owned navigation UI, so the
+//     shell sets `fog:false` on its mesh materials explicitly
+//     (belt-and-suspenders + token-stability). Done at the shell,
+//     not here — see shell.ts.
+//
+// Three.js export discipline (v1.0.md §4 / feedback_threejs_token_
+// exports_immutable): colours are immutable RGB tuples (`as const`)
+// + factory functions, never `export const c = new THREE.Color(...)`.
+
+/**
+ * Gradient stops, darkest at the floor/horizon band where the #215
+ * translucent overlays + #216 readouts visually sit. Deliberately
+ * conservative — kept in the `0x111122` family so the #215/#216
+ * token calibration (tuned against today's void) holds without a
+ * cluster-wide re-tune (#224 plan §1 / §2.3). The horizon stop is
+ * the load-bearing one (overlays sit against it); it is canary-
+ * tested in Environment.test.ts to stay within tolerance of
+ * `0x111122`.
+ *
+ * Smoke-tuned first-pass values (feedback_staging_dimensions_first_
+ * pass); the *invariant* (horizon ∈ 0x111122 family) is locked, the
+ * exact hex are not.
+ */
+export const ENVIRONMENT_ZENITH_RGB = [0x0a / 255, 0x0a / 255, 0x18 / 255] as const;
+export const ENVIRONMENT_MIDGLOW_RGB = [0x1a / 255, 0x1a / 255, 0x30 / 255] as const;
+export const ENVIRONMENT_HORIZON_RGB = [0x11 / 255, 0x11 / 255, 0x22 / 255] as const;
+
+/** Dome radius (world units). Default; overridable within invariants. */
+export const ENVIRONMENT_RADIUS_DEFAULT = 40;
+
+/**
+ * Minimum legal `fogNear` = the cluster's largest stage reach. The
+ * widest stage is tangent-planes (`outerHalfExtent: 6` + `back-
+ * Extension: 3`); worst-case camera-to-far-stage-corner ≈ 13–14 m.
+ * Linear fog ⇒ zero attenuation below this ⇒ the stage is provably
+ * un-hazed (#224 plan §2.2 invariant 1).
+ */
+export const ENVIRONMENT_FOG_NEAR_MIN = 14;
+export const ENVIRONMENT_FOG_NEAR_DEFAULT = 14;
+
+/**
+ * Max reachable camera distance from world origin: OrbitControls
+ * `maxDistance = 12` (cameraControls.ts:61) about `target =
+ * SURFACE_CENTER = (0, 1.5, -4)`; |SURFACE_CENTER| = √18.25 ≈ 4.27;
+ * 12 + 4.27 ≈ 16.3. VR is room-scale + no-teleport (#221), bounded
+ * tighter. The dome radius must clear this so a `BackSide` sphere
+ * can never be exited (→ black void on the primary audition
+ * surface — roundtable GPT #5).
+ */
+export const ENVIRONMENT_MAX_CAMERA_REACH = 16.3;
+export const ENVIRONMENT_RADIUS_MARGIN = 8;
+
+/**
+ * Shell `PerspectiveCamera` far plane (mirrors shell.ts:88).
+ * Asserted so a future far-plane reduction below the dome radius is
+ * caught at construction rather than as silent dome clipping.
+ */
+export const ENVIRONMENT_CAMERA_FAR = 100;
+
+/** Dome renders first + tests/writes no depth (see §3.2). */
+export const ENVIRONMENT_DOME_RENDER_ORDER = -1;
+
+/** Vertical resolution of the gradient DataTexture (1 × N RGBA8). */
+const GRADIENT_TEXELS = 64;
+
+type RGB = readonly [number, number, number];
+
+/**
+ * Pure: the three gradient stops as 0–1 RGB tuples. Exposed so the
+ * canary test can assert the horizon stop without rasterizing a
+ * texture (no jsdom canvas dependency — roundtable GPT #6).
+ */
+export function buildGradientStops(): {
+  zenith: RGB;
+  midGlow: RGB;
+  horizon: RGB;
+} {
+  return {
+    zenith: ENVIRONMENT_ZENITH_RGB,
+    midGlow: ENVIRONMENT_MIDGLOW_RGB,
+    horizon: ENVIRONMENT_HORIZON_RGB,
+  };
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+/**
+ * Build the vertical-gradient DataTexture. SphereGeometry's V runs 0
+ * at the −Y (floor-ward) pole to 1 at the +Y (zenith) pole, so texel
+ * 0 = horizon/floor tone, top texel = zenith, with the cool up-glow
+ * mid-dome. DataTexture needs no `<canvas>` → fully Vitest-
+ * constructible.
+ */
+function buildGradientTexture(): THREE.DataTexture {
+  const { zenith, midGlow, horizon } = buildGradientStops();
+  const data = new Uint8Array(GRADIENT_TEXELS * 4);
+  for (let i = 0; i < GRADIENT_TEXELS; i++) {
+    const v = i / (GRADIENT_TEXELS - 1); // 0 = floor-ward, 1 = zenith
+    // Piecewise: floor→up-glow over the lower half, up-glow→zenith
+    // over the upper half.
+    let r: number, g: number, b: number;
+    if (v < 0.5) {
+      const t = v / 0.5;
+      r = lerp(horizon[0], midGlow[0], t);
+      g = lerp(horizon[1], midGlow[1], t);
+      b = lerp(horizon[2], midGlow[2], t);
+    } else {
+      const t = (v - 0.5) / 0.5;
+      r = lerp(midGlow[0], zenith[0], t);
+      g = lerp(midGlow[1], zenith[1], t);
+      b = lerp(midGlow[2], zenith[2], t);
+    }
+    const o = i * 4;
+    data[o] = Math.round(r * 255);
+    data[o + 1] = Math.round(g * 255);
+    data[o + 2] = Math.round(b * 255);
+    data[o + 3] = 255;
+  }
+  const tex = new THREE.DataTexture(
+    data,
+    1,
+    GRADIENT_TEXELS,
+    THREE.RGBAFormat,
+  );
+  tex.minFilter = THREE.LinearFilter;
+  tex.magFilter = THREE.LinearFilter;
+  tex.wrapS = THREE.ClampToEdgeWrapping;
+  tex.wrapT = THREE.ClampToEdgeWrapping;
+  tex.needsUpdate = true;
+  return tex;
+}
+
+function horizonColor(): THREE.Color {
+  return new THREE.Color(...ENVIRONMENT_HORIZON_RGB);
+}
+
+export interface EnvironmentOptions {
+  /**
+   * `'dome'` (default) = gradient dome + linear fog. `'flat'` =
+   * tuned solid horizon-tone background, no fog (the Quest-72Hz
+   * core degrade tier, #224 plan §3.6).
+   */
+  readonly mode?: 'dome' | 'flat';
+  /**
+   * Dome radius (world units). Invariants:
+   * `fogFar ≤ radius`, `radius ≥ MAX_CAMERA_REACH + margin`,
+   * `radius < CAMERA_FAR`. Default `ENVIRONMENT_RADIUS_DEFAULT`.
+   */
+  readonly radius?: number;
+  /**
+   * Linear-fog onset. Invariant `fogNear ≥ ENVIRONMENT_FOG_NEAR_MIN`
+   * so the stage is provably un-hazed. Default
+   * `ENVIRONMENT_FOG_NEAR_DEFAULT`.
+   */
+  readonly fogNear?: number;
+  /** Linear-fog full-occlusion distance. Invariant `fogNear < fogFar
+   *  ≤ radius`. Default = `radius`. */
+  readonly fogFar?: number;
+  /** Opt-in dim distant-detail slabs at the fog boundary. v1 default
+   *  FALSE (atmosphere is the first cut, v1.0.md §2). */
+  readonly richness?: boolean;
+}
+
+export interface EnvironmentHandles {
+  /** Shell adds to `scene` once at boot; survives scene switches.
+   *  Empty group in `'flat'` mode. */
+  readonly group: THREE.Group;
+  /** Linear `THREE.Fog` (`'dome'`) or `null` (`'flat'`). Shell does
+   *  `scene.fog = handles.fog`. */
+  readonly fog: THREE.Fog | null;
+  /** Solid background for `'flat'` mode, else `null`. Shell does
+   *  `scene.background = handles.background`. */
+  readonly background: THREE.Color | null;
+  /** Idempotent. Disposes dome geo/mat + gradient texture (+ richness
+   *  geos/mats). Mirrors StageFloor's `disposed` guard. */
+  dispose(): void;
+}
+
+export function createEnvironment(
+  opts: EnvironmentOptions = {},
+): EnvironmentHandles {
+  const mode = opts.mode ?? 'dome';
+  const radius = opts.radius ?? ENVIRONMENT_RADIUS_DEFAULT;
+  const fogNear = opts.fogNear ?? ENVIRONMENT_FOG_NEAR_DEFAULT;
+  const fogFar = opts.fogFar ?? radius;
+  const richness = opts.richness ?? false;
+
+  const group = new THREE.Group();
+  group.name = 'environment';
+
+  if (mode === 'flat') {
+    // Degrade tier: a single tuned clear colour, no dome, no fog —
+    // ≈ today's cost but the *tuned* tone, still a deliberate
+    // improvement over the bare 0x111122 void.
+    let disposed = false;
+    return {
+      group,
+      fog: null,
+      background: horizonColor(),
+      dispose(): void {
+        if (disposed) return;
+        disposed = true;
+        // Nothing GPU-owned in 'flat' mode.
+      },
+    };
+  }
+
+  // ── 'dome' mode: invariant gate (#224 plan §2.2) ───────────────
+  if (fogNear < ENVIRONMENT_FOG_NEAR_MIN) {
+    throw new Error(
+      `createEnvironment: fogNear invariant violated — fogNear=${fogNear} ` +
+        `< ENVIRONMENT_FOG_NEAR_MIN=${ENVIRONMENT_FOG_NEAR_MIN}. Linear fog ` +
+        `would haze the stage; raise fogNear or shrink the stage envelope.`,
+    );
+  }
+  if (fogNear >= fogFar) {
+    throw new Error(
+      `createEnvironment: fog ordering invariant violated — ` +
+        `fogNear=${fogNear} must be < fogFar=${fogFar}.`,
+    );
+  }
+  if (fogFar > radius) {
+    throw new Error(
+      `createEnvironment: fogFar invariant violated — fogFar=${fogFar} ` +
+        `> radius=${radius}. Fog must fully occlude at/before the dome.`,
+    );
+  }
+  if (radius < ENVIRONMENT_MAX_CAMERA_REACH + ENVIRONMENT_RADIUS_MARGIN) {
+    throw new Error(
+      `createEnvironment: radius invariant violated — radius=${radius} ` +
+        `< MAX_CAMERA_REACH(${ENVIRONMENT_MAX_CAMERA_REACH}) + ` +
+        `margin(${ENVIRONMENT_RADIUS_MARGIN}). The camera could exit the ` +
+        `BackSide dome → black void.`,
+    );
+  }
+  if (radius >= ENVIRONMENT_CAMERA_FAR) {
+    throw new Error(
+      `createEnvironment: radius invariant violated — radius=${radius} ` +
+        `>= CAMERA_FAR(${ENVIRONMENT_CAMERA_FAR}). The dome would clip ` +
+        `against the camera far plane.`,
+    );
+  }
+
+  const gradientTexture = buildGradientTexture();
+  const domeGeometry = new THREE.SphereGeometry(radius, 32, 16);
+  const domeMaterial = new THREE.MeshBasicMaterial({
+    side: THREE.BackSide,
+    map: gradientTexture,
+    // Backdrop: paint first (renderOrder -1), test/write no depth so
+    // it can never occlude stage geometry and stage geometry never
+    // "punches through" it. Deterministic — does not rely on same-
+    // renderOrder opaque sort (roundtable Sonnet #5 / DeepSeek #2).
+    fog: false,
+    depthWrite: false,
+    depthTest: false,
+  });
+  const domeMesh = new THREE.Mesh(domeGeometry, domeMaterial);
+  domeMesh.renderOrder = ENVIRONMENT_DOME_RENDER_ORDER;
+  group.add(domeMesh);
+
+  const richnessGeometries: THREE.BufferGeometry[] = [];
+  const richnessMaterials: THREE.Material[] = [];
+  if (richness) {
+    // Dim unlit slabs just inside the dome, at the fog boundary, so
+    // they dissolve into the horizon-tone fog (fog:true is correct
+    // here — they sit at ~radius, far past fogNear). No per-exhibit-
+    // floor interaction (they're at the dome, nowhere near a floor).
+    const slabSpecs: ReadonlyArray<{ x: number; z: number; w: number }> = [
+      { x: 0, z: -(radius - 4), w: 3 },
+      { x: radius - 6, z: -(radius - 10), w: 2 },
+    ];
+    for (const s of slabSpecs) {
+      const g = new THREE.BoxGeometry(s.w, 4.5, 0.3);
+      const m = new THREE.MeshBasicMaterial({
+        color: new THREE.Color(...ENVIRONMENT_MIDGLOW_RGB),
+        fog: true,
+      });
+      const slab = new THREE.Mesh(g, m);
+      slab.position.set(s.x, 2.25, s.z);
+      group.add(slab);
+      richnessGeometries.push(g);
+      richnessMaterials.push(m);
+    }
+  }
+
+  const fog = new THREE.Fog(horizonColor(), fogNear, fogFar);
+
+  let disposed = false;
+  return {
+    group,
+    fog,
+    background: null,
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      domeGeometry.dispose();
+      domeMaterial.dispose();
+      gradientTexture.dispose();
+      for (const g of richnessGeometries) g.dispose();
+      for (const m of richnessMaterials) m.dispose();
+      richnessGeometries.length = 0;
+      richnessMaterials.length = 0;
+    },
+  };
+}

--- a/src/scaffold/staging/Environment.ts
+++ b/src/scaffold/staging/Environment.ts
@@ -31,14 +31,18 @@ import * as THREE from 'three';
 // DirectionalLight pairs untouched). `richness` (default FALSE)
 // opts the dome path into dim distant-detail slabs.
 //
-// ── Vantablack contrast box (#245 smoke, default ON) ─────────────
-// Independent of mode: a pure-black 5-face open-front box framing
-// the focal volume so the rendered surface reads at maximum
-// contrast against true black, while the rest of the environment
-// stays the off-black flat tone (or the dome). Shell-owned, ONE box
-// sized to the largest cluster focal volume (quadrics' ±3.5 AABB),
-// centred on the shared SURFACE_CENTER. Built mode-independently
-// and disposed by both flat + dome paths.
+// ── Vantablack sub-floor pit (#245 smoke, default ON) ────────────
+// Independent of mode: a pure-black carpet + short walls ENTIRELY
+// BELOW the StageFloor (world Y=0), beneath where the surface dips
+// through the floor cutout. Looking down past the floor reveals
+// purposeful pure black under the exhibit; at eye level / above
+// only the near-black skybox shows — it "obscures the skybox only
+// in the downward direction" (Brad's clarification: it is NOT an
+// enclosure around the surface). Open-top + open-front (4 faces);
+// the StageFloor + its cutout are the lid. Shell-owned, ONE pit
+// sized to cover the largest cluster cutout, XZ-centred on the
+// shared focal footprint. Built mode-independently, disposed by
+// both flat + dome paths.
 //
 // ── Fog model: LOCKED linear THREE.Fog (#224 plan §3.2) ──────────
 // Three-vendor roundtable converged on linear over FogExp2: linear
@@ -101,17 +105,17 @@ export const ENVIRONMENT_HORIZON_RGB = [0x11 / 255, 0x11 / 255, 0x22 / 255] as c
  * on darkness** against in-headset smoke (Brad's call each round):
  *
  *   bounds  = [ 0x000000 (darker, "vantablack")  ..
- *               0x1a1a2e (lighter, PR#245 round-1 — judged too light) ]
- *   round 2 = midpoint(0x1a1a2e, 0x000000)        = 0x0d0d17  ← CURRENT
+ *               0x0d0d17 (lighter, round-2 — judged still too light) ]
+ *   round 3 = midpoint(0x0d0d17, 0x000000)        = 0x07070c  ← CURRENT
  *
- * Next step rule: if round 2 still too light → midpoint(0x0d0d17,
- * 0x000000) ≈ 0x07070b; if too dark → midpoint(0x0d0d17, 0x1a1a2e)
- * ≈ 0x131320. Keep the converging bounds in this comment each
+ * Next step rule: if round 3 still too light → midpoint(0x07070c,
+ * 0x000000) ≈ 0x040406; if too dark → midpoint(0x07070c, 0x0d0d17)
+ * ≈ 0x0a0a12. Keep the converging bounds in this comment each
  * round (feedback_staging_dimensions_first_pass — smoke-tunable
  * value, locked intent). Kept distinct from the gradient horizon
  * stop so the two tune independently.
  */
-export const ENVIRONMENT_FLAT_BG_RGB = [0x0d / 255, 0x0d / 255, 0x17 / 255] as const;
+export const ENVIRONMENT_FLAT_BG_RGB = [0x07 / 255, 0x07 / 255, 0x0c / 255] as const;
 
 /**
  * The contrast box is pure black ("vantablack") on purpose — it
@@ -123,42 +127,42 @@ export const ENVIRONMENT_FLAT_BG_RGB = [0x0d / 255, 0x0d / 255, 0x17 / 255] as c
 export const ENVIRONMENT_CONTRAST_BOX_RGB = [0, 0, 0] as const;
 
 /**
- * Half-extent of the shell-owned contrast box, world units.
+ * The contrast box is a **sub-floor black pit**, not an enclosure
+ * around the surface (PR #245 smoke iteration 4 — Brad's
+ * clarification). It sits entirely BELOW the `StageFloor` (world
+ * Y = 0): a black "carpet" + short surrounding walls beneath where
+ * the surface dips through the floor cutout. Looking down past the
+ * floor reveals purposeful pure black under the exhibit; at eye
+ * level and above only the (near-black) background skybox shows —
+ * the pit "obscures the skybox only in the downward direction."
  *
- * Orientation is world-correct (verified against frames.ts:16
- * `math→world (X,Z,−Y)` + quadrics/index.ts:816 "Math-Z routes to
- * world-Y; cube bottom at world-Y −2"): the box is world-axis-
- * aligned, concentric with the raymarch cube at SURFACE_CENTER, and
- * its bottom face IS world-down. The PR#245-smoke "bottom points
- * into the distance" report is a *size* artefact, not a rotation
- * bug — at 4.5 (a 9 m cube around a ~2–4 m surface, camera ~7 m
- * away) the bottom is a huge horizontal plane that recedes ~9 m in
- * perspective, and the near-enclosing black dominates the FOV so
- * the off-black background can't be judged.
+ * Open-top + open-front (toward the user, +Z): 4 black faces —
+ * bottom + back(−Z) + left(−X) + right(+X). A closed top would
+ * z-fight the StageFloor at Y = 0 or cap the pit and defeat the
+ * look-down-and-see-black effect; the StageFloor + its cutout are
+ * the "lid" you peer through. (This is the documented 5→4-face
+ * deviation from the earlier "5-sided" framing; surfaced to Brad.)
  *
- * **Box-size binary search** (same loop as the darkness search;
- * Brad's call each round):
- *
- *   bounds  = [ 1.5 (tight, surface may poke out a touch)  ..
- *               4.5 (round-1 — judged too cavernous) ]
- *   round 2 = midpoint(4.5, 1.5) = 3.0                  ← CURRENT
- *
- * Next step: still cavernous → midpoint(3.0, 1.5) ≈ 2.25; surface
- * pokes out / want more margin → midpoint(3.0, 4.5) ≈ 3.75. Keep
- * the converging bounds here each round (feedback_staging_
- * dimensions_first_pass). Note quadrics' raymarch AABB is
- * BOUND = 3.5, so below 3.5 the most extreme hyperboloids can
- * extend past the box on some axes — acceptable per-iteration;
- * widen if Brad wants zero poke-out.
+ * `XZ_HALF` covers the LARGEST cluster floor cutout (quadrics'
+ * `BOUND·1.05 ≈ 3.7`) so everything visible through any scene's
+ * cutout is black; walls beyond a given scene's cutout are hidden
+ * under that scene's opaque StageFloor. `TOP_Y` is a hair below 0
+ * to avoid z-fighting the floor; `DEPTH` clears the deepest dip
+ * (quadrics cube bottom at world-Y −2) with margin. All three are
+ * first-pass smoke-tunable (feedback_staging_dimensions_first_pass).
  */
-export const ENVIRONMENT_CONTRAST_BOX_HALF_EXTENT = 3.0;
+export const ENVIRONMENT_PIT_XZ_HALF = 4.0;
+export const ENVIRONMENT_PIT_TOP_Y = -0.02;
+export const ENVIRONMENT_PIT_DEPTH = 3.0;
 
 /**
- * Focal-volume centre, world space. Duplicated here (rather than
+ * Focal-volume XZ centre, world space. Duplicated here (rather than
  * imported from an exhibit) for the same reason cameraControls.ts:18
  * duplicates it: the shell/scaffold layer stays free of cross-
  * cluster scene imports, and the four scenes' `SURFACE_CENTER`
  * constants are independent declarations that happen to coincide.
+ * Only XZ is used (the pit's Y is floor-relative, not surface-
+ * relative).
  */
 const CONTRAST_BOX_CENTER = new THREE.Vector3(0, 1.5, -4);
 
@@ -274,52 +278,71 @@ function horizonColor(): THREE.Color {
 }
 
 /**
- * Five-face open-front "vantablack" box framing the focal volume
- * (Brad's pick: full box, everything but the viewer/+Z side). Back
- * + top + bottom + two sides; the +Z face is omitted so the camera
- * looks in. All five faces are 2h × 2h squares sharing ONE geometry
- * + ONE unlit pure-black material (`DoubleSide`, `fog:false`) — so
- * winding/normal direction is irrelevant and dispose is one geo +
- * one mat (the StageFloor shared-material pattern). Opaque, normal
- * depth: the StageFloor / railing / raymarched surface correctly
- * render in front; through the floor cutout the surface dips into
- * pure black. The box is finite and centred on the focal volume, so
- * the off-black `scene.background` still shows past its edges / open
- * front — focal volume black, periphery off-black, exactly the
- * museum-shadow-box read.
+ * Build the sub-floor "vantablack" pit (PR #245 smoke iter 4 —
+ * Brad's clarification): a black carpet + short surrounding walls
+ * ENTIRELY below the StageFloor (world Y = 0), so looking down past
+ * the floor reveals pure black under the exhibit while the skybox
+ * stays visible at eye level / above.
+ *
+ * 4 faces, open-top + open-front(+Z): bottom + back(−Z) + left(−X)
+ * + right(+X). Sizes differ per face, so each gets its own
+ * `PlaneGeometry`; ONE shared unlit pure-black `DoubleSide`,
+ * `fog:false` material (the StageFloor shared-material pattern).
+ * Opaque, normal depth — the StageFloor occludes the walls except
+ * through its cutout, which is exactly the "lid you peer through."
+ *
+ * Geometry (XZ centred on the focal footprint, Y floor-relative):
+ *   topY    = ENVIRONMENT_PIT_TOP_Y           (≈ −0.02, just below floor)
+ *   botY    = topY − ENVIRONMENT_PIT_DEPTH    (clears the deepest dip)
+ *   ±half   = ENVIRONMENT_PIT_XZ_HALF         (covers the largest cutout)
  */
 function buildContrastBox(group: THREE.Group): {
-  geometry: THREE.PlaneGeometry;
+  geometries: THREE.PlaneGeometry[];
   material: THREE.MeshBasicMaterial;
 } {
-  const c = CONTRAST_BOX_CENTER;
-  const h = ENVIRONMENT_CONTRAST_BOX_HALF_EXTENT;
-  const geometry = new THREE.PlaneGeometry(2 * h, 2 * h);
+  const cx = CONTRAST_BOX_CENTER.x;
+  const cz = CONTRAST_BOX_CENTER.z;
+  const half = ENVIRONMENT_PIT_XZ_HALF;
+  const topY = ENVIRONMENT_PIT_TOP_Y;
+  const depth = ENVIRONMENT_PIT_DEPTH;
+  const botY = topY - depth;
+  const midY = topY - depth / 2;
+
   const material = new THREE.MeshBasicMaterial({
     color: new THREE.Color(...ENVIRONMENT_CONTRAST_BOX_RGB),
     side: THREE.DoubleSide,
     fog: false,
   });
-  // [position, rotation] per face. PlaneGeometry's default lies in
-  // XY with +Z normal; rotate to seat each wall. +Z (front) omitted.
-  const faces: ReadonlyArray<{
-    pos: [number, number, number];
-    rot: [number, number, number];
-  }> = [
-    { pos: [c.x, c.y, c.z - h], rot: [0, 0, 0] }, // back  (−Z wall)
-    { pos: [c.x, c.y + h, c.z], rot: [-Math.PI / 2, 0, 0] }, // top
-    { pos: [c.x, c.y - h, c.z], rot: [-Math.PI / 2, 0, 0] }, // bottom
-    { pos: [c.x - h, c.y, c.z], rot: [0, Math.PI / 2, 0] }, // left  (−X)
-    { pos: [c.x + h, c.y, c.z], rot: [0, Math.PI / 2, 0] }, // right (+X)
-  ];
-  for (const f of faces) {
-    const mesh = new THREE.Mesh(geometry, material);
-    mesh.position.set(...f.pos);
-    mesh.rotation.set(...f.rot);
+  const geometries: THREE.PlaneGeometry[] = [];
+
+  // Each face: its own geometry (sizes differ), one shared material.
+  // PlaneGeometry default lies in XY (normal +Z); rotate to seat.
+  const addFace = (
+    w: number,
+    h: number,
+    pos: [number, number, number],
+    rot: [number, number, number],
+  ): void => {
+    const g = new THREE.PlaneGeometry(w, h);
+    geometries.push(g);
+    const mesh = new THREE.Mesh(g, material);
+    mesh.position.set(...pos);
+    mesh.rotation.set(...rot);
     mesh.name = 'contrast-box-face';
     group.add(mesh);
-  }
-  return { geometry, material };
+  };
+
+  // bottom carpet — horizontal, spans the full XZ footprint.
+  addFace(2 * half, 2 * half, [cx, botY, cz], [-Math.PI / 2, 0, 0]);
+  // back wall (−Z) — vertical, spans X × depth.
+  addFace(2 * half, depth, [cx, midY, cz - half], [0, 0, 0]);
+  // left wall (−X) — vertical, spans Z × depth.
+  addFace(2 * half, depth, [cx - half, midY, cz], [0, Math.PI / 2, 0]);
+  // right wall (+X) — vertical, spans Z × depth.
+  addFace(2 * half, depth, [cx + half, midY, cz], [0, Math.PI / 2, 0]);
+  // open top (+Y, the StageFloor/cutout is the lid) + open front (+Z).
+
+  return { geometries, material };
 }
 
 export interface EnvironmentOptions {
@@ -348,9 +371,8 @@ export interface EnvironmentOptions {
   /** Opt-in dim distant-detail slabs at the fog boundary. v1 default
    *  FALSE (atmosphere is the first cut, v1.0.md §2). */
   readonly richness?: boolean;
-  /** Pure-black 5-face open-front contrast box framing the focal
-   *  volume (PR #245 smoke). Default TRUE — it's the shipped intent
-   *  in both flat and dome modes. */
+  /** Pure-black sub-floor contrast pit beneath the StageFloor (PR
+   *  #245 smoke). Default TRUE — shipped intent in flat + dome. */
   readonly contrastBox?: boolean;
 }
 
@@ -384,13 +406,13 @@ export function createEnvironment(
   const group = new THREE.Group();
   group.name = 'environment';
 
-  // Shell-owned, mode-independent: the vantablack contrast box is
+  // Shell-owned, mode-independent: the sub-floor vantablack pit is
   // built once and shared by flat + dome paths (Brad: one box,
   // shell-owned). Tracked here so BOTH dispose paths release it.
   const box = useContrastBox ? buildContrastBox(group) : null;
   const disposeBox = (): void => {
     if (!box) return;
-    box.geometry.dispose();
+    for (const g of box.geometries) g.dispose();
     box.material.dispose();
   };
 

--- a/src/scaffold/staging/Environment.ts
+++ b/src/scaffold/staging/Environment.ts
@@ -99,17 +99,18 @@ export const ENVIRONMENT_HORIZON_RGB = [0x11 / 255, 0x11 / 255, 0x22 / 255] as c
  * on darkness** against in-headset smoke (Brad's call each round):
  *
  *   bounds  = [ 0x000000 (darker, "vantablack")  ..
- *               0x040406 (lighter, round-4 — bracket upper) ]
- *   round 5 = midpoint(0x040406, 0x000000)        = 0x020203  ← CURRENT
+ *               0x020203 (lighter, round-5 — bracket upper) ]
+ *   round 6 = 0x010102  ← CURRENT (Brad-specified; expected LOCK —
+ *             essentially black, a hair off pure void)
  *
- * Next step rule: if round 5 still too light → midpoint(0x020203,
- * 0x000000) ≈ 0x010102; if too dark → midpoint(0x020203, 0x040406)
- * ≈ 0x030305. Keep the converging bounds in this comment each
- * round (feedback_staging_dimensions_first_pass — smoke-tunable
- * value, locked intent). Kept distinct from the gradient horizon
- * stop so the two tune independently.
+ * Next step rule (only if round 6 isn't locked): darker ⇒ 0x000000
+ * (pure black, the floor of the search); lighter ⇒
+ * midpoint(0x010102, 0x020203) ≈ 0x010203. Keep the converging
+ * bounds in this comment each round (feedback_staging_dimensions_
+ * first_pass — smoke-tunable value, locked intent). Kept distinct
+ * from the gradient horizon stop so the two tune independently.
  */
-export const ENVIRONMENT_FLAT_BG_RGB = [0x02 / 255, 0x02 / 255, 0x03 / 255] as const;
+export const ENVIRONMENT_FLAT_BG_RGB = [0x01 / 255, 0x01 / 255, 0x02 / 255] as const;
 
 /** Dome radius (world units). Default; overridable within invariants. */
 export const ENVIRONMENT_RADIUS_DEFAULT = 40;

--- a/src/scaffold/staging/Environment.ts
+++ b/src/scaffold/staging/Environment.ts
@@ -105,17 +105,17 @@ export const ENVIRONMENT_HORIZON_RGB = [0x11 / 255, 0x11 / 255, 0x22 / 255] as c
  * on darkness** against in-headset smoke (Brad's call each round):
  *
  *   bounds  = [ 0x000000 (darker, "vantablack")  ..
- *               0x0d0d17 (lighter, round-2 — judged still too light) ]
- *   round 3 = midpoint(0x0d0d17, 0x000000)        = 0x07070c  ← CURRENT
+ *               0x07070c (lighter, round-3 — bracket upper) ]
+ *   round 4 = midpoint(0x07070c, 0x000000)        = 0x040406  ← CURRENT
  *
- * Next step rule: if round 3 still too light → midpoint(0x07070c,
- * 0x000000) ≈ 0x040406; if too dark → midpoint(0x07070c, 0x0d0d17)
- * ≈ 0x0a0a12. Keep the converging bounds in this comment each
+ * Next step rule: if round 4 still too light → midpoint(0x040406,
+ * 0x000000) ≈ 0x020203; if too dark → midpoint(0x040406, 0x07070c)
+ * ≈ 0x050509. Keep the converging bounds in this comment each
  * round (feedback_staging_dimensions_first_pass — smoke-tunable
  * value, locked intent). Kept distinct from the gradient horizon
  * stop so the two tune independently.
  */
-export const ENVIRONMENT_FLAT_BG_RGB = [0x07 / 255, 0x07 / 255, 0x0c / 255] as const;
+export const ENVIRONMENT_FLAT_BG_RGB = [0x04 / 255, 0x04 / 255, 0x06 / 255] as const;
 
 /**
  * The contrast box is pure black ("vantablack") on purpose — it

--- a/src/scaffold/staging/Environment.ts
+++ b/src/scaffold/staging/Environment.ts
@@ -15,16 +15,21 @@ import * as THREE from 'three';
 // (dome geo/mat + gradient DataTexture) BEFORE renderer.dispose()
 // frees the GL context (#224 plan §3.4 — two-way roundtable HIGH).
 //
-// ── Core / richness split (#224 plan §1) ─────────────────────────
-// `mode: 'dome'` (default) = gradient sky dome + linear fog. The
-// "stage spotlight" read is delivered entirely by baked gradients —
-// ZERO lights are added (Quest 3S fragment-shader budget; per-scene
-// AmbientLight+DirectionalLight pairs are untouched). `mode: 'flat'`
-// = a tuned solid horizon-tone background + no fog ≈ today's cost;
-// the Quest-72Hz core degrade tier (regression ⇒ degrade, never
-// defer, per v1.0.md §3). `richness` (default FALSE for v1 —
-// atmosphere is the first cut, v1.0.md §2) opts in to dim distant-
-// detail slabs at the fog boundary.
+// ── Core / richness split (#224 plan §1; post-smoke amendment) ───
+// `mode: 'flat'` (DEFAULT after PR #245 headset smoke) = a single
+// tuned solid background, a touch lighter than the old 0x111122
+// void, no dome, no fog. Brad's smoke finding: the gradient dome +
+// fog were over-built for the perceptual payoff (a featureless
+// gradient sphere shows no parallax — confirmed in-headset — so the
+// dome-mesh-over-background-color rationale didn't hold; the fog
+// reads "really light for humans"); v1.0.md §2 ranks E1.3
+// atmosphere as the first cut, so the minimal "void, slightly
+// lighter" is what ships. `mode: 'dome'` = the reviewed gradient
+// sky dome + linear fog, kept as a tested opt-in for a future
+// richer pass (delivers its "stage spotlight" read entirely via
+// baked gradients — ZERO lights; per-scene AmbientLight+
+// DirectionalLight pairs untouched). `richness` (default FALSE)
+// opts the dome path into dim distant-detail slabs.
 //
 // ── Fog model: LOCKED linear THREE.Fog (#224 plan §3.2) ──────────
 // Three-vendor roundtable converged on linear over FogExp2: linear
@@ -81,6 +86,17 @@ import * as THREE from 'three';
 export const ENVIRONMENT_ZENITH_RGB = [0x0a / 255, 0x0a / 255, 0x18 / 255] as const;
 export const ENVIRONMENT_MIDGLOW_RGB = [0x1a / 255, 0x1a / 255, 0x30 / 255] as const;
 export const ENVIRONMENT_HORIZON_RGB = [0x11 / 255, 0x11 / 255, 0x22 / 255] as const;
+
+/**
+ * The shipped `mode: 'flat'` background — the old 0x111122 void
+ * nudged a touch lighter (same cool-dark family) per PR #245 smoke
+ * ("not much different from the void, just a little lighter").
+ * First-pass smoke-tunable (feedback_staging_dimensions_first_pass);
+ * Brad eyeballs the exact lift on the next preview. Kept distinct
+ * from the gradient horizon stop so the two are independently
+ * tunable and the intent is explicit, not coincidental.
+ */
+export const ENVIRONMENT_FLAT_BG_RGB = [0x1a / 255, 0x1a / 255, 0x2e / 255] as const;
 
 /** Dome radius (world units). Default; overridable within invariants. */
 export const ENVIRONMENT_RADIUS_DEFAULT = 40;
@@ -195,9 +211,10 @@ function horizonColor(): THREE.Color {
 
 export interface EnvironmentOptions {
   /**
-   * `'dome'` (default) = gradient dome + linear fog. `'flat'` =
-   * tuned solid horizon-tone background, no fog (the Quest-72Hz
-   * core degrade tier, #224 plan §3.6).
+   * `'flat'` (DEFAULT, post-#245-smoke) = a tuned solid background a
+   * touch lighter than the void, no dome/fog. `'dome'` = the
+   * reviewed gradient dome + linear fog (opt-in; future richer
+   * pass).
    */
   readonly mode?: 'dome' | 'flat';
   /**
@@ -238,7 +255,7 @@ export interface EnvironmentHandles {
 export function createEnvironment(
   opts: EnvironmentOptions = {},
 ): EnvironmentHandles {
-  const mode = opts.mode ?? 'dome';
+  const mode = opts.mode ?? 'flat';
   const radius = opts.radius ?? ENVIRONMENT_RADIUS_DEFAULT;
   const fogNear = opts.fogNear ?? ENVIRONMENT_FOG_NEAR_DEFAULT;
   const fogFar = opts.fogFar ?? radius;
@@ -248,14 +265,15 @@ export function createEnvironment(
   group.name = 'environment';
 
   if (mode === 'flat') {
-    // Degrade tier: a single tuned clear colour, no dome, no fog —
-    // ≈ today's cost but the *tuned* tone, still a deliberate
-    // improvement over the bare 0x111122 void.
+    // Shipped default (post-#245 smoke): a single tuned clear
+    // colour, no dome, no fog — ≈ today's cost, the void nudged a
+    // touch lighter. Cheapest possible for the Quest fragment
+    // budget.
     let disposed = false;
     return {
       group,
       fog: null,
-      background: horizonColor(),
+      background: new THREE.Color(...ENVIRONMENT_FLAT_BG_RGB),
       dispose(): void {
         if (disposed) return;
         disposed = true;

--- a/src/scaffold/staging/Environment.ts
+++ b/src/scaffold/staging/Environment.ts
@@ -88,15 +88,21 @@ export const ENVIRONMENT_MIDGLOW_RGB = [0x1a / 255, 0x1a / 255, 0x30 / 255] as c
 export const ENVIRONMENT_HORIZON_RGB = [0x11 / 255, 0x11 / 255, 0x22 / 255] as const;
 
 /**
- * The shipped `mode: 'flat'` background — the old 0x111122 void
- * nudged a touch lighter (same cool-dark family) per PR #245 smoke
- * ("not much different from the void, just a little lighter").
- * First-pass smoke-tunable (feedback_staging_dimensions_first_pass);
- * Brad eyeballs the exact lift on the next preview. Kept distinct
- * from the gradient horizon stop so the two are independently
- * tunable and the intent is explicit, not coincidental.
+ * The shipped `mode: 'flat'` background. Tuned by a **binary search
+ * on darkness** against in-headset smoke (Brad's call each round):
+ *
+ *   bounds  = [ 0x000000 (darker, "vantablack")  ..
+ *               0x1a1a2e (lighter, PR#245 round-1 — judged too light) ]
+ *   round 2 = midpoint(0x1a1a2e, 0x000000)        = 0x0d0d17  ← CURRENT
+ *
+ * Next step rule: if round 2 still too light → midpoint(0x0d0d17,
+ * 0x000000) ≈ 0x07070b; if too dark → midpoint(0x0d0d17, 0x1a1a2e)
+ * ≈ 0x131320. Keep the converging bounds in this comment each
+ * round (feedback_staging_dimensions_first_pass — smoke-tunable
+ * value, locked intent). Kept distinct from the gradient horizon
+ * stop so the two tune independently.
  */
-export const ENVIRONMENT_FLAT_BG_RGB = [0x1a / 255, 0x1a / 255, 0x2e / 255] as const;
+export const ENVIRONMENT_FLAT_BG_RGB = [0x0d / 255, 0x0d / 255, 0x17 / 255] as const;
 
 /** Dome radius (world units). Default; overridable within invariants. */
 export const ENVIRONMENT_RADIUS_DEFAULT = 40;

--- a/src/scaffold/staging/Environment.ts
+++ b/src/scaffold/staging/Environment.ts
@@ -31,6 +31,15 @@ import * as THREE from 'three';
 // DirectionalLight pairs untouched). `richness` (default FALSE)
 // opts the dome path into dim distant-detail slabs.
 //
+// ── Vantablack contrast box (#245 smoke, default ON) ─────────────
+// Independent of mode: a pure-black 5-face open-front box framing
+// the focal volume so the rendered surface reads at maximum
+// contrast against true black, while the rest of the environment
+// stays the off-black flat tone (or the dome). Shell-owned, ONE box
+// sized to the largest cluster focal volume (quadrics' ±3.5 AABB),
+// centred on the shared SURFACE_CENTER. Built mode-independently
+// and disposed by both flat + dome paths.
+//
 // ── Fog model: LOCKED linear THREE.Fog (#224 plan §3.2) ──────────
 // Three-vendor roundtable converged on linear over FogExp2: linear
 // fog applies ZERO attenuation for distance < `near`, making "the
@@ -103,6 +112,34 @@ export const ENVIRONMENT_HORIZON_RGB = [0x11 / 255, 0x11 / 255, 0x22 / 255] as c
  * stop so the two tune independently.
  */
 export const ENVIRONMENT_FLAT_BG_RGB = [0x0d / 255, 0x0d / 255, 0x17 / 255] as const;
+
+/**
+ * The contrast box is pure black ("vantablack") on purpose — it
+ * frames the focal volume so the rendered surface reads at maximum
+ * contrast, while the surrounding environment stays the off-black
+ * `ENVIRONMENT_FLAT_BG_RGB` tone (PR #245 smoke, Brad's call).
+ * Tuple+factory per the export discipline even though it's 0,0,0.
+ */
+export const ENVIRONMENT_CONTRAST_BOX_RGB = [0, 0, 0] as const;
+
+/**
+ * Half-extent of the shell-owned contrast box, world units. Sized
+ * to enclose the LARGEST cluster focal volume — quadrics' raymarch
+ * AABB, `BOUND = 3.5` — plus ~1 m margin (Brad: shell-owned, one
+ * box sized to the biggest scene). The smaller-surface scenes get a
+ * looser but still fully-black frame, which is fine. First-pass
+ * smoke-tunable (feedback_staging_dimensions_first_pass).
+ */
+export const ENVIRONMENT_CONTRAST_BOX_HALF_EXTENT = 4.5;
+
+/**
+ * Focal-volume centre, world space. Duplicated here (rather than
+ * imported from an exhibit) for the same reason cameraControls.ts:18
+ * duplicates it: the shell/scaffold layer stays free of cross-
+ * cluster scene imports, and the four scenes' `SURFACE_CENTER`
+ * constants are independent declarations that happen to coincide.
+ */
+const CONTRAST_BOX_CENTER = new THREE.Vector3(0, 1.5, -4);
 
 /** Dome radius (world units). Default; overridable within invariants. */
 export const ENVIRONMENT_RADIUS_DEFAULT = 40;
@@ -215,6 +252,55 @@ function horizonColor(): THREE.Color {
   return new THREE.Color(...ENVIRONMENT_HORIZON_RGB);
 }
 
+/**
+ * Five-face open-front "vantablack" box framing the focal volume
+ * (Brad's pick: full box, everything but the viewer/+Z side). Back
+ * + top + bottom + two sides; the +Z face is omitted so the camera
+ * looks in. All five faces are 2h × 2h squares sharing ONE geometry
+ * + ONE unlit pure-black material (`DoubleSide`, `fog:false`) — so
+ * winding/normal direction is irrelevant and dispose is one geo +
+ * one mat (the StageFloor shared-material pattern). Opaque, normal
+ * depth: the StageFloor / railing / raymarched surface correctly
+ * render in front; through the floor cutout the surface dips into
+ * pure black. The box is finite and centred on the focal volume, so
+ * the off-black `scene.background` still shows past its edges / open
+ * front — focal volume black, periphery off-black, exactly the
+ * museum-shadow-box read.
+ */
+function buildContrastBox(group: THREE.Group): {
+  geometry: THREE.PlaneGeometry;
+  material: THREE.MeshBasicMaterial;
+} {
+  const c = CONTRAST_BOX_CENTER;
+  const h = ENVIRONMENT_CONTRAST_BOX_HALF_EXTENT;
+  const geometry = new THREE.PlaneGeometry(2 * h, 2 * h);
+  const material = new THREE.MeshBasicMaterial({
+    color: new THREE.Color(...ENVIRONMENT_CONTRAST_BOX_RGB),
+    side: THREE.DoubleSide,
+    fog: false,
+  });
+  // [position, rotation] per face. PlaneGeometry's default lies in
+  // XY with +Z normal; rotate to seat each wall. +Z (front) omitted.
+  const faces: ReadonlyArray<{
+    pos: [number, number, number];
+    rot: [number, number, number];
+  }> = [
+    { pos: [c.x, c.y, c.z - h], rot: [0, 0, 0] }, // back  (−Z wall)
+    { pos: [c.x, c.y + h, c.z], rot: [-Math.PI / 2, 0, 0] }, // top
+    { pos: [c.x, c.y - h, c.z], rot: [-Math.PI / 2, 0, 0] }, // bottom
+    { pos: [c.x - h, c.y, c.z], rot: [0, Math.PI / 2, 0] }, // left  (−X)
+    { pos: [c.x + h, c.y, c.z], rot: [0, Math.PI / 2, 0] }, // right (+X)
+  ];
+  for (const f of faces) {
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.set(...f.pos);
+    mesh.rotation.set(...f.rot);
+    mesh.name = 'contrast-box-face';
+    group.add(mesh);
+  }
+  return { geometry, material };
+}
+
 export interface EnvironmentOptions {
   /**
    * `'flat'` (DEFAULT, post-#245-smoke) = a tuned solid background a
@@ -241,6 +327,10 @@ export interface EnvironmentOptions {
   /** Opt-in dim distant-detail slabs at the fog boundary. v1 default
    *  FALSE (atmosphere is the first cut, v1.0.md §2). */
   readonly richness?: boolean;
+  /** Pure-black 5-face open-front contrast box framing the focal
+   *  volume (PR #245 smoke). Default TRUE — it's the shipped intent
+   *  in both flat and dome modes. */
+  readonly contrastBox?: boolean;
 }
 
 export interface EnvironmentHandles {
@@ -253,7 +343,8 @@ export interface EnvironmentHandles {
   /** Solid background for `'flat'` mode, else `null`. Shell does
    *  `scene.background = handles.background`. */
   readonly background: THREE.Color | null;
-  /** Idempotent. Disposes dome geo/mat + gradient texture (+ richness
+  /** Idempotent. Disposes the contrast-box geo/mat (both modes) +,
+   *  in `'dome'` mode, dome geo/mat + gradient texture (+ richness
    *  geos/mats). Mirrors StageFloor's `disposed` guard. */
   dispose(): void;
 }
@@ -267,14 +358,26 @@ export function createEnvironment(
   const fogFar = opts.fogFar ?? radius;
   const richness = opts.richness ?? false;
 
+  const useContrastBox = opts.contrastBox ?? true;
+
   const group = new THREE.Group();
   group.name = 'environment';
 
+  // Shell-owned, mode-independent: the vantablack contrast box is
+  // built once and shared by flat + dome paths (Brad: one box,
+  // shell-owned). Tracked here so BOTH dispose paths release it.
+  const box = useContrastBox ? buildContrastBox(group) : null;
+  const disposeBox = (): void => {
+    if (!box) return;
+    box.geometry.dispose();
+    box.material.dispose();
+  };
+
   if (mode === 'flat') {
     // Shipped default (post-#245 smoke): a single tuned clear
-    // colour, no dome, no fog — ≈ today's cost, the void nudged a
-    // touch lighter. Cheapest possible for the Quest fragment
-    // budget.
+    // colour, no dome, no fog — ≈ today's cost, the void nudged
+    // darker (binary search). The contrast box (above) is the only
+    // GPU-owned resource in this mode.
     let disposed = false;
     return {
       group,
@@ -283,7 +386,7 @@ export function createEnvironment(
       dispose(): void {
         if (disposed) return;
         disposed = true;
-        // Nothing GPU-owned in 'flat' mode.
+        disposeBox();
       },
     };
   }
@@ -376,6 +479,7 @@ export function createEnvironment(
     dispose(): void {
       if (disposed) return;
       disposed = true;
+      disposeBox();
       domeGeometry.dispose();
       domeMaterial.dispose();
       gradientTexture.dispose();

--- a/src/scaffold/staging/Environment.ts
+++ b/src/scaffold/staging/Environment.ts
@@ -31,18 +31,12 @@ import * as THREE from 'three';
 // DirectionalLight pairs untouched). `richness` (default FALSE)
 // opts the dome path into dim distant-detail slabs.
 //
-// ── Vantablack sub-floor pit (#245 smoke, default ON) ────────────
-// Independent of mode: a pure-black carpet + short walls ENTIRELY
-// BELOW the StageFloor (world Y=0), beneath where the surface dips
-// through the floor cutout. Looking down past the floor reveals
-// purposeful pure black under the exhibit; at eye level / above
-// only the near-black skybox shows — it "obscures the skybox only
-// in the downward direction" (Brad's clarification: it is NOT an
-// enclosure around the surface). Open-top + open-front (4 faces);
-// the StageFloor + its cutout are the lid. Shell-owned, ONE pit
-// sized to cover the largest cluster cutout, XZ-centred on the
-// shared focal footprint. Built mode-independently, disposed by
-// both flat + dome paths.
+// The sub-floor "vantablack" contrast pit is NOT here — it's an
+// exhibit-owned per-scene primitive in ContrastPit.ts (PR #245
+// smoke iter 5: one shell-owned box couldn't be both contained
+// under tangent-planes' shallow floor and cover quadrics' deep
+// cutout; sizing it to each scene's cutout footprint resolves it).
+// Environment owns only the backdrop: flat tone, or dome + fog.
 //
 // ── Fog model: LOCKED linear THREE.Fog (#224 plan §3.2) ──────────
 // Three-vendor roundtable converged on linear over FogExp2: linear
@@ -116,55 +110,6 @@ export const ENVIRONMENT_HORIZON_RGB = [0x11 / 255, 0x11 / 255, 0x22 / 255] as c
  * stop so the two tune independently.
  */
 export const ENVIRONMENT_FLAT_BG_RGB = [0x04 / 255, 0x04 / 255, 0x06 / 255] as const;
-
-/**
- * The contrast box is pure black ("vantablack") on purpose — it
- * frames the focal volume so the rendered surface reads at maximum
- * contrast, while the surrounding environment stays the off-black
- * `ENVIRONMENT_FLAT_BG_RGB` tone (PR #245 smoke, Brad's call).
- * Tuple+factory per the export discipline even though it's 0,0,0.
- */
-export const ENVIRONMENT_CONTRAST_BOX_RGB = [0, 0, 0] as const;
-
-/**
- * The contrast box is a **sub-floor black pit**, not an enclosure
- * around the surface (PR #245 smoke iteration 4 — Brad's
- * clarification). It sits entirely BELOW the `StageFloor` (world
- * Y = 0): a black "carpet" + short surrounding walls beneath where
- * the surface dips through the floor cutout. Looking down past the
- * floor reveals purposeful pure black under the exhibit; at eye
- * level and above only the (near-black) background skybox shows —
- * the pit "obscures the skybox only in the downward direction."
- *
- * Open-top + open-front (toward the user, +Z): 4 black faces —
- * bottom + back(−Z) + left(−X) + right(+X). A closed top would
- * z-fight the StageFloor at Y = 0 or cap the pit and defeat the
- * look-down-and-see-black effect; the StageFloor + its cutout are
- * the "lid" you peer through. (This is the documented 5→4-face
- * deviation from the earlier "5-sided" framing; surfaced to Brad.)
- *
- * `XZ_HALF` covers the LARGEST cluster floor cutout (quadrics'
- * `BOUND·1.05 ≈ 3.7`) so everything visible through any scene's
- * cutout is black; walls beyond a given scene's cutout are hidden
- * under that scene's opaque StageFloor. `TOP_Y` is a hair below 0
- * to avoid z-fighting the floor; `DEPTH` clears the deepest dip
- * (quadrics cube bottom at world-Y −2) with margin. All three are
- * first-pass smoke-tunable (feedback_staging_dimensions_first_pass).
- */
-export const ENVIRONMENT_PIT_XZ_HALF = 4.0;
-export const ENVIRONMENT_PIT_TOP_Y = -0.02;
-export const ENVIRONMENT_PIT_DEPTH = 3.0;
-
-/**
- * Focal-volume XZ centre, world space. Duplicated here (rather than
- * imported from an exhibit) for the same reason cameraControls.ts:18
- * duplicates it: the shell/scaffold layer stays free of cross-
- * cluster scene imports, and the four scenes' `SURFACE_CENTER`
- * constants are independent declarations that happen to coincide.
- * Only XZ is used (the pit's Y is floor-relative, not surface-
- * relative).
- */
-const CONTRAST_BOX_CENTER = new THREE.Vector3(0, 1.5, -4);
 
 /** Dome radius (world units). Default; overridable within invariants. */
 export const ENVIRONMENT_RADIUS_DEFAULT = 40;
@@ -277,74 +222,6 @@ function horizonColor(): THREE.Color {
   return new THREE.Color(...ENVIRONMENT_HORIZON_RGB);
 }
 
-/**
- * Build the sub-floor "vantablack" pit (PR #245 smoke iter 4 —
- * Brad's clarification): a black carpet + short surrounding walls
- * ENTIRELY below the StageFloor (world Y = 0), so looking down past
- * the floor reveals pure black under the exhibit while the skybox
- * stays visible at eye level / above.
- *
- * 4 faces, open-top + open-front(+Z): bottom + back(−Z) + left(−X)
- * + right(+X). Sizes differ per face, so each gets its own
- * `PlaneGeometry`; ONE shared unlit pure-black `DoubleSide`,
- * `fog:false` material (the StageFloor shared-material pattern).
- * Opaque, normal depth — the StageFloor occludes the walls except
- * through its cutout, which is exactly the "lid you peer through."
- *
- * Geometry (XZ centred on the focal footprint, Y floor-relative):
- *   topY    = ENVIRONMENT_PIT_TOP_Y           (≈ −0.02, just below floor)
- *   botY    = topY − ENVIRONMENT_PIT_DEPTH    (clears the deepest dip)
- *   ±half   = ENVIRONMENT_PIT_XZ_HALF         (covers the largest cutout)
- */
-function buildContrastBox(group: THREE.Group): {
-  geometries: THREE.PlaneGeometry[];
-  material: THREE.MeshBasicMaterial;
-} {
-  const cx = CONTRAST_BOX_CENTER.x;
-  const cz = CONTRAST_BOX_CENTER.z;
-  const half = ENVIRONMENT_PIT_XZ_HALF;
-  const topY = ENVIRONMENT_PIT_TOP_Y;
-  const depth = ENVIRONMENT_PIT_DEPTH;
-  const botY = topY - depth;
-  const midY = topY - depth / 2;
-
-  const material = new THREE.MeshBasicMaterial({
-    color: new THREE.Color(...ENVIRONMENT_CONTRAST_BOX_RGB),
-    side: THREE.DoubleSide,
-    fog: false,
-  });
-  const geometries: THREE.PlaneGeometry[] = [];
-
-  // Each face: its own geometry (sizes differ), one shared material.
-  // PlaneGeometry default lies in XY (normal +Z); rotate to seat.
-  const addFace = (
-    w: number,
-    h: number,
-    pos: [number, number, number],
-    rot: [number, number, number],
-  ): void => {
-    const g = new THREE.PlaneGeometry(w, h);
-    geometries.push(g);
-    const mesh = new THREE.Mesh(g, material);
-    mesh.position.set(...pos);
-    mesh.rotation.set(...rot);
-    mesh.name = 'contrast-box-face';
-    group.add(mesh);
-  };
-
-  // bottom carpet — horizontal, spans the full XZ footprint.
-  addFace(2 * half, 2 * half, [cx, botY, cz], [-Math.PI / 2, 0, 0]);
-  // back wall (−Z) — vertical, spans X × depth.
-  addFace(2 * half, depth, [cx, midY, cz - half], [0, 0, 0]);
-  // left wall (−X) — vertical, spans Z × depth.
-  addFace(2 * half, depth, [cx - half, midY, cz], [0, Math.PI / 2, 0]);
-  // right wall (+X) — vertical, spans Z × depth.
-  addFace(2 * half, depth, [cx + half, midY, cz], [0, Math.PI / 2, 0]);
-  // open top (+Y, the StageFloor/cutout is the lid) + open front (+Z).
-
-  return { geometries, material };
-}
-
 export interface EnvironmentOptions {
   /**
    * `'flat'` (DEFAULT, post-#245-smoke) = a tuned solid background a
@@ -371,9 +248,6 @@ export interface EnvironmentOptions {
   /** Opt-in dim distant-detail slabs at the fog boundary. v1 default
    *  FALSE (atmosphere is the first cut, v1.0.md §2). */
   readonly richness?: boolean;
-  /** Pure-black sub-floor contrast pit beneath the StageFloor (PR
-   *  #245 smoke). Default TRUE — shipped intent in flat + dome. */
-  readonly contrastBox?: boolean;
 }
 
 export interface EnvironmentHandles {
@@ -386,9 +260,9 @@ export interface EnvironmentHandles {
   /** Solid background for `'flat'` mode, else `null`. Shell does
    *  `scene.background = handles.background`. */
   readonly background: THREE.Color | null;
-  /** Idempotent. Disposes the contrast-box geo/mat (both modes) +,
-   *  in `'dome'` mode, dome geo/mat + gradient texture (+ richness
-   *  geos/mats). Mirrors StageFloor's `disposed` guard. */
+  /** Idempotent. `'flat'` owns nothing GPU-side; `'dome'` disposes
+   *  dome geo/mat + gradient texture (+ richness geos/mats).
+   *  Mirrors StageFloor's `disposed` guard. */
   dispose(): void;
 }
 
@@ -401,26 +275,13 @@ export function createEnvironment(
   const fogFar = opts.fogFar ?? radius;
   const richness = opts.richness ?? false;
 
-  const useContrastBox = opts.contrastBox ?? true;
-
   const group = new THREE.Group();
   group.name = 'environment';
-
-  // Shell-owned, mode-independent: the sub-floor vantablack pit is
-  // built once and shared by flat + dome paths (Brad: one box,
-  // shell-owned). Tracked here so BOTH dispose paths release it.
-  const box = useContrastBox ? buildContrastBox(group) : null;
-  const disposeBox = (): void => {
-    if (!box) return;
-    for (const g of box.geometries) g.dispose();
-    box.material.dispose();
-  };
 
   if (mode === 'flat') {
     // Shipped default (post-#245 smoke): a single tuned clear
     // colour, no dome, no fog — ≈ today's cost, the void nudged
-    // darker (binary search). The contrast box (above) is the only
-    // GPU-owned resource in this mode.
+    // darker (binary search). Nothing GPU-owned in 'flat' mode.
     let disposed = false;
     return {
       group,
@@ -429,7 +290,6 @@ export function createEnvironment(
       dispose(): void {
         if (disposed) return;
         disposed = true;
-        disposeBox();
       },
     };
   }
@@ -522,7 +382,6 @@ export function createEnvironment(
     dispose(): void {
       if (disposed) return;
       disposed = true;
-      disposeBox();
       domeGeometry.dispose();
       domeMaterial.dispose();
       gradientTexture.dispose();

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -17,6 +17,7 @@ import type { Pointer } from './Pointer';
 import { VRPointer } from './VRPointer';
 import { DesktopPointer } from './DesktopPointer';
 import { createCameraControls } from './cameraControls';
+import { createEnvironment } from '@/scaffold/staging/Environment';
 
 // Vite HMR can re-execute module-level code in dev. `bootShell` is
 // idempotent against double-invocation: subsequent calls early-return
@@ -80,7 +81,17 @@ async function bootShellAsync(): Promise<void> {
   const myGeneration = bootGeneration;
 
   const scene = new THREE.Scene();
-  scene.background = new THREE.Color(0x111122);
+  // Shell-owned environment surround (#224 / E1.3). Constructed at
+  // the scene seam: mode-independent (pre-mode-probe; the :142 HMR
+  // generation bail only gates *post*-await allocation, and a
+  // mid-probe HMR drains `disposers[]` which already holds this
+  // env's disposer). The disposer itself is pushed AFTER the
+  // renderer disposer below so LIFO runs environment.dispose()
+  // BEFORE renderer.dispose() frees the GL context (#224 plan §3.4).
+  const environment = createEnvironment();
+  scene.add(environment.group);
+  scene.fog = environment.fog;
+  scene.background = environment.background;
 
   const camera = new THREE.PerspectiveCamera(
     75,
@@ -100,6 +111,16 @@ async function bootShellAsync(): Promise<void> {
   disposers.push(() => {
     renderer.dispose();
     renderer.domElement.remove();
+  });
+  // Pushed AFTER the renderer disposer so the LIFO drain runs
+  // environment.dispose() (dome geo/mat + gradient DataTexture)
+  // BEFORE renderer.dispose() frees the GL context (#224 plan §3.4
+  // — two-way roundtable convergent HIGH).
+  disposers.push(() => {
+    scene.remove(environment.group);
+    scene.fog = null;
+    scene.background = null;
+    environment.dispose();
   });
 
   const resizeHandler = (): void => {
@@ -429,6 +450,28 @@ async function bootShellAsync(): Promise<void> {
     onSelect: (id) => scheduler.requestSwitch(id, 'push'),
   });
   scene.add(rack.group);
+  // scene.fog material audit (#224 plan §3.5, amended at impl). The
+  // fogNear≥14 linear-fog invariant provably un-fogs all near-field
+  // cluster UI (see Environment.ts header). SceneRack is the lone
+  // exception worth an explicit opt-out: in an extreme orbit pose it
+  // can marginally exceed fogNear (~15 m, ~4% fade) AND it's the
+  // persistent shell-owned nav surface, so token-stability wants it
+  // fog-immune unconditionally. Troika-derived label materials are
+  // lazy (may not exist yet) but are tiny near-field text the
+  // invariant already covers; the tab disc/background meshes — the
+  // visually significant mass — are standard materials present now.
+  // `fog` lives on concrete materials, not the base `THREE.Material`
+  // type — augment the cast rather than narrow per material class.
+  type Foggable = THREE.Material & { fog: boolean };
+  rack.group.traverse((obj) => {
+    const mat = (obj as THREE.Mesh).material as
+      | THREE.Material
+      | THREE.Material[]
+      | undefined;
+    if (!mat) return;
+    if (Array.isArray(mat)) for (const m of mat) (m as Foggable).fog = false;
+    else (mat as Foggable).fog = false;
+  });
 
   function applyUrlSync(id: string, historyMode: HistoryMode): void {
     const plan = planUrlSync(id, historyMode, defaultId, window.location.href);

--- a/test/scaffold/staging/ContrastPit.test.ts
+++ b/test/scaffold/staging/ContrastPit.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+import {
+  createContrastPit,
+  CONTRAST_PIT_DEPTH_DEFAULT,
+  CONTRAST_PIT_TOP_Y_DEFAULT,
+} from '../../../src/scaffold/staging/ContrastPit.ts';
+
+function meshes(g: THREE.Object3D): THREE.Mesh[] {
+  const out: THREE.Mesh[] = [];
+  g.traverse((o) => {
+    if (o instanceof THREE.Mesh) out.push(o);
+  });
+  return out;
+}
+
+describe('createContrastPit (#224 / E1.3 — sub-floor vantablack pit)', () => {
+  it('builds 5 faces (bottom + 4 walls, open top), one shared black material', () => {
+    const pit = createContrastPit({
+      cutout: { kind: 'rect', centerXZ: [0, -4], halfExtentX: 3, halfExtentZ: 2 },
+    });
+    const m = meshes(pit.group);
+    expect(m.length).toBe(5);
+    const mat = m[0].material as THREE.MeshBasicMaterial;
+    const geos = new Set<THREE.BufferGeometry>();
+    for (const f of m) {
+      expect(f.material).toBe(mat); // shared material
+      expect(f.name).toBe('contrast-pit-face');
+      geos.add(f.geometry);
+    }
+    expect(geos.size).toBe(5); // distinct per-face geometries
+    expect(mat).toBeInstanceOf(THREE.MeshBasicMaterial);
+    expect(mat.color.getHex()).toBe(0x000000);
+    expect(mat.fog).toBe(false);
+    expect(mat.side).toBe(THREE.DoubleSide);
+    pit.dispose();
+  });
+
+  it('sits ENTIRELY below the floor (open top): every face at/below topY', () => {
+    const pit = createContrastPit({
+      cutout: { kind: 'rect', centerXZ: [0, -4], halfExtentX: 3, halfExtentZ: 3 },
+    });
+    const faces = meshes(pit.group);
+    for (const f of faces) {
+      expect(f.position.y).toBeLessThanOrEqual(CONTRAST_PIT_TOP_Y_DEFAULT + 1e-6);
+    }
+    // The single horizontal face is the bottom carpet at topY−depth.
+    const botY = CONTRAST_PIT_TOP_Y_DEFAULT - CONTRAST_PIT_DEPTH_DEFAULT;
+    expect(faces.some((f) => Math.abs(f.position.y - botY) < 1e-6)).toBe(true);
+    pit.dispose();
+  });
+
+  it('rect cutout → footprint matches the cutout half-extents at its centre', () => {
+    const pit = createContrastPit({
+      cutout: { kind: 'rect', centerXZ: [0, -4], halfExtentX: 3.675, halfExtentZ: 3.675 },
+    });
+    const faces = meshes(pit.group);
+    // The four walls sit one half-extent from the cutout centre on
+    // their axis; the back/front walls at z = cz ± halfZ, side walls
+    // at x = cx ± halfX.
+    expect(faces.some((f) => Math.abs(f.position.z - (-4 - 3.675)) < 1e-6)).toBe(
+      true,
+    ); // back (−Z)
+    expect(faces.some((f) => Math.abs(f.position.z - (-4 + 3.675)) < 1e-6)).toBe(
+      true,
+    ); // front (+Z, user)
+    expect(faces.some((f) => Math.abs(f.position.x - 3.675) < 1e-6)).toBe(true);
+    expect(faces.some((f) => Math.abs(f.position.x + 3.675) < 1e-6)).toBe(true);
+    pit.dispose();
+  });
+
+  it('circle cutout → square footprint of radius at the cutout centre', () => {
+    // Mirrors tangent-planes: circle r=1.5 at (0,-4). The pit must
+    // stay within tangent-planes' floor (back edge world Z = −6):
+    // pit back at z = −4 − 1.5 = −5.5 > −6 ✓ (the conflict fix).
+    const pit = createContrastPit({
+      cutout: { kind: 'circle', centerXZ: [0, -4], radius: 1.5 },
+    });
+    const faces = meshes(pit.group);
+    expect(faces.length).toBe(5);
+    const backZ = Math.min(...faces.map((f) => f.position.z));
+    expect(backZ).toBeCloseTo(-5.5, 6);
+    expect(backZ).toBeGreaterThan(-6); // contained under TP floor
+    pit.dispose();
+  });
+
+  it('respects custom depth + topY', () => {
+    const pit = createContrastPit({
+      cutout: { kind: 'rect', centerXZ: [0, 0], halfExtentX: 2, halfExtentZ: 2 },
+      depth: 5,
+      topY: -0.1,
+    });
+    const faces = meshes(pit.group);
+    const ys = faces.map((f) => f.position.y);
+    expect(Math.min(...ys)).toBeCloseTo(-0.1 - 5, 6); // bottom at topY−depth
+    for (const y of ys) expect(y).toBeLessThanOrEqual(-0.1 + 1e-6);
+    pit.dispose();
+  });
+
+  describe('dispose() — idempotent + leak-free', () => {
+    it('disposes every geometry + the shared material exactly once', () => {
+      const pit = createContrastPit({
+        cutout: { kind: 'rect', centerXZ: [0, -4], halfExtentX: 3, halfExtentZ: 3 },
+      });
+      const faces = meshes(pit.group);
+      const mSpy = vi.fn();
+      (faces[0].material as THREE.Material).addEventListener('dispose', mSpy);
+      const gSpies = faces.map((f) => {
+        const s = vi.fn();
+        f.geometry.addEventListener('dispose', s);
+        return s;
+      });
+      pit.dispose();
+      for (const s of gSpies) expect(s).toHaveBeenCalledTimes(1);
+      expect(mSpy).toHaveBeenCalledTimes(1);
+      pit.dispose(); // idempotent
+      for (const s of gSpies) expect(s).toHaveBeenCalledTimes(1);
+      expect(mSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/test/scaffold/staging/Environment.test.ts
+++ b/test/scaffold/staging/Environment.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+import {
+  createEnvironment,
+  buildGradientStops,
+  ENVIRONMENT_RADIUS_DEFAULT,
+  ENVIRONMENT_FOG_NEAR_MIN,
+  ENVIRONMENT_MAX_CAMERA_REACH,
+  ENVIRONMENT_RADIUS_MARGIN,
+  ENVIRONMENT_CAMERA_FAR,
+  ENVIRONMENT_DOME_RENDER_ORDER,
+} from '../../../src/scaffold/staging/Environment.ts';
+
+function collectMeshes(g: THREE.Object3D): THREE.Mesh[] {
+  const out: THREE.Mesh[] = [];
+  g.traverse((o) => {
+    if (o instanceof THREE.Mesh) out.push(o);
+  });
+  return out;
+}
+
+describe('createEnvironment (#224 / E1.3)', () => {
+  describe("mode: 'dome' (default)", () => {
+    it('produces a linear THREE.Fog, no solid background, a dome mesh', () => {
+      const env = createEnvironment();
+      expect(env.fog).toBeInstanceOf(THREE.Fog);
+      expect(env.background).toBeNull();
+      const meshes = collectMeshes(env.group);
+      expect(meshes.length).toBe(1); // dome only, richness default false
+      env.dispose();
+    });
+
+    it('dome material/render-state is the deterministic backdrop config', () => {
+      const env = createEnvironment();
+      const dome = collectMeshes(env.group)[0];
+      const mat = dome.material as THREE.MeshBasicMaterial;
+      expect(mat).toBeInstanceOf(THREE.MeshBasicMaterial);
+      expect(mat.side).toBe(THREE.BackSide);
+      expect(mat.fog).toBe(false); // dome is the fog backdrop, not fogged
+      expect(mat.depthWrite).toBe(false);
+      expect(mat.depthTest).toBe(false);
+      expect(dome.renderOrder).toBe(ENVIRONMENT_DOME_RENDER_ORDER);
+      expect(dome.renderOrder).toBe(-1);
+      env.dispose();
+    });
+  });
+
+  describe("mode: 'flat' degrade tier", () => {
+    it('has no dome mesh, no fog, and a tuned solid background', () => {
+      const env = createEnvironment({ mode: 'flat' });
+      expect(env.fog).toBeNull();
+      expect(env.background).toBeInstanceOf(THREE.Color);
+      expect(collectMeshes(env.group).length).toBe(0);
+      env.dispose();
+    });
+  });
+
+  describe('richness severance (default false)', () => {
+    it('richness:true adds meshes; the dome is present in both', () => {
+      const core = createEnvironment({ richness: false });
+      const rich = createEnvironment({ richness: true });
+      const coreMeshes = collectMeshes(core.group);
+      const richMeshes = collectMeshes(rich.group);
+      expect(coreMeshes.length).toBe(1); // dome only
+      expect(richMeshes.length).toBeGreaterThan(coreMeshes.length);
+      // Dome geometry identical (same radius) in both.
+      const coreDome = coreMeshes[0].geometry as THREE.SphereGeometry;
+      const richDome = richMeshes[0].geometry as THREE.SphereGeometry;
+      expect(richDome.parameters.radius).toBe(coreDome.parameters.radius);
+      core.dispose();
+      rich.dispose();
+    });
+  });
+
+  describe('linear-fog + dome geometric invariants', () => {
+    it('default fog/radius satisfy the §2.2 invariant chain', () => {
+      const env = createEnvironment();
+      const fog = env.fog as THREE.Fog;
+      expect(fog).toBeInstanceOf(THREE.Fog);
+      expect(fog.near).toBeGreaterThanOrEqual(ENVIRONMENT_FOG_NEAR_MIN);
+      expect(fog.near).toBeLessThan(fog.far);
+      expect(fog.far).toBeLessThanOrEqual(ENVIRONMENT_RADIUS_DEFAULT);
+      expect(ENVIRONMENT_RADIUS_DEFAULT).toBeLessThan(ENVIRONMENT_CAMERA_FAR);
+      expect(ENVIRONMENT_RADIUS_DEFAULT).toBeGreaterThanOrEqual(
+        ENVIRONMENT_MAX_CAMERA_REACH + ENVIRONMENT_RADIUS_MARGIN,
+      );
+      env.dispose();
+    });
+  });
+
+  describe('construction-time invariant rejection', () => {
+    it('rejects fogNear below the stage-reach minimum', () => {
+      expect(() => createEnvironment({ fogNear: 5 })).toThrow(/invariant/);
+    });
+    it('rejects fogNear >= fogFar', () => {
+      expect(() =>
+        createEnvironment({ fogNear: 30, fogFar: 20 }),
+      ).toThrow(/invariant/);
+    });
+    it('rejects fogFar exceeding radius', () => {
+      expect(() =>
+        createEnvironment({ radius: 40, fogFar: 50 }),
+      ).toThrow(/invariant/);
+    });
+    it('rejects a radius the camera could exit (black-void guard)', () => {
+      expect(() => createEnvironment({ radius: 15 })).toThrow(/invariant/);
+    });
+    it('rejects a radius that would clip the camera far plane', () => {
+      expect(() => createEnvironment({ radius: 120 })).toThrow(/invariant/);
+    });
+    it("does NOT gate 'flat' mode on dome invariants", () => {
+      // 'flat' has no dome/fog, so the dome invariants must not fire.
+      expect(() =>
+        createEnvironment({ mode: 'flat', radius: 1 }),
+      ).not.toThrow();
+    });
+  });
+
+  // v1.0-INTENTIONAL canary guarding the #215/#216 token calibration
+  // (plan §2.3). NOT a forward-compatible invariant — if a later epic
+  // deliberately brightens the environment, DELETE this test as part
+  // of that epic's token re-tune; do NOT silently loosen it.
+  describe('gradient horizon-stop canary (v1.0-intentional)', () => {
+    it('keeps the horizon stop within ±0x10/channel of 0x111122', () => {
+      const { horizon } = buildGradientStops();
+      const target = [0x11 / 255, 0x11 / 255, 0x22 / 255];
+      const tol = 0x10 / 255;
+      for (let c = 0; c < 3; c++) {
+        expect(Math.abs(horizon[c] - target[c])).toBeLessThanOrEqual(tol);
+      }
+    });
+  });
+
+  describe('env-owned material fog flags (§3.5 audit, env half)', () => {
+    it('dome fog:false; richness detail meshes fog:true', () => {
+      const env = createEnvironment({ richness: true });
+      const meshes = collectMeshes(env.group);
+      const dome = meshes[0];
+      expect((dome.material as THREE.MeshBasicMaterial).fog).toBe(false);
+      for (let i = 1; i < meshes.length; i++) {
+        expect((meshes[i].material as THREE.MeshBasicMaterial).fog).toBe(true);
+      }
+      env.dispose();
+    });
+  });
+
+  describe('dispose() — idempotent + leak-free', () => {
+    // Three.js dispatches a 'dispose' event on geometries, materials,
+    // and textures; spying it verifies dispose ran without poking
+    // internal state (same pattern as StageFloor.test.ts).
+    it('disposes dome geometry, material, and gradient texture once', () => {
+      const env = createEnvironment();
+      const dome = collectMeshes(env.group)[0];
+      const geomSpy = vi.fn();
+      const matSpy = vi.fn();
+      const texSpy = vi.fn();
+      dome.geometry.addEventListener('dispose', geomSpy);
+      (dome.material as THREE.Material).addEventListener('dispose', matSpy);
+      const tex = (dome.material as THREE.MeshBasicMaterial).map!;
+      tex.addEventListener('dispose', texSpy);
+
+      env.dispose();
+      expect(geomSpy).toHaveBeenCalledTimes(1);
+      expect(matSpy).toHaveBeenCalledTimes(1);
+      expect(texSpy).toHaveBeenCalledTimes(1);
+
+      env.dispose(); // idempotent
+      expect(geomSpy).toHaveBeenCalledTimes(1);
+      expect(matSpy).toHaveBeenCalledTimes(1);
+      expect(texSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('disposes richness geometries + materials too', () => {
+      const env = createEnvironment({ richness: true });
+      const meshes = collectMeshes(env.group);
+      const spies = meshes.flatMap((m) => {
+        const gs = vi.fn();
+        const ms = vi.fn();
+        m.geometry.addEventListener('dispose', gs);
+        (m.material as THREE.Material).addEventListener('dispose', ms);
+        return [gs, ms];
+      });
+      env.dispose();
+      for (const s of spies) expect(s).toHaveBeenCalledTimes(1);
+      env.dispose();
+      for (const s of spies) expect(s).toHaveBeenCalledTimes(1);
+    });
+
+    it("'flat' mode dispose is idempotent and safe", () => {
+      const env = createEnvironment({ mode: 'flat' });
+      expect(() => {
+        env.dispose();
+        env.dispose();
+      }).not.toThrow();
+    });
+  });
+});

--- a/test/scaffold/staging/Environment.test.ts
+++ b/test/scaffold/staging/Environment.test.ts
@@ -10,7 +10,9 @@ import {
   ENVIRONMENT_CAMERA_FAR,
   ENVIRONMENT_DOME_RENDER_ORDER,
   ENVIRONMENT_FLAT_BG_RGB,
-  ENVIRONMENT_CONTRAST_BOX_HALF_EXTENT,
+  ENVIRONMENT_PIT_TOP_Y,
+  ENVIRONMENT_PIT_DEPTH,
+  ENVIRONMENT_PIT_XZ_HALF,
 } from '../../../src/scaffold/staging/Environment.ts';
 
 function collectMeshes(g: THREE.Object3D): THREE.Mesh[] {
@@ -33,7 +35,7 @@ describe('createEnvironment (#224 / E1.3)', () => {
       expect(env.background).toBeInstanceOf(THREE.Color);
       const meshes = collectMeshes(env.group);
       expect(nonBox(meshes).length).toBe(0); // no dome in flat
-      expect(boxFaces(meshes).length).toBe(5); // box default ON
+      expect(boxFaces(meshes).length).toBe(4); // sub-floor pit, default ON
       env.dispose();
     });
 
@@ -67,12 +69,12 @@ describe('createEnvironment (#224 / E1.3)', () => {
     });
   });
 
-  describe('vantablack contrast box (#245 smoke; default ON)', () => {
-    it('is present in BOTH flat and dome modes', () => {
+  describe('vantablack sub-floor pit (#245 smoke; default ON)', () => {
+    it('is present in BOTH flat and dome modes (4 faces)', () => {
       const flat = createEnvironment();
       const dome = createEnvironment({ mode: 'dome' });
-      expect(boxFaces(collectMeshes(flat.group)).length).toBe(5);
-      expect(boxFaces(collectMeshes(dome.group)).length).toBe(5);
+      expect(boxFaces(collectMeshes(flat.group)).length).toBe(4);
+      expect(boxFaces(collectMeshes(dome.group)).length).toBe(4);
       flat.dispose();
       dome.dispose();
     });
@@ -83,16 +85,17 @@ describe('createEnvironment (#224 / E1.3)', () => {
       env.dispose();
     });
 
-    it('all 5 faces share ONE geometry + ONE material; pure-black, fog:false, DoubleSide', () => {
+    it('4 faces share ONE material (sizes differ → per-face geo); pure-black, fog:false, DoubleSide', () => {
       const env = createEnvironment();
       const faces = boxFaces(collectMeshes(env.group));
-      expect(faces.length).toBe(5);
-      const g0 = faces[0].geometry;
+      expect(faces.length).toBe(4);
       const m0 = faces[0].material as THREE.MeshBasicMaterial;
+      const geos = new Set<THREE.BufferGeometry>();
       for (const f of faces) {
-        expect(f.geometry).toBe(g0); // shared geometry instance
         expect(f.material).toBe(m0); // shared material instance
+        geos.add(f.geometry);
       }
+      expect(geos.size).toBe(4); // distinct per-face geometries
       expect(m0).toBeInstanceOf(THREE.MeshBasicMaterial);
       expect(m0.color.getHex()).toBe(0x000000);
       expect(m0.fog).toBe(false);
@@ -100,26 +103,31 @@ describe('createEnvironment (#224 / E1.3)', () => {
       env.dispose();
     });
 
-    it('omits the +Z (viewer) face and seats the others at ±half-extent', () => {
+    it('sits ENTIRELY below the floor (Y=0); open top + open front', () => {
       const env = createEnvironment();
       const faces = boxFaces(collectMeshes(env.group));
-      const c = new THREE.Vector3(0, 1.5, -4); // CONTRAST_BOX_CENTER
-      const h = ENVIRONMENT_CONTRAST_BOX_HALF_EXTENT;
-      // No face sits on the +Z (open / viewer) side.
+      // Every face is at or below the floor — the pit never rises to
+      // eye level / never obscures the skybox except downward.
       for (const f of faces) {
-        expect(f.position.z).toBeLessThanOrEqual(c.z + 1e-6);
+        expect(f.position.y).toBeLessThanOrEqual(ENVIRONMENT_PIT_TOP_Y + 1e-6);
       }
-      // The back wall is exactly one half-extent behind centre.
-      expect(faces.some((f) => Math.abs(f.position.z - (c.z - h)) < 1e-6)).toBe(
-        true,
-      );
-      // Top + bottom one half-extent above/below centre.
-      expect(faces.some((f) => Math.abs(f.position.y - (c.y + h)) < 1e-6)).toBe(
-        true,
-      );
-      expect(faces.some((f) => Math.abs(f.position.y - (c.y - h)) < 1e-6)).toBe(
-        true,
-      );
+      // Open top: no horizontal face at/above floor level. The only
+      // horizontal face is the bottom carpet at topY − depth.
+      const botY = ENVIRONMENT_PIT_TOP_Y - ENVIRONMENT_PIT_DEPTH;
+      expect(
+        faces.some((f) => Math.abs(f.position.y - botY) < 1e-6),
+      ).toBe(true);
+      // Open front (+Z, user side): no face in front of the focal
+      // footprint centre; the back wall is one XZ-half behind it.
+      const cz = -4; // CONTRAST_BOX_CENTER.z
+      for (const f of faces) {
+        expect(f.position.z).toBeLessThanOrEqual(cz + 1e-6);
+      }
+      expect(
+        faces.some(
+          (f) => Math.abs(f.position.z - (cz - ENVIRONMENT_PIT_XZ_HALF)) < 1e-6,
+        ),
+      ).toBe(true);
       env.dispose();
     });
   });
@@ -258,18 +266,22 @@ describe('createEnvironment (#224 / E1.3)', () => {
   });
 
   describe('dispose() — idempotent + leak-free', () => {
-    it('flat mode disposes the contrast box geo + mat exactly once', () => {
-      const env = createEnvironment(); // flat, box on
+    it('flat mode disposes every pit geo + the shared mat exactly once', () => {
+      const env = createEnvironment(); // flat, pit on
       const faces = boxFaces(collectMeshes(env.group));
-      const gSpy = vi.fn();
+      expect(faces.length).toBe(4);
       const mSpy = vi.fn();
-      faces[0].geometry.addEventListener('dispose', gSpy);
       (faces[0].material as THREE.Material).addEventListener('dispose', mSpy);
+      const gSpies = faces.map((f) => {
+        const s = vi.fn();
+        f.geometry.addEventListener('dispose', s);
+        return s;
+      });
       env.dispose();
-      expect(gSpy).toHaveBeenCalledTimes(1);
+      for (const s of gSpies) expect(s).toHaveBeenCalledTimes(1);
       expect(mSpy).toHaveBeenCalledTimes(1);
       env.dispose(); // idempotent
-      expect(gSpy).toHaveBeenCalledTimes(1);
+      for (const s of gSpies) expect(s).toHaveBeenCalledTimes(1);
       expect(mSpy).toHaveBeenCalledTimes(1);
     });
 

--- a/test/scaffold/staging/Environment.test.ts
+++ b/test/scaffold/staging/Environment.test.ts
@@ -9,6 +9,8 @@ import {
   ENVIRONMENT_RADIUS_MARGIN,
   ENVIRONMENT_CAMERA_FAR,
   ENVIRONMENT_DOME_RENDER_ORDER,
+  ENVIRONMENT_FLAT_BG_RGB,
+  ENVIRONMENT_HORIZON_RGB,
 } from '../../../src/scaffold/staging/Environment.ts';
 
 function collectMeshes(g: THREE.Object3D): THREE.Mesh[] {
@@ -20,23 +22,55 @@ function collectMeshes(g: THREE.Object3D): THREE.Mesh[] {
 }
 
 describe('createEnvironment (#224 / E1.3)', () => {
-  describe("mode: 'dome' (default)", () => {
-    it('produces a linear THREE.Fog, no solid background, a dome mesh', () => {
+  describe("mode: 'flat' (DEFAULT, post-#245 smoke)", () => {
+    it('default (no args) is flat: no fog, no meshes, a solid bg', () => {
       const env = createEnvironment();
+      expect(env.fog).toBeNull();
+      expect(env.background).toBeInstanceOf(THREE.Color);
+      expect(collectMeshes(env.group).length).toBe(0);
+      env.dispose();
+    });
+
+    it('flat bg is the tuned tone, a touch lighter than the old void', () => {
+      const env = createEnvironment();
+      const bg = env.background as THREE.Color;
+      const expected = new THREE.Color(...ENVIRONMENT_FLAT_BG_RGB);
+      expect(bg.getHex()).toBe(expected.getHex());
+      // "a little bit lighter" — strictly brighter than 0x111122,
+      // same family (no channel darker than the void).
+      const void_ = ENVIRONMENT_HORIZON_RGB; // 0x111122
+      expect(ENVIRONMENT_FLAT_BG_RGB[0]).toBeGreaterThanOrEqual(void_[0]);
+      expect(ENVIRONMENT_FLAT_BG_RGB[1]).toBeGreaterThanOrEqual(void_[1]);
+      expect(ENVIRONMENT_FLAT_BG_RGB[2]).toBeGreaterThanOrEqual(void_[2]);
+      const sum = (c: readonly number[]): number => c[0] + c[1] + c[2];
+      expect(sum(ENVIRONMENT_FLAT_BG_RGB)).toBeGreaterThan(sum(void_));
+      env.dispose();
+    });
+
+    it('does NOT gate flat mode on the dome invariants', () => {
+      // flat has no dome/fog, so dome invariants must not fire.
+      expect(() =>
+        createEnvironment({ mode: 'flat', radius: 1, fogNear: 1 }),
+      ).not.toThrow();
+    });
+  });
+
+  describe("mode: 'dome' (opt-in; future richer pass)", () => {
+    it('produces a linear THREE.Fog, no solid background, a dome mesh', () => {
+      const env = createEnvironment({ mode: 'dome' });
       expect(env.fog).toBeInstanceOf(THREE.Fog);
       expect(env.background).toBeNull();
-      const meshes = collectMeshes(env.group);
-      expect(meshes.length).toBe(1); // dome only, richness default false
+      expect(collectMeshes(env.group).length).toBe(1); // dome only
       env.dispose();
     });
 
     it('dome material/render-state is the deterministic backdrop config', () => {
-      const env = createEnvironment();
+      const env = createEnvironment({ mode: 'dome' });
       const dome = collectMeshes(env.group)[0];
       const mat = dome.material as THREE.MeshBasicMaterial;
       expect(mat).toBeInstanceOf(THREE.MeshBasicMaterial);
       expect(mat.side).toBe(THREE.BackSide);
-      expect(mat.fog).toBe(false); // dome is the fog backdrop, not fogged
+      expect(mat.fog).toBe(false);
       expect(mat.depthWrite).toBe(false);
       expect(mat.depthTest).toBe(false);
       expect(dome.renderOrder).toBe(ENVIRONMENT_DOME_RENDER_ORDER);
@@ -45,25 +79,14 @@ describe('createEnvironment (#224 / E1.3)', () => {
     });
   });
 
-  describe("mode: 'flat' degrade tier", () => {
-    it('has no dome mesh, no fog, and a tuned solid background', () => {
-      const env = createEnvironment({ mode: 'flat' });
-      expect(env.fog).toBeNull();
-      expect(env.background).toBeInstanceOf(THREE.Color);
-      expect(collectMeshes(env.group).length).toBe(0);
-      env.dispose();
-    });
-  });
-
-  describe('richness severance (default false)', () => {
+  describe('richness severance (dome path; default false)', () => {
     it('richness:true adds meshes; the dome is present in both', () => {
-      const core = createEnvironment({ richness: false });
-      const rich = createEnvironment({ richness: true });
+      const core = createEnvironment({ mode: 'dome', richness: false });
+      const rich = createEnvironment({ mode: 'dome', richness: true });
       const coreMeshes = collectMeshes(core.group);
       const richMeshes = collectMeshes(rich.group);
-      expect(coreMeshes.length).toBe(1); // dome only
+      expect(coreMeshes.length).toBe(1);
       expect(richMeshes.length).toBeGreaterThan(coreMeshes.length);
-      // Dome geometry identical (same radius) in both.
       const coreDome = coreMeshes[0].geometry as THREE.SphereGeometry;
       const richDome = richMeshes[0].geometry as THREE.SphereGeometry;
       expect(richDome.parameters.radius).toBe(coreDome.parameters.radius);
@@ -74,7 +97,7 @@ describe('createEnvironment (#224 / E1.3)', () => {
 
   describe('linear-fog + dome geometric invariants', () => {
     it('default fog/radius satisfy the §2.2 invariant chain', () => {
-      const env = createEnvironment();
+      const env = createEnvironment({ mode: 'dome' });
       const fog = env.fog as THREE.Fog;
       expect(fog).toBeInstanceOf(THREE.Fog);
       expect(fog.near).toBeGreaterThanOrEqual(ENVIRONMENT_FOG_NEAR_MIN);
@@ -88,38 +111,38 @@ describe('createEnvironment (#224 / E1.3)', () => {
     });
   });
 
-  describe('construction-time invariant rejection', () => {
+  describe('construction-time invariant rejection (dome path)', () => {
     it('rejects fogNear below the stage-reach minimum', () => {
-      expect(() => createEnvironment({ fogNear: 5 })).toThrow(/invariant/);
+      expect(() =>
+        createEnvironment({ mode: 'dome', fogNear: 5 }),
+      ).toThrow(/invariant/);
     });
     it('rejects fogNear >= fogFar', () => {
       expect(() =>
-        createEnvironment({ fogNear: 30, fogFar: 20 }),
+        createEnvironment({ mode: 'dome', fogNear: 30, fogFar: 20 }),
       ).toThrow(/invariant/);
     });
     it('rejects fogFar exceeding radius', () => {
       expect(() =>
-        createEnvironment({ radius: 40, fogFar: 50 }),
+        createEnvironment({ mode: 'dome', radius: 40, fogFar: 50 }),
       ).toThrow(/invariant/);
     });
     it('rejects a radius the camera could exit (black-void guard)', () => {
-      expect(() => createEnvironment({ radius: 15 })).toThrow(/invariant/);
+      expect(() =>
+        createEnvironment({ mode: 'dome', radius: 15 }),
+      ).toThrow(/invariant/);
     });
     it('rejects a radius that would clip the camera far plane', () => {
-      expect(() => createEnvironment({ radius: 120 })).toThrow(/invariant/);
-    });
-    it("does NOT gate 'flat' mode on dome invariants", () => {
-      // 'flat' has no dome/fog, so the dome invariants must not fire.
       expect(() =>
-        createEnvironment({ mode: 'flat', radius: 1 }),
-      ).not.toThrow();
+        createEnvironment({ mode: 'dome', radius: 120 }),
+      ).toThrow(/invariant/);
     });
   });
 
   // v1.0-INTENTIONAL canary guarding the #215/#216 token calibration
-  // (plan §2.3). NOT a forward-compatible invariant — if a later epic
-  // deliberately brightens the environment, DELETE this test as part
-  // of that epic's token re-tune; do NOT silently loosen it.
+  // (plan §2.3). Still relevant for the dome opt-in path. NOT a
+  // forward-compatible invariant — if a later epic deliberately
+  // brightens the gradient, DELETE this as part of that re-tune.
   describe('gradient horizon-stop canary (v1.0-intentional)', () => {
     it('keeps the horizon stop within ±0x10/channel of 0x111122', () => {
       const { horizon } = buildGradientStops();
@@ -133,7 +156,7 @@ describe('createEnvironment (#224 / E1.3)', () => {
 
   describe('env-owned material fog flags (§3.5 audit, env half)', () => {
     it('dome fog:false; richness detail meshes fog:true', () => {
-      const env = createEnvironment({ richness: true });
+      const env = createEnvironment({ mode: 'dome', richness: true });
       const meshes = collectMeshes(env.group);
       const dome = meshes[0];
       expect((dome.material as THREE.MeshBasicMaterial).fog).toBe(false);
@@ -149,7 +172,7 @@ describe('createEnvironment (#224 / E1.3)', () => {
     // and textures; spying it verifies dispose ran without poking
     // internal state (same pattern as StageFloor.test.ts).
     it('disposes dome geometry, material, and gradient texture once', () => {
-      const env = createEnvironment();
+      const env = createEnvironment({ mode: 'dome' });
       const dome = collectMeshes(env.group)[0];
       const geomSpy = vi.fn();
       const matSpy = vi.fn();
@@ -171,7 +194,7 @@ describe('createEnvironment (#224 / E1.3)', () => {
     });
 
     it('disposes richness geometries + materials too', () => {
-      const env = createEnvironment({ richness: true });
+      const env = createEnvironment({ mode: 'dome', richness: true });
       const meshes = collectMeshes(env.group);
       const spies = meshes.flatMap((m) => {
         const gs = vi.fn();
@@ -186,7 +209,7 @@ describe('createEnvironment (#224 / E1.3)', () => {
       for (const s of spies) expect(s).toHaveBeenCalledTimes(1);
     });
 
-    it("'flat' mode dispose is idempotent and safe", () => {
+    it('flat-mode dispose is idempotent and safe', () => {
       const env = createEnvironment({ mode: 'flat' });
       expect(() => {
         env.dispose();

--- a/test/scaffold/staging/Environment.test.ts
+++ b/test/scaffold/staging/Environment.test.ts
@@ -10,6 +10,7 @@ import {
   ENVIRONMENT_CAMERA_FAR,
   ENVIRONMENT_DOME_RENDER_ORDER,
   ENVIRONMENT_FLAT_BG_RGB,
+  ENVIRONMENT_CONTRAST_BOX_HALF_EXTENT,
 } from '../../../src/scaffold/staging/Environment.ts';
 
 function collectMeshes(g: THREE.Object3D): THREE.Mesh[] {
@@ -19,37 +20,40 @@ function collectMeshes(g: THREE.Object3D): THREE.Mesh[] {
   });
   return out;
 }
+const boxFaces = (m: THREE.Mesh[]): THREE.Mesh[] =>
+  m.filter((x) => x.name === 'contrast-box-face');
+const nonBox = (m: THREE.Mesh[]): THREE.Mesh[] =>
+  m.filter((x) => x.name !== 'contrast-box-face');
 
 describe('createEnvironment (#224 / E1.3)', () => {
   describe("mode: 'flat' (DEFAULT, post-#245 smoke)", () => {
-    it('default (no args) is flat: no fog, no meshes, a solid bg', () => {
+    it('default is flat: no fog, solid bg, only the contrast box', () => {
       const env = createEnvironment();
       expect(env.fog).toBeNull();
       expect(env.background).toBeInstanceOf(THREE.Color);
-      expect(collectMeshes(env.group).length).toBe(0);
+      const meshes = collectMeshes(env.group);
+      expect(nonBox(meshes).length).toBe(0); // no dome in flat
+      expect(boxFaces(meshes).length).toBe(5); // box default ON
       env.dispose();
     });
 
     it('flat bg is the tuned tone within the darkness binary-search bounds', () => {
       const env = createEnvironment();
       const bg = env.background as THREE.Color;
-      const expected = new THREE.Color(...ENVIRONMENT_FLAT_BG_RGB);
-      expect(bg.getHex()).toBe(expected.getHex());
-      // The search converges between black and the round-1 upper
-      // bound (0x1a1a2e, judged too light). Every channel must stay
-      // inside [0x000000, 0x1a1a2e] and be a near-black cool tone
-      // (B ≥ R ≈ G, no channel above the upper bound). Strictly
-      // brighter than pure black so it's an off-black, not a void.
-      const LOWER = [0, 0, 0]; // vantablack
-      const UPPER = [0x1a / 255, 0x1a / 255, 0x2e / 255]; // round-1
+      expect(bg.getHex()).toBe(
+        new THREE.Color(...ENVIRONMENT_FLAT_BG_RGB).getHex(),
+      );
+      // Search converges between black and the round-1 upper bound
+      // (0x1a1a2e, judged too light). Stay inside [black, upper],
+      // off-black (not pure black), cool (B ≥ R).
+      const UPPER = [0x1a / 255, 0x1a / 255, 0x2e / 255];
       const sum = (c: readonly number[]): number => c[0] + c[1] + c[2];
       for (let c = 0; c < 3; c++) {
-        expect(ENVIRONMENT_FLAT_BG_RGB[c]).toBeGreaterThanOrEqual(LOWER[c]);
+        expect(ENVIRONMENT_FLAT_BG_RGB[c]).toBeGreaterThanOrEqual(0);
         expect(ENVIRONMENT_FLAT_BG_RGB[c]).toBeLessThanOrEqual(UPPER[c]);
       }
-      expect(sum(ENVIRONMENT_FLAT_BG_RGB)).toBeGreaterThan(0); // not pure black
+      expect(sum(ENVIRONMENT_FLAT_BG_RGB)).toBeGreaterThan(0);
       expect(sum(ENVIRONMENT_FLAT_BG_RGB)).toBeLessThan(sum(UPPER));
-      // Cool near-black: blue ≥ red ≈ green (same family as the void).
       expect(ENVIRONMENT_FLAT_BG_RGB[2]).toBeGreaterThanOrEqual(
         ENVIRONMENT_FLAT_BG_RGB[0],
       );
@@ -57,16 +61,72 @@ describe('createEnvironment (#224 / E1.3)', () => {
     });
 
     it('does NOT gate flat mode on the dome invariants', () => {
-      // flat has no dome/fog, so dome invariants must not fire.
       expect(() =>
         createEnvironment({ mode: 'flat', radius: 1, fogNear: 1 }),
       ).not.toThrow();
     });
   });
 
+  describe('vantablack contrast box (#245 smoke; default ON)', () => {
+    it('is present in BOTH flat and dome modes', () => {
+      const flat = createEnvironment();
+      const dome = createEnvironment({ mode: 'dome' });
+      expect(boxFaces(collectMeshes(flat.group)).length).toBe(5);
+      expect(boxFaces(collectMeshes(dome.group)).length).toBe(5);
+      flat.dispose();
+      dome.dispose();
+    });
+
+    it('contrastBox:false removes it', () => {
+      const env = createEnvironment({ contrastBox: false });
+      expect(boxFaces(collectMeshes(env.group)).length).toBe(0);
+      env.dispose();
+    });
+
+    it('all 5 faces share ONE geometry + ONE material; pure-black, fog:false, DoubleSide', () => {
+      const env = createEnvironment();
+      const faces = boxFaces(collectMeshes(env.group));
+      expect(faces.length).toBe(5);
+      const g0 = faces[0].geometry;
+      const m0 = faces[0].material as THREE.MeshBasicMaterial;
+      for (const f of faces) {
+        expect(f.geometry).toBe(g0); // shared geometry instance
+        expect(f.material).toBe(m0); // shared material instance
+      }
+      expect(m0).toBeInstanceOf(THREE.MeshBasicMaterial);
+      expect(m0.color.getHex()).toBe(0x000000);
+      expect(m0.fog).toBe(false);
+      expect(m0.side).toBe(THREE.DoubleSide);
+      env.dispose();
+    });
+
+    it('omits the +Z (viewer) face and seats the others at ±half-extent', () => {
+      const env = createEnvironment();
+      const faces = boxFaces(collectMeshes(env.group));
+      const c = new THREE.Vector3(0, 1.5, -4); // CONTRAST_BOX_CENTER
+      const h = ENVIRONMENT_CONTRAST_BOX_HALF_EXTENT;
+      // No face sits on the +Z (open / viewer) side.
+      for (const f of faces) {
+        expect(f.position.z).toBeLessThanOrEqual(c.z + 1e-6);
+      }
+      // The back wall is exactly one half-extent behind centre.
+      expect(faces.some((f) => Math.abs(f.position.z - (c.z - h)) < 1e-6)).toBe(
+        true,
+      );
+      // Top + bottom one half-extent above/below centre.
+      expect(faces.some((f) => Math.abs(f.position.y - (c.y + h)) < 1e-6)).toBe(
+        true,
+      );
+      expect(faces.some((f) => Math.abs(f.position.y - (c.y - h)) < 1e-6)).toBe(
+        true,
+      );
+      env.dispose();
+    });
+  });
+
   describe("mode: 'dome' (opt-in; future richer pass)", () => {
     it('produces a linear THREE.Fog, no solid background, a dome mesh', () => {
-      const env = createEnvironment({ mode: 'dome' });
+      const env = createEnvironment({ mode: 'dome', contrastBox: false });
       expect(env.fog).toBeInstanceOf(THREE.Fog);
       expect(env.background).toBeNull();
       expect(collectMeshes(env.group).length).toBe(1); // dome only
@@ -74,7 +134,7 @@ describe('createEnvironment (#224 / E1.3)', () => {
     });
 
     it('dome material/render-state is the deterministic backdrop config', () => {
-      const env = createEnvironment({ mode: 'dome' });
+      const env = createEnvironment({ mode: 'dome', contrastBox: false });
       const dome = collectMeshes(env.group)[0];
       const mat = dome.material as THREE.MeshBasicMaterial;
       expect(mat).toBeInstanceOf(THREE.MeshBasicMaterial);
@@ -90,8 +150,16 @@ describe('createEnvironment (#224 / E1.3)', () => {
 
   describe('richness severance (dome path; default false)', () => {
     it('richness:true adds meshes; the dome is present in both', () => {
-      const core = createEnvironment({ mode: 'dome', richness: false });
-      const rich = createEnvironment({ mode: 'dome', richness: true });
+      const core = createEnvironment({
+        mode: 'dome',
+        richness: false,
+        contrastBox: false,
+      });
+      const rich = createEnvironment({
+        mode: 'dome',
+        richness: true,
+        contrastBox: false,
+      });
       const coreMeshes = collectMeshes(core.group);
       const richMeshes = collectMeshes(rich.group);
       expect(coreMeshes.length).toBe(1);
@@ -106,7 +174,7 @@ describe('createEnvironment (#224 / E1.3)', () => {
 
   describe('linear-fog + dome geometric invariants', () => {
     it('default fog/radius satisfy the §2.2 invariant chain', () => {
-      const env = createEnvironment({ mode: 'dome' });
+      const env = createEnvironment({ mode: 'dome', contrastBox: false });
       const fog = env.fog as THREE.Fog;
       expect(fog).toBeInstanceOf(THREE.Fog);
       expect(fog.near).toBeGreaterThanOrEqual(ENVIRONMENT_FOG_NEAR_MIN);
@@ -123,35 +191,45 @@ describe('createEnvironment (#224 / E1.3)', () => {
   describe('construction-time invariant rejection (dome path)', () => {
     it('rejects fogNear below the stage-reach minimum', () => {
       expect(() =>
-        createEnvironment({ mode: 'dome', fogNear: 5 }),
+        createEnvironment({ mode: 'dome', fogNear: 5, contrastBox: false }),
       ).toThrow(/invariant/);
     });
     it('rejects fogNear >= fogFar', () => {
       expect(() =>
-        createEnvironment({ mode: 'dome', fogNear: 30, fogFar: 20 }),
+        createEnvironment({
+          mode: 'dome',
+          fogNear: 30,
+          fogFar: 20,
+          contrastBox: false,
+        }),
       ).toThrow(/invariant/);
     });
     it('rejects fogFar exceeding radius', () => {
       expect(() =>
-        createEnvironment({ mode: 'dome', radius: 40, fogFar: 50 }),
+        createEnvironment({
+          mode: 'dome',
+          radius: 40,
+          fogFar: 50,
+          contrastBox: false,
+        }),
       ).toThrow(/invariant/);
     });
     it('rejects a radius the camera could exit (black-void guard)', () => {
       expect(() =>
-        createEnvironment({ mode: 'dome', radius: 15 }),
+        createEnvironment({ mode: 'dome', radius: 15, contrastBox: false }),
       ).toThrow(/invariant/);
     });
     it('rejects a radius that would clip the camera far plane', () => {
       expect(() =>
-        createEnvironment({ mode: 'dome', radius: 120 }),
+        createEnvironment({ mode: 'dome', radius: 120, contrastBox: false }),
       ).toThrow(/invariant/);
     });
   });
 
   // v1.0-INTENTIONAL canary guarding the #215/#216 token calibration
-  // (plan §2.3). Still relevant for the dome opt-in path. NOT a
-  // forward-compatible invariant — if a later epic deliberately
-  // brightens the gradient, DELETE this as part of that re-tune.
+  // (plan §2.3). NOT a forward-compatible invariant — if a later
+  // epic deliberately brightens the gradient, DELETE this test as
+  // part of that re-tune; do NOT silently loosen it.
   describe('gradient horizon-stop canary (v1.0-intentional)', () => {
     it('keeps the horizon stop within ±0x10/channel of 0x111122', () => {
       const { horizon } = buildGradientStops();
@@ -165,10 +243,13 @@ describe('createEnvironment (#224 / E1.3)', () => {
 
   describe('env-owned material fog flags (§3.5 audit, env half)', () => {
     it('dome fog:false; richness detail meshes fog:true', () => {
-      const env = createEnvironment({ mode: 'dome', richness: true });
+      const env = createEnvironment({
+        mode: 'dome',
+        richness: true,
+        contrastBox: false,
+      });
       const meshes = collectMeshes(env.group);
-      const dome = meshes[0];
-      expect((dome.material as THREE.MeshBasicMaterial).fog).toBe(false);
+      expect((meshes[0].material as THREE.MeshBasicMaterial).fog).toBe(false);
       for (let i = 1; i < meshes.length; i++) {
         expect((meshes[i].material as THREE.MeshBasicMaterial).fog).toBe(true);
       }
@@ -177,53 +258,63 @@ describe('createEnvironment (#224 / E1.3)', () => {
   });
 
   describe('dispose() — idempotent + leak-free', () => {
-    // Three.js dispatches a 'dispose' event on geometries, materials,
-    // and textures; spying it verifies dispose ran without poking
-    // internal state (same pattern as StageFloor.test.ts).
-    it('disposes dome geometry, material, and gradient texture once', () => {
-      const env = createEnvironment({ mode: 'dome' });
+    it('flat mode disposes the contrast box geo + mat exactly once', () => {
+      const env = createEnvironment(); // flat, box on
+      const faces = boxFaces(collectMeshes(env.group));
+      const gSpy = vi.fn();
+      const mSpy = vi.fn();
+      faces[0].geometry.addEventListener('dispose', gSpy);
+      (faces[0].material as THREE.Material).addEventListener('dispose', mSpy);
+      env.dispose();
+      expect(gSpy).toHaveBeenCalledTimes(1);
+      expect(mSpy).toHaveBeenCalledTimes(1);
+      env.dispose(); // idempotent
+      expect(gSpy).toHaveBeenCalledTimes(1);
+      expect(mSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('dome mode disposes dome geo, material, gradient texture once', () => {
+      const env = createEnvironment({ mode: 'dome', contrastBox: false });
       const dome = collectMeshes(env.group)[0];
       const geomSpy = vi.fn();
       const matSpy = vi.fn();
       const texSpy = vi.fn();
       dome.geometry.addEventListener('dispose', geomSpy);
       (dome.material as THREE.Material).addEventListener('dispose', matSpy);
-      const tex = (dome.material as THREE.MeshBasicMaterial).map!;
-      tex.addEventListener('dispose', texSpy);
-
+      (dome.material as THREE.MeshBasicMaterial).map!.addEventListener(
+        'dispose',
+        texSpy,
+      );
       env.dispose();
       expect(geomSpy).toHaveBeenCalledTimes(1);
       expect(matSpy).toHaveBeenCalledTimes(1);
       expect(texSpy).toHaveBeenCalledTimes(1);
-
-      env.dispose(); // idempotent
+      env.dispose();
       expect(geomSpy).toHaveBeenCalledTimes(1);
-      expect(matSpy).toHaveBeenCalledTimes(1);
-      expect(texSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('disposes richness geometries + materials too', () => {
+    it('dome+richness+box disposes everything once', () => {
       const env = createEnvironment({ mode: 'dome', richness: true });
       const meshes = collectMeshes(env.group);
-      const spies = meshes.flatMap((m) => {
-        const gs = vi.fn();
-        const ms = vi.fn();
-        m.geometry.addEventListener('dispose', gs);
-        (m.material as THREE.Material).addEventListener('dispose', ms);
-        return [gs, ms];
-      });
+      // Unique geometries/materials (box shares one of each).
+      const geos = new Set(meshes.map((m) => m.geometry));
+      const mats = new Set(meshes.map((m) => m.material as THREE.Material));
+      const spies = [
+        ...[...geos].map((g) => {
+          const s = vi.fn();
+          g.addEventListener('dispose', s);
+          return s;
+        }),
+        ...[...mats].map((m) => {
+          const s = vi.fn();
+          m.addEventListener('dispose', s);
+          return s;
+        }),
+      ];
       env.dispose();
       for (const s of spies) expect(s).toHaveBeenCalledTimes(1);
       env.dispose();
       for (const s of spies) expect(s).toHaveBeenCalledTimes(1);
-    });
-
-    it('flat-mode dispose is idempotent and safe', () => {
-      const env = createEnvironment({ mode: 'flat' });
-      expect(() => {
-        env.dispose();
-        env.dispose();
-      }).not.toThrow();
     });
   });
 });

--- a/test/scaffold/staging/Environment.test.ts
+++ b/test/scaffold/staging/Environment.test.ts
@@ -10,9 +10,6 @@ import {
   ENVIRONMENT_CAMERA_FAR,
   ENVIRONMENT_DOME_RENDER_ORDER,
   ENVIRONMENT_FLAT_BG_RGB,
-  ENVIRONMENT_PIT_TOP_Y,
-  ENVIRONMENT_PIT_DEPTH,
-  ENVIRONMENT_PIT_XZ_HALF,
 } from '../../../src/scaffold/staging/Environment.ts';
 
 function collectMeshes(g: THREE.Object3D): THREE.Mesh[] {
@@ -22,20 +19,14 @@ function collectMeshes(g: THREE.Object3D): THREE.Mesh[] {
   });
   return out;
 }
-const boxFaces = (m: THREE.Mesh[]): THREE.Mesh[] =>
-  m.filter((x) => x.name === 'contrast-box-face');
-const nonBox = (m: THREE.Mesh[]): THREE.Mesh[] =>
-  m.filter((x) => x.name !== 'contrast-box-face');
 
-describe('createEnvironment (#224 / E1.3)', () => {
-  describe("mode: 'flat' (DEFAULT, post-#245 smoke)", () => {
-    it('default is flat: no fog, solid bg, only the contrast box', () => {
+describe('createEnvironment (#224 / E1.3) — backdrop only', () => {
+  describe("mode: 'flat' (DEFAULT)", () => {
+    it('default is flat: no fog, no meshes, a solid bg', () => {
       const env = createEnvironment();
       expect(env.fog).toBeNull();
       expect(env.background).toBeInstanceOf(THREE.Color);
-      const meshes = collectMeshes(env.group);
-      expect(nonBox(meshes).length).toBe(0); // no dome in flat
-      expect(boxFaces(meshes).length).toBe(4); // sub-floor pit, default ON
+      expect(collectMeshes(env.group).length).toBe(0);
       env.dispose();
     });
 
@@ -45,8 +36,8 @@ describe('createEnvironment (#224 / E1.3)', () => {
       expect(bg.getHex()).toBe(
         new THREE.Color(...ENVIRONMENT_FLAT_BG_RGB).getHex(),
       );
-      // Search converges between black and the round-1 upper bound
-      // (0x1a1a2e, judged too light). Stay inside [black, upper],
+      // Converges between black and the round-1 upper bound
+      // (0x1a1a2e, judged too light). Inside [black, upper],
       // off-black (not pure black), cool (B ≥ R).
       const UPPER = [0x1a / 255, 0x1a / 255, 0x2e / 255];
       const sum = (c: readonly number[]): number => c[0] + c[1] + c[2];
@@ -69,72 +60,9 @@ describe('createEnvironment (#224 / E1.3)', () => {
     });
   });
 
-  describe('vantablack sub-floor pit (#245 smoke; default ON)', () => {
-    it('is present in BOTH flat and dome modes (4 faces)', () => {
-      const flat = createEnvironment();
-      const dome = createEnvironment({ mode: 'dome' });
-      expect(boxFaces(collectMeshes(flat.group)).length).toBe(4);
-      expect(boxFaces(collectMeshes(dome.group)).length).toBe(4);
-      flat.dispose();
-      dome.dispose();
-    });
-
-    it('contrastBox:false removes it', () => {
-      const env = createEnvironment({ contrastBox: false });
-      expect(boxFaces(collectMeshes(env.group)).length).toBe(0);
-      env.dispose();
-    });
-
-    it('4 faces share ONE material (sizes differ → per-face geo); pure-black, fog:false, DoubleSide', () => {
-      const env = createEnvironment();
-      const faces = boxFaces(collectMeshes(env.group));
-      expect(faces.length).toBe(4);
-      const m0 = faces[0].material as THREE.MeshBasicMaterial;
-      const geos = new Set<THREE.BufferGeometry>();
-      for (const f of faces) {
-        expect(f.material).toBe(m0); // shared material instance
-        geos.add(f.geometry);
-      }
-      expect(geos.size).toBe(4); // distinct per-face geometries
-      expect(m0).toBeInstanceOf(THREE.MeshBasicMaterial);
-      expect(m0.color.getHex()).toBe(0x000000);
-      expect(m0.fog).toBe(false);
-      expect(m0.side).toBe(THREE.DoubleSide);
-      env.dispose();
-    });
-
-    it('sits ENTIRELY below the floor (Y=0); open top + open front', () => {
-      const env = createEnvironment();
-      const faces = boxFaces(collectMeshes(env.group));
-      // Every face is at or below the floor — the pit never rises to
-      // eye level / never obscures the skybox except downward.
-      for (const f of faces) {
-        expect(f.position.y).toBeLessThanOrEqual(ENVIRONMENT_PIT_TOP_Y + 1e-6);
-      }
-      // Open top: no horizontal face at/above floor level. The only
-      // horizontal face is the bottom carpet at topY − depth.
-      const botY = ENVIRONMENT_PIT_TOP_Y - ENVIRONMENT_PIT_DEPTH;
-      expect(
-        faces.some((f) => Math.abs(f.position.y - botY) < 1e-6),
-      ).toBe(true);
-      // Open front (+Z, user side): no face in front of the focal
-      // footprint centre; the back wall is one XZ-half behind it.
-      const cz = -4; // CONTRAST_BOX_CENTER.z
-      for (const f of faces) {
-        expect(f.position.z).toBeLessThanOrEqual(cz + 1e-6);
-      }
-      expect(
-        faces.some(
-          (f) => Math.abs(f.position.z - (cz - ENVIRONMENT_PIT_XZ_HALF)) < 1e-6,
-        ),
-      ).toBe(true);
-      env.dispose();
-    });
-  });
-
   describe("mode: 'dome' (opt-in; future richer pass)", () => {
     it('produces a linear THREE.Fog, no solid background, a dome mesh', () => {
-      const env = createEnvironment({ mode: 'dome', contrastBox: false });
+      const env = createEnvironment({ mode: 'dome' });
       expect(env.fog).toBeInstanceOf(THREE.Fog);
       expect(env.background).toBeNull();
       expect(collectMeshes(env.group).length).toBe(1); // dome only
@@ -142,7 +70,7 @@ describe('createEnvironment (#224 / E1.3)', () => {
     });
 
     it('dome material/render-state is the deterministic backdrop config', () => {
-      const env = createEnvironment({ mode: 'dome', contrastBox: false });
+      const env = createEnvironment({ mode: 'dome' });
       const dome = collectMeshes(env.group)[0];
       const mat = dome.material as THREE.MeshBasicMaterial;
       expect(mat).toBeInstanceOf(THREE.MeshBasicMaterial);
@@ -158,16 +86,8 @@ describe('createEnvironment (#224 / E1.3)', () => {
 
   describe('richness severance (dome path; default false)', () => {
     it('richness:true adds meshes; the dome is present in both', () => {
-      const core = createEnvironment({
-        mode: 'dome',
-        richness: false,
-        contrastBox: false,
-      });
-      const rich = createEnvironment({
-        mode: 'dome',
-        richness: true,
-        contrastBox: false,
-      });
+      const core = createEnvironment({ mode: 'dome', richness: false });
+      const rich = createEnvironment({ mode: 'dome', richness: true });
       const coreMeshes = collectMeshes(core.group);
       const richMeshes = collectMeshes(rich.group);
       expect(coreMeshes.length).toBe(1);
@@ -182,7 +102,7 @@ describe('createEnvironment (#224 / E1.3)', () => {
 
   describe('linear-fog + dome geometric invariants', () => {
     it('default fog/radius satisfy the §2.2 invariant chain', () => {
-      const env = createEnvironment({ mode: 'dome', contrastBox: false });
+      const env = createEnvironment({ mode: 'dome' });
       const fog = env.fog as THREE.Fog;
       expect(fog).toBeInstanceOf(THREE.Fog);
       expect(fog.near).toBeGreaterThanOrEqual(ENVIRONMENT_FOG_NEAR_MIN);
@@ -198,39 +118,29 @@ describe('createEnvironment (#224 / E1.3)', () => {
 
   describe('construction-time invariant rejection (dome path)', () => {
     it('rejects fogNear below the stage-reach minimum', () => {
-      expect(() =>
-        createEnvironment({ mode: 'dome', fogNear: 5, contrastBox: false }),
-      ).toThrow(/invariant/);
+      expect(() => createEnvironment({ mode: 'dome', fogNear: 5 })).toThrow(
+        /invariant/,
+      );
     });
     it('rejects fogNear >= fogFar', () => {
       expect(() =>
-        createEnvironment({
-          mode: 'dome',
-          fogNear: 30,
-          fogFar: 20,
-          contrastBox: false,
-        }),
+        createEnvironment({ mode: 'dome', fogNear: 30, fogFar: 20 }),
       ).toThrow(/invariant/);
     });
     it('rejects fogFar exceeding radius', () => {
       expect(() =>
-        createEnvironment({
-          mode: 'dome',
-          radius: 40,
-          fogFar: 50,
-          contrastBox: false,
-        }),
+        createEnvironment({ mode: 'dome', radius: 40, fogFar: 50 }),
       ).toThrow(/invariant/);
     });
     it('rejects a radius the camera could exit (black-void guard)', () => {
-      expect(() =>
-        createEnvironment({ mode: 'dome', radius: 15, contrastBox: false }),
-      ).toThrow(/invariant/);
+      expect(() => createEnvironment({ mode: 'dome', radius: 15 })).toThrow(
+        /invariant/,
+      );
     });
     it('rejects a radius that would clip the camera far plane', () => {
-      expect(() =>
-        createEnvironment({ mode: 'dome', radius: 120, contrastBox: false }),
-      ).toThrow(/invariant/);
+      expect(() => createEnvironment({ mode: 'dome', radius: 120 })).toThrow(
+        /invariant/,
+      );
     });
   });
 
@@ -251,11 +161,7 @@ describe('createEnvironment (#224 / E1.3)', () => {
 
   describe('env-owned material fog flags (§3.5 audit, env half)', () => {
     it('dome fog:false; richness detail meshes fog:true', () => {
-      const env = createEnvironment({
-        mode: 'dome',
-        richness: true,
-        contrastBox: false,
-      });
+      const env = createEnvironment({ mode: 'dome', richness: true });
       const meshes = collectMeshes(env.group);
       expect((meshes[0].material as THREE.MeshBasicMaterial).fog).toBe(false);
       for (let i = 1; i < meshes.length; i++) {
@@ -266,27 +172,16 @@ describe('createEnvironment (#224 / E1.3)', () => {
   });
 
   describe('dispose() — idempotent + leak-free', () => {
-    it('flat mode disposes every pit geo + the shared mat exactly once', () => {
-      const env = createEnvironment(); // flat, pit on
-      const faces = boxFaces(collectMeshes(env.group));
-      expect(faces.length).toBe(4);
-      const mSpy = vi.fn();
-      (faces[0].material as THREE.Material).addEventListener('dispose', mSpy);
-      const gSpies = faces.map((f) => {
-        const s = vi.fn();
-        f.geometry.addEventListener('dispose', s);
-        return s;
-      });
-      env.dispose();
-      for (const s of gSpies) expect(s).toHaveBeenCalledTimes(1);
-      expect(mSpy).toHaveBeenCalledTimes(1);
-      env.dispose(); // idempotent
-      for (const s of gSpies) expect(s).toHaveBeenCalledTimes(1);
-      expect(mSpy).toHaveBeenCalledTimes(1);
+    it('flat mode owns nothing GPU-side; dispose is a safe no-op', () => {
+      const env = createEnvironment();
+      expect(() => {
+        env.dispose();
+        env.dispose();
+      }).not.toThrow();
     });
 
     it('dome mode disposes dome geo, material, gradient texture once', () => {
-      const env = createEnvironment({ mode: 'dome', contrastBox: false });
+      const env = createEnvironment({ mode: 'dome' });
       const dome = collectMeshes(env.group)[0];
       const geomSpy = vi.fn();
       const matSpy = vi.fn();
@@ -305,10 +200,9 @@ describe('createEnvironment (#224 / E1.3)', () => {
       expect(geomSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('dome+richness+box disposes everything once', () => {
+    it('dome+richness disposes every unique geo + mat once', () => {
       const env = createEnvironment({ mode: 'dome', richness: true });
       const meshes = collectMeshes(env.group);
-      // Unique geometries/materials (box shares one of each).
       const geos = new Set(meshes.map((m) => m.geometry));
       const mats = new Set(meshes.map((m) => m.material as THREE.Material));
       const spies = [

--- a/test/scaffold/staging/Environment.test.ts
+++ b/test/scaffold/staging/Environment.test.ts
@@ -10,7 +10,6 @@ import {
   ENVIRONMENT_CAMERA_FAR,
   ENVIRONMENT_DOME_RENDER_ORDER,
   ENVIRONMENT_FLAT_BG_RGB,
-  ENVIRONMENT_HORIZON_RGB,
 } from '../../../src/scaffold/staging/Environment.ts';
 
 function collectMeshes(g: THREE.Object3D): THREE.Mesh[] {
@@ -31,19 +30,29 @@ describe('createEnvironment (#224 / E1.3)', () => {
       env.dispose();
     });
 
-    it('flat bg is the tuned tone, a touch lighter than the old void', () => {
+    it('flat bg is the tuned tone within the darkness binary-search bounds', () => {
       const env = createEnvironment();
       const bg = env.background as THREE.Color;
       const expected = new THREE.Color(...ENVIRONMENT_FLAT_BG_RGB);
       expect(bg.getHex()).toBe(expected.getHex());
-      // "a little bit lighter" — strictly brighter than 0x111122,
-      // same family (no channel darker than the void).
-      const void_ = ENVIRONMENT_HORIZON_RGB; // 0x111122
-      expect(ENVIRONMENT_FLAT_BG_RGB[0]).toBeGreaterThanOrEqual(void_[0]);
-      expect(ENVIRONMENT_FLAT_BG_RGB[1]).toBeGreaterThanOrEqual(void_[1]);
-      expect(ENVIRONMENT_FLAT_BG_RGB[2]).toBeGreaterThanOrEqual(void_[2]);
+      // The search converges between black and the round-1 upper
+      // bound (0x1a1a2e, judged too light). Every channel must stay
+      // inside [0x000000, 0x1a1a2e] and be a near-black cool tone
+      // (B ≥ R ≈ G, no channel above the upper bound). Strictly
+      // brighter than pure black so it's an off-black, not a void.
+      const LOWER = [0, 0, 0]; // vantablack
+      const UPPER = [0x1a / 255, 0x1a / 255, 0x2e / 255]; // round-1
       const sum = (c: readonly number[]): number => c[0] + c[1] + c[2];
-      expect(sum(ENVIRONMENT_FLAT_BG_RGB)).toBeGreaterThan(sum(void_));
+      for (let c = 0; c < 3; c++) {
+        expect(ENVIRONMENT_FLAT_BG_RGB[c]).toBeGreaterThanOrEqual(LOWER[c]);
+        expect(ENVIRONMENT_FLAT_BG_RGB[c]).toBeLessThanOrEqual(UPPER[c]);
+      }
+      expect(sum(ENVIRONMENT_FLAT_BG_RGB)).toBeGreaterThan(0); // not pure black
+      expect(sum(ENVIRONMENT_FLAT_BG_RGB)).toBeLessThan(sum(UPPER));
+      // Cool near-black: blue ≥ red ≈ green (same family as the void).
+      expect(ENVIRONMENT_FLAT_BG_RGB[2]).toBeGreaterThanOrEqual(
+        ENVIRONMENT_FLAT_BG_RGB[0],
+      );
       env.dispose();
     });
 


### PR DESCRIPTION
Closes #224 (E1.3 under the v1.0 staged-exhibit vocabulary #221).

Replaces the flat `scene.background = 0x111122` void with a shell-owned, baked **gradient sky dome + linear `THREE.Fog`**. Inherited by all four cluster scenes with zero per-scene wiring; reads as "a dim room with this exhibit on a lit stage."

## How it was built

Plan → 3-vendor `/roundtable-plan-review` (Sonnet + GPT-5.5 + DeepSeek; unanimous REVISE) → v2 folding all convergent/agreed findings → second-Sonnet sanity check (all 10 prior findings verified CLOSED against source; 1 new MEDIUM) → v3 → one Brad-approved implementation-time amendment. Full record in `_private/plans/224-environment-surround.md` (maintainer-only).

Key locked decisions from the review:
- **Linear `THREE.Fog`, not `FogExp2`** — makes "stage stays crisp" a *provable* invariant (zero attenuation below `fogNear=14`), dissolves the FogExp2 crisp@14m-vs-heavy@40m impossibility.
- **Disposer pushed AFTER the renderer disposer** (LIFO → env GPU freed before the GL context dies) — fixed a two-way convergent HIGH.
- **Camera-can't-exit-dome invariant** grounded in the audited `OrbitControls.maxDistance=12` (`radius ≥ MAX_CAMERA_REACH+margin`, asserted).
- **`scene.fog` audit via invariant, not scattered flags** — `fogNear≥14` provably un-fogs all near-field UI; `TranslucentRect` is structurally fog-immune (ShaderMaterial); explicit `fog:false` only on `SceneRack`. (Brad-approved simplification of v3 §3.5 after reading the UI code — stronger/more maintainable; recorded in the plan status block.)
- **`mode:'flat'` degrade tier** — solid tuned-tone background + no fog ≈ today's cost; the Quest-72Hz core fallback (regression ⇒ degrade, never defer).
- **`richness` default off** — distant-detail meshes opt-in (v1.0.md §2: atmosphere is the first cut).

## Automated checks (green)

- `npm run build` (tsc --noEmit + vite build) ✅
- Full Vitest suite: 489 passed (incl. 16 new `Environment.test.ts`) ✅
- `npm run lint` ✅ · pre-commit (gitleaks + fixers) ✅

## Headset / pancake smoke — needs maintainer eyes on the Cloudflare PR preview

Automated checks cover CPU-side correctness only; the following are eyes-on calls (plan §6):

- [x] **Quest 3S 72Hz hold** across all four scenes (binding gate at the quadrics raymarcher). If it regresses, apply the §3.6 ladder (`richness:false` → shrink radius → `mode:'flat'`).
- [x] Void gone; dim gradient dome with correct **VR head-turn parallax**; stage/floor/railing/math **crisp, zero haze**; distance dissolves into the horizon-tone fog with no dome seam.
- [x] **#215/#216 token re-validation:** translucent overlays (slicing/tangent/level/Taylor) + all readouts read with unchanged contrast/no fog tint against the new backdrop. Record verdict here.
- [x] **Camera-exit check:** zoom to OrbitControls max in each scene — dome still encloses, no black void.
- [x] SceneRack-switch all four: environment persistent, no flicker; `[renderer.info]` returns to baseline (±1) after switch-away-and-back.
- [x] HMR cycle (maintainer localhost): edit-save `Environment.ts` → no `renderer.info` growth; `scene.fog === null` between dispose and re-boot.
- [x] Pancake (audition surface): default framing unchanged; "dim room" read; ≥60 fps; overlays/readouts legible at ~⅓ viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)