### PR TITLE
feat(scaffold): RendererInfoProbe.snapshot() for programmable mount-leak checks (#247)

### DIFF
--- a/src/scaffold/perf/RendererInfoProbe.ts
+++ b/src/scaffold/perf/RendererInfoProbe.ts
@@ -15,6 +15,29 @@ import * as THREE from 'three';
 
 const LOG_INTERVAL_MS = 5000;
 
+// Point-in-time `renderer.info` reading (#247). Two classes of counter:
+//
+//  - `calls` / `triangles` / `points` / `lines` are *per-frame* render
+//    stats (Three.js resets them each frame via `info.autoReset`). They
+//    proxy "scene-graph cost right now" — the value the manual
+//    mount-leak smoke eyeballs returning to baseline after a SceneRack
+//    switch. Read these immediately after a render of the relevant
+//    state.
+//  - `geometries` / `textures` / `programs` are *persistent* GPU-object
+//    counts that fall only on disposal. These are the true
+//    mount → unmount → re-mount leak signal: a delta vs. a pre-mount
+//    baseline means an exhibit leaked a geometry/texture/program
+//    through its unmount path.
+export interface RendererInfoSnapshot {
+  readonly calls: number;
+  readonly triangles: number;
+  readonly points: number;
+  readonly lines: number;
+  readonly geometries: number;
+  readonly textures: number;
+  readonly programs: number;
+}
+
 export class RendererInfoProbe {
   private readonly renderer: THREE.WebGLRenderer;
   private lastLogMs = 0;
@@ -23,17 +46,37 @@ export class RendererInfoProbe {
     this.renderer = renderer;
   }
 
+  // Side-effect-free read of the current `renderer.info`. Does not
+  // touch the log throttle, so it composes with `update()` and is
+  // safe to call at arbitrary points (e.g. a programmable mount-leak
+  // assertion: snapshot before mount, snapshot after unmount, compare
+  // the persistent counts).
+  snapshot(): RendererInfoSnapshot {
+    const { render, memory, programs } = this.renderer.info;
+    return {
+      calls: render.calls,
+      triangles: render.triangles,
+      points: render.points,
+      lines: render.lines,
+      geometries: memory.geometries,
+      textures: memory.textures,
+      programs: programs?.length ?? 0,
+    };
+  }
+
   update(nowMs: number): void {
     if (nowMs - this.lastLogMs < LOG_INTERVAL_MS) return;
     this.lastLogMs = nowMs;
 
-    const { render, programs } = this.renderer.info;
+    const s = this.snapshot();
     console.log(
-      `[renderer.info] calls=${render.calls} ` +
-        `triangles=${render.triangles} ` +
-        `points=${render.points} ` +
-        `lines=${render.lines} ` +
-        `programs=${programs?.length ?? 0}`,
+      `[renderer.info] calls=${s.calls} ` +
+        `triangles=${s.triangles} ` +
+        `points=${s.points} ` +
+        `lines=${s.lines} ` +
+        `geometries=${s.geometries} ` +
+        `textures=${s.textures} ` +
+        `programs=${s.programs}`,
     );
   }
 }

--- a/test/scaffold/perf/RendererInfoProbe.test.ts
+++ b/test/scaffold/perf/RendererInfoProbe.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type * as THREE from 'three';
+import { RendererInfoProbe } from '../../../src/scaffold/perf/RendererInfoProbe.ts';
+
+// `WebGLRenderer` needs a real GL context; the probe only ever reads
+// `renderer.info`, so a stub with a mutable `info` shape is sufficient
+// and lets us drive counter changes deterministically.
+function stubRenderer(info: {
+  render: { calls: number; triangles: number; points: number; lines: number };
+  memory: { geometries: number; textures: number };
+  programs: { length: number } | null;
+}): THREE.WebGLRenderer {
+  return { info } as unknown as THREE.WebGLRenderer;
+}
+
+function defaultInfo() {
+  return {
+    render: { calls: 3, triangles: 120, points: 0, lines: 4 },
+    memory: { geometries: 7, textures: 2 },
+    programs: { length: 5 },
+  };
+}
+
+describe('RendererInfoProbe (#247 — programmable mount-leak snapshot)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('snapshot() reflects current renderer.info, render + memory + programs', () => {
+    const probe = new RendererInfoProbe(stubRenderer(defaultInfo()));
+    expect(probe.snapshot()).toEqual({
+      calls: 3,
+      triangles: 120,
+      points: 0,
+      lines: 4,
+      geometries: 7,
+      textures: 2,
+      programs: 5,
+    });
+  });
+
+  it('snapshot() treats a null programs list as zero', () => {
+    const info = defaultInfo();
+    const probe = new RendererInfoProbe(
+      stubRenderer({ ...info, programs: null }),
+    );
+    expect(probe.snapshot().programs).toBe(0);
+  });
+
+  it('snapshot() re-reads live — leak shows as a persistent-count delta', () => {
+    const info = defaultInfo();
+    const probe = new RendererInfoProbe(stubRenderer(info));
+    const baseline = probe.snapshot();
+
+    // Simulate mount → unmount → re-mount that leaks one geometry +
+    // one texture (per-frame render counts returned to baseline).
+    info.memory.geometries += 1;
+    info.memory.textures += 1;
+    const after = probe.snapshot();
+
+    expect(after.geometries - baseline.geometries).toBe(1);
+    expect(after.textures - baseline.textures).toBe(1);
+    expect(after.calls).toBe(baseline.calls);
+  });
+
+  it('snapshot() is side-effect-free: does not arm the log throttle', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const probe = new RendererInfoProbe(stubRenderer(defaultInfo()));
+
+    probe.snapshot();
+    probe.snapshot();
+    probe.snapshot();
+    // Snapshot must not move the throttle: the first logging update is
+    // still the one past LOG_INTERVAL_MS, identical to baseline.
+    probe.update(4999); // within the 5 s window — suppressed
+    expect(log).not.toHaveBeenCalled();
+    probe.update(5000); // window elapsed — logs once
+    expect(log).toHaveBeenCalledTimes(1);
+  });
+
+  it('update() throttles to LOG_INTERVAL_MS and logs the full snapshot', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const probe = new RendererInfoProbe(stubRenderer(defaultInfo()));
+
+    // lastLogMs initializes to 0, so the t=0 call is itself within the
+    // window and suppressed — pre-existing throttle behavior, unchanged
+    // by #247.
+    probe.update(0); // suppressed (0 - 0 < 5000)
+    probe.update(5000); // window elapsed — logs (1)
+    probe.update(9999); // within window — suppressed
+    probe.update(10000); // window elapsed — logs (2)
+    expect(log).toHaveBeenCalledTimes(2);
+    expect(log.mock.calls[0][0]).toContain('geometries=7');
+    expect(log.mock.calls[0][0]).toContain('textures=2');
+    expect(log.mock.calls[0][0]).toContain('programs=5');
+  });
+});


### PR DESCRIPTION
Closes #247.

## What

Adds a side-effect-free `snapshot(): RendererInfoSnapshot` to `RendererInfoProbe`. Today the probe only console-logs `renderer.info` every 5 s, so the staging primitives' mount → unmount → re-mount **leak-free** acceptance (a v1.0.md §4 lifecycle rule for `StageFloor`/`StageRailing`/`ContrastPit`/`Environment`) is verified by a *manual* `chrome://inspect` + `?fps=1` eyeball. `snapshot()` makes that a programmable assertion.

## Snapshot shape

`{ calls, triangles, points, lines, geometries, textures, programs }`

The issue suggested `{ calls; triangles; programs }` "(or similar)". Design call captured in the doc comment: `calls`/`triangles`/`points`/`lines` are *per-frame* render stats (the "scene-graph returned to baseline" proxy the manual smoke eyeballs); `geometries`/`textures`/`programs` are *persistent* GPU-object counts that fall only on disposal — the **true** mount-leak signal. Including both makes the leak check assertable on the real signal, not just the proxy.

- `update()` now reuses `snapshot()` (no duplicated field reads); logged line gains the three persistent counts.
- `snapshot()` does not touch the log throttle — safe to interleave with `update()`.
- Pre-existing `lastLogMs = 0` throttle behavior (the t=0 `update()` is suppressed) is intentionally unchanged; covered by a test with a comment.

## Scope

Probe API only. Wiring it into a shell Vitest/integration harness is explicitly deferred (#245 plan §4.4 — no shell test rig today).

## Verification

- New `test/scaffold/perf/RendererInfoProbe.test.ts` — 5 cases (snapshot fidelity, null-programs → 0, leak-as-persistent-delta, throttle-untouched, throttle semantics).
- Full suite: 501 passed (36 files). `tsc --noEmit` clean. `eslint` clean.
- No visual/headset surface — non-visual probe API with full unit coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)