### PR TITLE
feat(staging): three scenes on plinth + cluster-wide readout slot registration (#251)

### DIFF
--- a/src/exhibits/gradient-levels/SPEC.md
+++ b/src/exhibits/gradient-levels/SPEC.md
@@ -430,3 +430,51 @@ Inner railing (#223 v3): shared `StageInnerRailing` primitive, rect
 path. 4 corner posts at the cutout corners (`±BOUND` from
 `SURFACE_CENTER.xz`) + 4 perimeter tubes. Same height + color as
 the outer railing.
+
+### Staging — Control plinth (#225 / E1.4)
+
+Interactive UI (θ / φ / k sliders + per-slider labels + gradient-
+levels readout + math-frame axis indicator) lifts onto the cluster-
+shared `createPlinth` primitive from `src/scaffold/staging/Plinth.ts`,
+matching quadrics' PR1 ship and the master plan
+(`_private/plans/225-control-plinth.md` §4.2 PR2 / `251-cluster-on-
+plinth.md` §3.2). Drafting-table-console silhouette anchored at world
+`(0, 0, 0.05)` — cluster-uniform anchor. Working-surface depth =
+`Plinth.ts` default 0.5 m: the 3-slider rack at `SLIDER_ROW_PITCH =
+0.14 m` fits in slot-Y ∈ [0.135, 0.415] with breathing room above
+and below.
+
+Every UI primitive's `group` is reparented under `plinth.group` via
+the slot manifest in `mount()`; positions are slot-local. Slot
+manifest:
+
+- **θ slider** (top row) at slot-local `(0, 0.415, 0)`.
+- **φ slider** (mid row) at slot-local `(0, 0.275, 0)`.
+- **k slider** (bottom row) at slot-local `(0, 0.135, 0)` — full
+  `SLIDER_ROW_PITCH = 0.14 m` between rows, matching the pre-plinth
+  `THETA_Y / PHI_Y / K_Y` derivation.
+- **Per-slider labels** at slot-local
+  `(SLIDER_LABEL_X_OFFSET, sliderY, 0)` for each row.
+- **GradientLevelsReadout** at slot-local `(0, 0.57, 0)` — floats
+  above the working-surface back edge at slot-Y = 0.5, mirroring
+  quadrics' "readout above back edge" pattern.
+- **WorldAxes** at slot-local `(0.42, 0.275, 0)`, `orientation:
+  'world'` — keeps the math-frame X/Y/Z arrows aligned to the math
+  frame regardless of plinth tilt.
+
+**Math-object affordances stay in world frame.** `surfaceMesh`,
+`gradientArrow`, and `indicator` are children of `ctx.group`, never
+reparented under `plinth.group` — they're rendered at the math
+object's position (`SURFACE_CENTER`), not on the control surface.
+
+**Readout billboard carve-out.** `GradientLevelsReadout` overwrites
+`group.rotation` every frame via `faceCamera`, so the slot's default
+`'surface'` orientation is documentation-only — the readout yaw-
+billboards regardless. The slot position binds it to the plinth's
+slot-Y axis above the rack.
+
+**Grab radius.** All interactive primitives (three sliders) use
+`GRAB_RADIUS_MULTIPLIER_PLINTH = 1.5` from
+`scaffold/ui/clusterRackTokens.ts`. The pre-plinth mid-air `2.75`
+constant was deleted at PR2 (#251) once all four cluster scenes
+ported onto the plinth.

--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -11,14 +11,13 @@ import { formatAnglePiFraction } from '@/scaffold/ui/formatAnglePiFraction';
 import { Label } from '@/scaffold/ui/Label';
 import { Slider } from '@/scaffold/ui/Slider';
 import {
-  GRAB_RADIUS_MULTIPLIER,
+  GRAB_RADIUS_MULTIPLIER_PLINTH,
   SLIDER_LABEL_LINE_GAP,
   SLIDER_LABEL_PRIMARY_FONT_SIZE,
   SLIDER_LABEL_SECONDARY_FONT_SIZE,
   SLIDER_LABEL_X_OFFSET,
   SLIDER_ROW_PITCH,
   SLIDER_SNAP_DETENT,
-  createSliderRackCenter,
 } from '@/scaffold/ui/clusterRackTokens';
 import { WorldAxes, type AxisName } from '@/scaffold/ui/WorldAxes';
 import {
@@ -44,6 +43,11 @@ import {
   createStageInnerRailing,
   type StageInnerRailingHandles,
 } from '@/scaffold/staging/StageInnerRailing';
+import {
+  createPlinth,
+  type PlinthHandles,
+  type PlinthSlot,
+} from '@/scaffold/staging/Plinth';
 import { createGradientArrow, type GradientArrowHandles } from './GradientArrow';
 import { GradientLevelsReadout } from './GradientLevelsReadout';
 import { BOUND, fJsRaw, gradJs } from './surfaceModel';
@@ -71,18 +75,28 @@ import { BOUND, fJsRaw, gradJs } from './surfaceModel';
 // Constants
 // ────────────────────────────────────────────────────────────────────
 
-// Match cluster siblings so SceneRack swaps don't visually relocate the
-// surface or the rack.
+// Cluster-shared math-object anchor so SceneRack swaps don't visually
+// relocate the surface across sibling scenes.
 const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
-// Per-file fresh THREE.Vector3 from scaffold/ui/clusterRackTokens
-// (#201 PR 4). Per-scene instance — mutation can't leak across scenes.
-const SLIDER_RACK_CENTER = createSliderRackCenter();
-const AXIS_INDICATOR_POSITION = new THREE.Vector3(0.35, 1.17, -0.7);
 
-// Live readout (#166) — anchored above the three-row slider rack. y bumped
-// to 1.42 (vs. tangent-planes' 1.32) to maintain ~0.18 m bottom-to-thumb-top
-// clearance over the taller rack (top of θ slider thumb at y ≈ 1.21).
-const READOUT_POSITION = new THREE.Vector3(0, 1.42, -0.7);
+// Plinth (#225 / E1.4 PR2). Cluster-uniform anchor matches quadrics'
+// PR1 ship — railing/floor geometry is shared. Working-surface depth
+// default 0.5 m fits the 3-row slider rack at SLIDER_ROW_PITCH = 0.14 m
+// (slot-Y ∈ [0.135, 0.415]) with breathing room above and below.
+const PLINTH_ANCHOR_WORLD_XYZ = [0, 0, 0.05] as const;
+
+// Slot-local layout (slot-local +X right, +Y up the tilted face toward
+// the back, +Z out from the surface normal). Three-row rack centered
+// on slot-Y = 0.275 (mid-surface): θ top at 0.415, φ middle at 0.275,
+// k bottom at 0.135 — full SLIDER_ROW_PITCH = 0.14 m between rows,
+// matching the pre-plinth `THETA_Y / PHI_Y / K_Y` derivation. Per-
+// slider labels at slot-X = SLIDER_LABEL_X_OFFSET = -0.2. Readout
+// above the back edge at slot-Y = 0.57. Math-frame axis indicator at
+// the right edge with orientation: 'world'.
+const PLINTH_SLIDER_MID_Y = 0.275;
+const PLINTH_READOUT_Y = 0.57;
+const PLINTH_AXIS_INDICATOR_X = 0.42;
+const PLINTH_AXIS_INDICATOR_Y = 0.275;
 
 // Per-slider variable + value labels (#170). All three sliders (θ/φ/k)
 // carry a two-line right-aligned label anchored ~0.05 m left of each
@@ -100,14 +114,15 @@ const BASE_COLOR = new THREE.Color(0.4, 0.7, 0.95);
 // Quadrics' design feel ports across the cluster — imported from
 // scaffold/ui/clusterRackTokens (#201 PR 4).
 
-// Three-row slider stack centered at SLIDER_RACK_CENTER.y. Top to bottom:
-// θ (point selector, polar), φ (point selector, azimuth), k (level value).
-// k moves to the bottom row in #164 — was at rack-center in #163. The
-// pedagogy hierarchy is "where on this surface (θ/φ) ← which surface (k)";
-// the where-question lives above the family-selector.
-const THETA_Y = SLIDER_RACK_CENTER.y + SLIDER_ROW_PITCH;
-const PHI_Y = SLIDER_RACK_CENTER.y;
-const K_Y = SLIDER_RACK_CENTER.y - SLIDER_ROW_PITCH;
+// Three-row slider stack: top to bottom, θ (polar point selector),
+// φ (azimuthal point selector), k (level value). k moves to the bottom
+// row in #164 — was at rack-center in #163. The pedagogy hierarchy is
+// "where on this surface (θ/φ) ← which surface (k)"; the where-question
+// lives above the family-selector. Slot-Y derivations below; positions
+// applied via the plinth slot manifest at the end of mount().
+const PLINTH_THETA_Y = PLINTH_SLIDER_MID_Y + SLIDER_ROW_PITCH;
+const PLINTH_PHI_Y = PLINTH_SLIDER_MID_Y;
+const PLINTH_K_Y = PLINTH_SLIDER_MID_Y - SLIDER_ROW_PITCH;
 
 // k ∈ [-2, 2]. Wide enough to show distinct 2-sheet and 1-sheet poses
 // while keeping the slider thumb's spatial sweep mapped to a meaningful
@@ -263,6 +278,7 @@ let stageFloor: StageFloorHandles | undefined;
 let contrastPit: ContrastPitHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
 let stageInnerRailing: StageInnerRailingHandles | undefined;
+let plinth: PlinthHandles | undefined;
 let pointers: readonly Pointer[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
 // yaw-billboarding in update().
@@ -346,11 +362,10 @@ const gradientLevelsExhibit: Exhibit = {
     surfaceMaterial = surfaceHandles.material;
     group.add(surfaceHandles.mesh);
 
-    // Three-row slider stack: θ on top, φ middle, k on bottom. The
-    // stack is centered at SLIDER_RACK_CENTER.y; row pitch matches
-    // cluster siblings (#147 § tangent-planes). All three share
-    // SLIDER_BASE_COLOR (neutral gray) — none carry axis meaning.
-
+    // Three-row slider stack: θ on top, φ middle, k on bottom. All
+    // three share SLIDER_BASE_COLOR (neutral gray) — none carry axis
+    // meaning. Slot positions applied via the slot manifest at the
+    // end of this function.
     thetaSlider = new Slider({
       label: 'θ',
       min: 0,
@@ -358,16 +373,10 @@ const gradientLevelsExhibit: Exhibit = {
       initial: THETA_INITIAL,
       snapDetent: SLIDER_SNAP_DETENT,
       snapPoints: THETA_SNAP_POINTS,
-      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER,
+      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER_PLINTH,
       baseColor: SLIDER_BASE_COLOR,
       thumbShape: 'sphere',
     });
-    thetaSlider.group.position.set(
-      SLIDER_RACK_CENTER.x,
-      THETA_Y,
-      SLIDER_RACK_CENTER.z,
-    );
-    group.add(thetaSlider.group);
 
     phiSlider = new Slider({
       label: 'φ',
@@ -376,16 +385,10 @@ const gradientLevelsExhibit: Exhibit = {
       initial: PHI_INITIAL,
       snapDetent: SLIDER_SNAP_DETENT,
       snapPoints: PHI_SNAP_POINTS,
-      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER,
+      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER_PLINTH,
       baseColor: SLIDER_BASE_COLOR,
       thumbShape: 'sphere',
     });
-    phiSlider.group.position.set(
-      SLIDER_RACK_CENTER.x,
-      PHI_Y,
-      SLIDER_RACK_CENTER.z,
-    );
-    group.add(phiSlider.group);
 
     // k slider — `initial` matches the extraUniforms.uK seed above so
     // the boot pose is consistent across material and slider on first
@@ -397,60 +400,44 @@ const gradientLevelsExhibit: Exhibit = {
       initial: K_INITIAL,
       snapDetent: SLIDER_SNAP_DETENT,
       snapPoints: K_SNAP_POINTS,
-      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER,
+      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER_PLINTH,
       baseColor: SLIDER_BASE_COLOR,
       thumbShape: 'sphere',
     });
-    kSlider.group.position.set(
-      SLIDER_RACK_CENTER.x,
-      K_Y,
-      SLIDER_RACK_CENTER.z,
-    );
-    group.add(kSlider.group);
 
-    // Point indicator. Positioned in update() each frame; visible
-    // only on raycast hit (Option A from plan §2.2 — miss → hide).
+    // Point indicator — math-object affordance at world frame.
+    // Positioned in update() each frame; visible only on raycast hit
+    // (Option A from #164 plan §2.2 — miss → hide).
     indicator = new THREE.Mesh(
       new THREE.SphereGeometry(INDICATOR_RADIUS, 16, 12),
       new THREE.MeshStandardMaterial({ color: INDICATOR_COLOR }),
     );
     group.add(indicator);
 
-    // Gradient-vector arrow at the selected point (#165). Constructed
+    // Gradient-vector arrow at the selected point (#165). Math-object
+    // affordance, stays world-anchored at SURFACE_CENTER. Constructed
     // with `group.visible = false` so the renderer can't paint a stale
-    // pose between mount and the first update tick — the first hit
-    // frame in update calls setPose then setVisible(true) to uncloak.
-    // Renders as overlay (depthTest: false, renderOrder: 2) so the
-    // §11.6 punch line stays visible regardless of camera angle, even
-    // for k<0 inward orientations where the surface body would
-    // otherwise occlude the arrow.
+    // pose between mount and the first update tick. Renders as overlay
+    // (depthTest: false, renderOrder: 2) so the §11.6 punch line stays
+    // visible regardless of camera angle.
     gradientArrow = createGradientArrow({ surfaceCenter: SURFACE_CENTER });
     group.add(gradientArrow.group);
 
-    // Live readout of ∇f components + |∇f| (#166). Anchored above the
-    // slider rack on the same z-plane. Top-line components carry the
-    // cluster's axis-color convention (vermillion/bluish-green/sky-blue
-    // for math-X/Y/Z); the |∇f| numeric is YELLOW to pair with the
-    // gradient arrow — direction (arrow) + magnitude (number) are
-    // facets of the same gradient vector. The arrow's rendered length
-    // is fixed per #165; the YELLOW pairing communicates "same vector,"
-    // not "this number is that arrow's length." See SPEC.md Readout
-    // section for the full color-identity-decoupling note.
+    // Live readout of ∇f components + |∇f| (#166). Slotted on the
+    // plinth at slot-Y = PLINTH_READOUT_Y. Top-line components carry
+    // the cluster's axis-color convention; the |∇f| numeric is YELLOW
+    // to pair with the gradient arrow. Billboard carve-out: faceCamera
+    // overwrites group.rotation every frame, so the slot's default
+    // 'surface' orientation is documentation-only.
     gradientLevelsReadout = new GradientLevelsReadout({
       axisColors: [VERMILLION, BLUISH_GREEN, SKY_BLUE],
       magnitudeColor: YELLOW,
     });
-    gradientLevelsReadout.group.position.copy(READOUT_POSITION);
-    group.add(gradientLevelsReadout.group);
 
-    // Per-slider variable + value labels (#170). All three sliders carry
-    // the same two-line right-aligned shape: primary = variable name (set
-    // once at mount), secondary = live value (per-frame in update()). The
-    // k label was originally one-line "k = 0.50" below the slider (#167);
-    // unified here into the cluster-uniform shape so all three sliders
-    // read visually identically. Right-align (anchorX: 'right') keeps
-    // worst-case secondary text — "−2.00" at k_min, "−0.80π" at φ
-    // extremes — clear of the slider thumb at any value.
+    // Per-slider labels (#170). Right-anchored so worst-case secondary
+    // text ("−2.00" at k_min, "−0.80π" at φ extremes) stays clear of
+    // the slider thumb at any value. Slot positions applied via the
+    // manifest below.
     thetaLabel = new Label({
       primaryFontSize: SLIDER_LABEL_PRIMARY_FONT_SIZE,
       secondaryFontSize: SLIDER_LABEL_SECONDARY_FONT_SIZE,
@@ -458,12 +445,6 @@ const gradientLevelsExhibit: Exhibit = {
       anchorX: 'right',
     });
     thetaLabel.setPrimary('θ');
-    thetaLabel.group.position.set(
-      SLIDER_RACK_CENTER.x + SLIDER_LABEL_X_OFFSET,
-      THETA_Y,
-      SLIDER_RACK_CENTER.z,
-    );
-    group.add(thetaLabel.group);
 
     phiLabel = new Label({
       primaryFontSize: SLIDER_LABEL_PRIMARY_FONT_SIZE,
@@ -472,12 +453,6 @@ const gradientLevelsExhibit: Exhibit = {
       anchorX: 'right',
     });
     phiLabel.setPrimary('φ');
-    phiLabel.group.position.set(
-      SLIDER_RACK_CENTER.x + SLIDER_LABEL_X_OFFSET,
-      PHI_Y,
-      SLIDER_RACK_CENTER.z,
-    );
-    group.add(phiLabel.group);
 
     kLabel = new Label({
       primaryFontSize: SLIDER_LABEL_PRIMARY_FONT_SIZE,
@@ -486,17 +461,34 @@ const gradientLevelsExhibit: Exhibit = {
       anchorX: 'right',
     });
     kLabel.setPrimary('k');
-    kLabel.group.position.set(
-      SLIDER_RACK_CENTER.x + SLIDER_LABEL_X_OFFSET,
-      K_Y,
-      SLIDER_RACK_CENTER.z,
-    );
-    group.add(kLabel.group);
 
-    // Math-frame axis indicator — same anchor as cluster siblings.
+    // Math-frame axis indicator. orientation: 'world' so the X/Y/Z
+    // arrows read in the math frame, not the tabletop frame.
     worldAxes = new WorldAxes({ axisColors: AXIS_COLORS });
-    worldAxes.group.position.copy(AXIS_INDICATOR_POSITION);
-    group.add(worldAxes.group);
+
+    // Slot manifest (#225 / E1.4 PR2). 8 slots: 3 sliders + 3 labels
+    // + 1 readout + 1 world-axes. createPlinth reparents each target
+    // under plinth.group at construction.
+    const slots: PlinthSlot[] = [
+      { id: 'slider-theta', target: thetaSlider.group, localXYZ: [0, PLINTH_THETA_Y, 0] },
+      { id: 'slider-phi', target: phiSlider.group, localXYZ: [0, PLINTH_PHI_Y, 0] },
+      { id: 'slider-k', target: kSlider.group, localXYZ: [0, PLINTH_K_Y, 0] },
+      { id: 'label-theta', target: thetaLabel.group, localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_THETA_Y, 0] },
+      { id: 'label-phi', target: phiLabel.group, localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_PHI_Y, 0] },
+      { id: 'label-k', target: kLabel.group, localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_K_Y, 0] },
+      { id: 'readout', target: gradientLevelsReadout.group, localXYZ: [0, PLINTH_READOUT_Y, 0] },
+      {
+        id: 'world-axes',
+        target: worldAxes.group,
+        localXYZ: [PLINTH_AXIS_INDICATOR_X, PLINTH_AXIS_INDICATOR_Y, 0],
+        orientation: 'world',
+      },
+    ];
+    plinth = createPlinth({
+      anchorWorldXYZ: PLINTH_ANCHOR_WORLD_XYZ,
+      slots,
+    });
+    group.add(plinth.group);
   },
 
   update() {
@@ -669,6 +661,10 @@ const gradientLevelsExhibit: Exhibit = {
     if (stageInnerRailing) {
       stageInnerRailing.dispose();
       stageInnerRailing = undefined;
+    }
+    if (plinth) {
+      plinth.dispose();
+      plinth = undefined;
     }
 
     // 3. Drop external references so a re-mount starts clean. The shell

--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -487,8 +487,10 @@ slider thumb stays disjoint at the new 1.5× multiplier (the
 `CROSS_SECTION_TOGGLE_OFFSET_X = -0.22` separation is generous
 relative to the tighter hit radius).
 
-PR1 ships quadrics only; the other three cluster scenes still use
-the mid-air `GRAB_RADIUS_MULTIPLIER = 2.75` and free-floating UI
-positions until PR2 (#251) closes the cluster sweep. The mixed
-state is intentional per `_private/plans/225-control-plinth.md` §3.4
-— not a regression to flag.
+PR2 (#251) closed the cluster sweep — all four cluster scenes
+(quadrics, tangent-planes, gradient-levels, saddle-extrema) now use
+`GRAB_RADIUS_MULTIPLIER_PLINTH = 1.5` and slot their interactive UI
+under their own plinth. The pre-plinth `GRAB_RADIUS_MULTIPLIER = 2.75`
+export was deleted from `scaffold/ui/clusterRackTokens.ts` at the
+same PR; the static-grep regression test in `test/exhibits/`
+enforces zero references in `.ts` files repo-wide.

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -319,16 +319,12 @@ function easeInOutCubic(t: number): number {
 }
 
 // Ray–thumb / ray–button hit-test sphere is this multiple of each
-// primitive's visual radius. The cluster's `GRAB_RADIUS_MULTIPLIER`
-// (2.75) was tuned for mid-air sphere-aim ergonomics; quadrics is the
-// first scene to use `GRAB_RADIUS_MULTIPLIER_PLINTH` (1.5, #225 / E1.4
-// PR1) because plinth-mounted UI changes the kinematics from aim-AT
-// to hand-TO-surface, where a tighter radius reads as precise rather
-// than fiddly. The other three cluster scenes ship on the plinth in
-// PR2 (#251); until then they continue to import the 2.75 value, and
-// quadrics' intentionally mixed-state smoke is documented in
-// `_private/plans/225-control-plinth.md` §3.4 as expected, not a
-// regression.
+// primitive's visual radius. `GRAB_RADIUS_MULTIPLIER_PLINTH` (1.5)
+// from `scaffold/ui/clusterRackTokens.ts` is the cluster-uniform
+// plinth-mounted value — tighter than the pre-plinth mid-air 2.75
+// because plinth-mounted UI changes the kinematics from controller-
+// aim-AT to hand-TO-surface, where a tighter radius reads as precise
+// rather than fiddly.
 
 // Vertical stacking pitch for the rack (slot-local +Y on the plinth
 // working surface). Lower bound set by the slider's grab region: at

--- a/src/exhibits/saddle-extrema/SPEC.md
+++ b/src/exhibits/saddle-extrema/SPEC.md
@@ -761,3 +761,62 @@ preset's `x² − y²` surface — which reaches the full
 ±STAGE_CUTOUT_HALF domain — has a small annular breathing margin
 between math and railing. Other presets at narrower domains get
 the same margin scaled appropriately.
+
+### Staging — Control plinth (#225 / E1.4)
+
+Interactive UI (x / y sliders + per-slider labels + 5-preset row +
+classification readout + math-frame axis indicator) lifts onto the
+cluster-shared `createPlinth` primitive from
+`src/scaffold/staging/Plinth.ts`, matching quadrics' PR1 ship and
+the master plan (`_private/plans/225-control-plinth.md` §4.2 PR2 /
+`251-cluster-on-plinth.md` §3.3). Drafting-table-console silhouette
+anchored at world `(0, 0, 0.05)` — cluster-uniform anchor.
+Working-surface depth = `Plinth.ts` default 0.5 m: the 2-slider rack
+fits comfortably in slot-Y ∈ [0.205, 0.345]; the 5-preset row and
+3-line readout deliberately float above the back edge at slot-Y >
+0.5, mirroring quadrics' preset-grid + classifier pattern.
+
+Every UI primitive's `group` is reparented under `plinth.group` via
+the slot manifest in `mount()`; positions are slot-local (11 slots
+total: 2 sliders + 2 labels + 5 presets + 1 readout + 1 world-axes).
+Slot manifest:
+
+- **x slider** (top row) at slot-local `(0, 0.345, 0)`.
+- **y slider** (bottom row) at slot-local `(0, 0.205, 0)` —
+  inter-slider distance 0.14 m, matching the pre-plinth
+  `X_SLIDER_Y - Y_SLIDER_Y = 0.14 m` straddle.
+- **Per-slider labels** at slot-local
+  `(SLIDER_LABEL_X_OFFSET, sliderY, 0)` for each row.
+- **Preset row** of 5 buttons at slot-local
+  `(PLINTH_PRESET_ROW_START_X + i * PLINTH_PRESET_COL_PITCH, 0.55, 0)`
+  for `i ∈ [0, 4]` — columns at slot-X ∈ {-0.26, -0.13, 0, 0.13,
+  0.26} with cluster pitch 0.13. Just above the back edge at
+  slot-Y = 0.5, mirroring quadrics' 2 × 4 preset-grid pattern
+  simplified to one row.
+- **SaddleExtremaReadout** at slot-local `(0, 0.70, 0)` — above the
+  preset row; mirrors quadrics' `PLINTH_RACK_LABEL_Y = 0.74`
+  row-above-content pattern.
+- **WorldAxes** at slot-local `(0.42, 0.275, 0)`, `orientation:
+  'world'` — keeps the math-frame X/Y/Z arrows aligned to the math
+  frame regardless of plinth tilt.
+
+**Math-object affordances stay in world frame.** `graphSurface.mesh`,
+`criticalPointMarkers`, `taylorOverlay.mesh`, and `indicator` are
+children of `ctx.group`, never reparented under `plinth.group`. The
+`applyPreset()` rebuild (which swaps `graphSurface` /
+`criticalPointMarkers` / `taylorOverlay` on preset change) operates
+on `exhibitGroup`, not on the plinth — the sliders themselves stay
+reference-stable under `plinth.group` across preset swaps, with
+`setRange` / `setSnapPoints` adjusting their internal state in
+place.
+
+**Readout billboard carve-out.** `SaddleExtremaReadout` overwrites
+`group.rotation` every frame via `faceCamera`, so the slot's default
+`'surface'` orientation is documentation-only — the readout yaw-
+billboards regardless.
+
+**Grab radius.** All interactive primitives (two sliders + five
+presets) use `GRAB_RADIUS_MULTIPLIER_PLINTH = 1.5` from
+`scaffold/ui/clusterRackTokens.ts`. The pre-plinth mid-air `2.75`
+constant was deleted at PR2 (#251) once all four cluster scenes
+ported onto the plinth.

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -13,14 +13,12 @@ import { Label } from '@/scaffold/ui/Label';
 import { Slider } from '@/scaffold/ui/Slider';
 import { Preset } from '@/scaffold/ui/Preset';
 import {
-  GRAB_RADIUS_MULTIPLIER,
+  GRAB_RADIUS_MULTIPLIER_PLINTH,
   SLIDER_LABEL_LINE_GAP,
   SLIDER_LABEL_PRIMARY_FONT_SIZE,
   SLIDER_LABEL_SECONDARY_FONT_SIZE,
   SLIDER_LABEL_X_OFFSET,
-  SLIDER_ROW_PITCH,
   SLIDER_SNAP_DETENT,
-  createSliderRackCenter,
 } from '@/scaffold/ui/clusterRackTokens';
 import { WorldAxes } from '@/scaffold/ui/WorldAxes';
 import {
@@ -39,6 +37,11 @@ import {
   createStageInnerRailing,
   type StageInnerRailingHandles,
 } from '@/scaffold/staging/StageInnerRailing';
+import {
+  createPlinth,
+  type PlinthHandles,
+  type PlinthSlot,
+} from '@/scaffold/staging/Plinth';
 import {
   createCriticalPointMarkers,
   type CriticalPointMarkersHandles,
@@ -79,9 +82,38 @@ import {
 // ────────────────────────────────────────────────────────────────────
 
 const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
-const AXIS_INDICATOR_POSITION = new THREE.Vector3(0.35, 1.17, -0.7);
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
 const BASE_COLOR = new THREE.Color(0.4, 0.7, 0.95);
+
+// Plinth (#225 / E1.4 PR2). Cluster-uniform anchor matches quadrics'
+// PR1 ship — railing/floor geometry is shared. Working-surface depth
+// default 0.5 m fits the 2-row slider rack with breathing room; the
+// 5-preset row and 3-line readout deliberately float above the back
+// edge (slot-Y > 0.5), mirroring quadrics' preset-grid + classifier
+// pattern.
+const PLINTH_ANCHOR_WORLD_XYZ = [0, 0, 0.05] as const;
+
+// Slot-local layout. Two-row slider rack centered on slot-Y = 0.275:
+// x at 0.345, y at 0.205 — inter-slider distance 0.14 m, matching the
+// pre-plinth `X_SLIDER_Y - Y_SLIDER_Y = 0.14 m` straddle (see
+// `_private/plans/251-cluster-on-plinth.md` §3.3). Per-slider labels
+// at slot-X = SLIDER_LABEL_X_OFFSET = -0.2. Preset row of 5 buttons
+// centered on slot-X = 0 at slot-Y = 0.55 (just above the back edge):
+// columns at slot-X ∈ {-0.26, -0.13, 0, 0.13, 0.26} with cluster
+// pitch 0.13 (mirrors quadrics' 2 × 4 grid pattern, simplified to
+// one row). Readout above the presets at slot-Y = 0.70 — mirrors
+// quadrics' PLINTH_RACK_LABEL_Y = 0.74 row-above-content pattern.
+// Math-frame axis indicator at the right edge with orientation:
+// 'world'.
+const PLINTH_X_SLIDER_Y = 0.345;
+const PLINTH_Y_SLIDER_Y = 0.205;
+const PLINTH_PRESET_ROW_Y = 0.55;
+const PLINTH_PRESET_COL_PITCH = 0.13;
+// 5 columns centered on slot-X = 0 ⇒ leftmost col at -2 × pitch.
+const PLINTH_PRESET_ROW_START_X = -2 * PLINTH_PRESET_COL_PITCH;
+const PLINTH_READOUT_Y = 0.70;
+const PLINTH_AXIS_INDICATOR_X = 0.42;
+const PLINTH_AXIS_INDICATOR_Y = 0.275;
 
 // Stage floor cutout half-extent (#238 / E1.1) — derived from the
 // widest preset domain so a future preset with a wider (x, y) window
@@ -98,33 +130,17 @@ const STAGE_CUTOUT_HALF = Math.max(
   ),
 );
 
-// Classification readout (#181) — three lines (Hessian entries / D /
-// verdict). Anchored above the preset row (preset-row buttons cap at
-// y ≈ 1.32 including button radius) with ~0.12 m vertical clearance.
-// Shares the foreground-UI z-plane with the slider rack and preset
-// row so the user's gaze stays in one depth band.
-const READOUT_POSITION = new THREE.Vector3(0, 1.5, -0.7);
-
-// Slider rack — two-row symmetric straddle around SLIDER_RACK_CENTER. The
-// 3-row top-heavy pattern from gradient-levels (θ/φ/k at [center+pitch,
-// center, center-pitch]) doesn't carry over cleanly to a 2-row rack; the
-// straddle layout reads as balanced. SLIDER_RACK_CENTER / SLIDER_ROW_PITCH
-// imported from scaffold/ui/clusterRackTokens (#201 PR 4) — per-file
-// fresh THREE.Vector3 from the factory so mutation can't leak across
-// scenes.
-const SLIDER_RACK_CENTER = createSliderRackCenter();
-const X_SLIDER_Y = SLIDER_RACK_CENTER.y + SLIDER_ROW_PITCH / 2;
-const Y_SLIDER_Y = SLIDER_RACK_CENTER.y - SLIDER_ROW_PITCH / 2;
-
-// Slider design feel — quadric-tuned constants, ported from cluster
-// siblings. Snap detents combine the slider-canonical origin (always
-// seeded) with the active preset's critical-point coordinates,
-// projected per axis (#200). For every v0.8 preset the CPs sit at the
-// origin, so the projected snap set collapses to `[0]` and visible
-// behavior is unchanged from v0.7; future off-origin presets (or
-// user-supplied f(x, y) in v1.x) get correct CP-aware snaps for free.
-// SLIDER_SNAP_DETENT / GRAB_RADIUS_MULTIPLIER imported from
-// scaffold/ui/clusterRackTokens (#201 PR 4).
+// Slider rack — two-row symmetric straddle. Slot-Y values applied via
+// the slot manifest in mount(); per-slider plinth-Y derivations above
+// (`PLINTH_X_SLIDER_Y` / `PLINTH_Y_SLIDER_Y`).
+//
+// SLIDER_SNAP_DETENT / GRAB_RADIUS_MULTIPLIER_PLINTH / SLIDER_ROW_PITCH
+// imported from scaffold/ui/clusterRackTokens. Snap detents combine
+// the slider-canonical origin with the active preset's critical-point
+// coordinates, projected per axis (#200). For every v0.8 preset the
+// CPs sit at the origin, so the projected snap set collapses to `[0]`
+// and visible behavior is unchanged from v0.7; future off-origin
+// presets get correct CP-aware snaps for free.
 
 // Initial pose — off origin-snap, off endpoints, off both axes,
 // non-equal — so first-frame drag responds in any direction.
@@ -143,16 +159,14 @@ const INDICATOR_COLOR = 0xdddddd;
 // Cluster glyph convention for negative-magnitude formatting.
 const SLIDER_VALUE_MINUS = '−'; // U+2212
 
-// Preset row (#178). Five buttons in a single horizontal row above the
-// slider rack, centered on x = 0. Always-visible — five archetypes is
-// small enough to live on screen at all times (the quadrics manipulator's
-// 8-preset rack needed an expand/collapse chevron; here that machinery
-// would be friction without payoff). The y level clears the top slider's
-// grab sphere (≈ 0.07 m radius) with ~0.16 m of clear air.
-const PRESET_ROW_Y = 1.30;
-const PRESET_HORIZONTAL_PITCH = 0.13;
-// 5 columns centered on x = 0 ⇒ leftmost col at -2 × pitch.
-const PRESET_ROW_START_X = -2 * PRESET_HORIZONTAL_PITCH;
+// Preset row (#178). Five buttons in a single horizontal row above
+// the slider rack, centered on slot-X = 0. Always-visible — five
+// archetypes is small enough to live on screen at all times (the
+// quadrics manipulator's 8-preset rack needed an expand/collapse
+// chevron; here that machinery would be friction without payoff).
+// Slot positions applied via the slot manifest in mount(); column
+// pitch and start derivations above (`PLINTH_PRESET_COL_PITCH`,
+// `PLINTH_PRESET_ROW_START_X`, `PLINTH_PRESET_ROW_Y`).
 const PRESET_RES = 128;
 
 // Mirror the manipulator's `Preset` visual identity (cool blue base,
@@ -196,6 +210,7 @@ let stageFloor: StageFloorHandles | undefined;
 let contrastPit: ContrastPitHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
 let stageInnerRailing: StageInnerRailingHandles | undefined;
+let plinth: PlinthHandles | undefined;
 let activePresetIndex = DEFAULT_PRESET_INDEX;
 let saddleExtremaReadout: SaddleExtremaReadout | undefined;
 let camera: THREE.Camera | undefined;
@@ -322,7 +337,8 @@ const saddleExtremaExhibit: Exhibit = {
     // x slider — vermillion (math-X axis tint). Honest pickup since
     // x IS the math-X axis value, not a derived parameter. Mirrors
     // the quadrics manipulator's (a, b, c) coefficient-slider color
-    // convention.
+    // convention. Slot positions applied via the slot manifest at the
+    // end of this function.
     xSlider = new Slider({
       label: 'x',
       min: initialPreset.domain.xMin,
@@ -330,16 +346,10 @@ const saddleExtremaExhibit: Exhibit = {
       initial: X_INITIAL,
       snapDetent: SLIDER_SNAP_DETENT,
       snapPoints: buildAxisSnapPoints(initialPreset.criticalPoints, 0),
-      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER,
+      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER_PLINTH,
       baseColor: VERMILLION,
       thumbShape: 'sphere',
     });
-    xSlider.group.position.set(
-      SLIDER_RACK_CENTER.x,
-      X_SLIDER_Y,
-      SLIDER_RACK_CENTER.z,
-    );
-    group.add(xSlider.group);
 
     // y slider — bluish-green (math-Y axis tint).
     ySlider = new Slider({
@@ -349,16 +359,10 @@ const saddleExtremaExhibit: Exhibit = {
       initial: Y_INITIAL,
       snapDetent: SLIDER_SNAP_DETENT,
       snapPoints: buildAxisSnapPoints(initialPreset.criticalPoints, 1),
-      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER,
+      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER_PLINTH,
       baseColor: BLUISH_GREEN,
       thumbShape: 'sphere',
     });
-    ySlider.group.position.set(
-      SLIDER_RACK_CENTER.x,
-      Y_SLIDER_Y,
-      SLIDER_RACK_CENTER.z,
-    );
-    group.add(ySlider.group);
 
     // Per-slider labels — primary = variable name (set once at mount),
     // secondary = live value (per-frame in update()).
@@ -369,12 +373,6 @@ const saddleExtremaExhibit: Exhibit = {
       anchorX: 'right',
     });
     xLabel.setPrimary('x');
-    xLabel.group.position.set(
-      SLIDER_RACK_CENTER.x + SLIDER_LABEL_X_OFFSET,
-      X_SLIDER_Y,
-      SLIDER_RACK_CENTER.z,
-    );
-    group.add(xLabel.group);
 
     yLabel = new Label({
       primaryFontSize: SLIDER_LABEL_PRIMARY_FONT_SIZE,
@@ -383,16 +381,12 @@ const saddleExtremaExhibit: Exhibit = {
       anchorX: 'right',
     });
     yLabel.setPrimary('y');
-    yLabel.group.position.set(
-      SLIDER_RACK_CENTER.x + SLIDER_LABEL_X_OFFSET,
-      Y_SLIDER_Y,
-      SLIDER_RACK_CENTER.z,
-    );
-    group.add(yLabel.group);
 
-    // Indicator — sphere at the selected point. Position seeded at the
-    // boot pose so the first paint shows the correct location even
-    // before update() runs.
+    // Indicator — sphere at the selected point. Math-object affordance:
+    // stays world-anchored at SURFACE_CENTER (via writeGraphPointToWorld),
+    // NOT slotted on the plinth. Position seeded at the boot pose so
+    // the first paint shows the correct location even before update()
+    // runs.
     indicator = new THREE.Mesh(
       new THREE.SphereGeometry(INDICATOR_RADIUS, 16, 12),
       new THREE.MeshStandardMaterial({ color: INDICATOR_COLOR }),
@@ -407,44 +401,74 @@ const saddleExtremaExhibit: Exhibit = {
     indicator.position.copy(indicatorWorld);
     group.add(indicator);
 
+    // Math-frame axis indicator. orientation: 'world' so the X/Y/Z
+    // arrows read in the math frame, not the tabletop frame.
     worldAxes = new WorldAxes({ axisColors: DEFAULT_AXIS_COLORS });
-    worldAxes.group.position.copy(AXIS_INDICATOR_POSITION);
-    group.add(worldAxes.group);
 
     // Classification readout (#181). f_xx and f_yy tinted with the
-    // cluster's math-X / math-Y axis colors (vermillion / bluish-green)
-    // to reinforce "f_xx is the pure-x² term, f_yy is the pure-y²
-    // term"; the cross-term f_xy stays white to read as "neither pure
-    // axis." D and verdict use YELLOW — the same accent gradient-levels
-    // (#166) uses for the |∇f| numeric. Boots hidden; the first
-    // update() tick populates the slots and uncloaks.
+    // cluster's math-X / math-Y axis colors (vermillion / bluish-green);
+    // cross-term f_xy stays white. D and verdict use YELLOW — the same
+    // accent gradient-levels (#166) uses for the |∇f| numeric. Boots
+    // hidden; the first update() tick populates the slots and uncloaks.
+    // Billboard carve-out: faceCamera overwrites group.rotation every
+    // frame, so the slot's default 'surface' orientation is
+    // documentation-only.
     saddleExtremaReadout = new SaddleExtremaReadout({
       fxxColor: VERMILLION,
       fxyColor: 0xffffff,
       fyyColor: BLUISH_GREEN,
       accentColor: YELLOW,
     });
-    saddleExtremaReadout.group.position.copy(READOUT_POSITION);
-    group.add(saddleExtremaReadout.group);
 
     // Preset row (#178) — five archetypes left → right, mirroring the
-    // PRESETS array order. The starter (saddle, DEFAULT_PRESET_INDEX) is
-    // marked sticky-active so the user reads which archetype is current.
-    presetButtons = PRESETS.map((preset, i) => {
-      const btn = new Preset({
+    // PRESETS array order. The starter (saddle, DEFAULT_PRESET_INDEX)
+    // is marked sticky-active so the user reads which archetype is
+    // current. Slot positions applied via the manifest below.
+    presetButtons = PRESETS.map((preset) => {
+      return new Preset({
         name: preset.label,
-        grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER,
+        grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER_PLINTH,
         activeEmissive: PRESET_ACTIVE_EMISSIVE,
       });
-      btn.group.position.set(
-        PRESET_ROW_START_X + i * PRESET_HORIZONTAL_PITCH,
-        PRESET_ROW_Y,
-        SLIDER_RACK_CENTER.z,
-      );
-      group.add(btn.group);
-      return btn;
     });
     presetButtons[activePresetIndex]?.setActive(true);
+
+    // Slot manifest (#225 / E1.4 PR2). 11 slots: 2 sliders + 2 labels
+    // + 5 presets + 1 readout + 1 world-axes. createPlinth reparents
+    // each target under plinth.group at construction.
+    const slots: PlinthSlot[] = [
+      { id: 'slider-x', target: xSlider.group, localXYZ: [0, PLINTH_X_SLIDER_Y, 0] },
+      { id: 'slider-y', target: ySlider.group, localXYZ: [0, PLINTH_Y_SLIDER_Y, 0] },
+      { id: 'label-x', target: xLabel.group, localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_X_SLIDER_Y, 0] },
+      { id: 'label-y', target: yLabel.group, localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_Y_SLIDER_Y, 0] },
+    ];
+    presetButtons.forEach((btn, i) => {
+      slots.push({
+        id: `preset-${i}`,
+        target: btn.group,
+        localXYZ: [
+          PLINTH_PRESET_ROW_START_X + i * PLINTH_PRESET_COL_PITCH,
+          PLINTH_PRESET_ROW_Y,
+          0,
+        ],
+      });
+    });
+    slots.push({
+      id: 'readout',
+      target: saddleExtremaReadout.group,
+      localXYZ: [0, PLINTH_READOUT_Y, 0],
+    });
+    slots.push({
+      id: 'world-axes',
+      target: worldAxes.group,
+      localXYZ: [PLINTH_AXIS_INDICATOR_X, PLINTH_AXIS_INDICATOR_Y, 0],
+      orientation: 'world',
+    });
+    plinth = createPlinth({
+      anchorWorldXYZ: PLINTH_ANCHOR_WORLD_XYZ,
+      slots,
+    });
+    group.add(plinth.group);
   },
 
   update() {
@@ -568,6 +592,10 @@ const saddleExtremaExhibit: Exhibit = {
     if (stageInnerRailing) {
       stageInnerRailing.dispose();
       stageInnerRailing = undefined;
+    }
+    if (plinth) {
+      plinth.dispose();
+      plinth = undefined;
     }
 
     // 3. Drop external references so a re-mount starts clean.

--- a/src/exhibits/tangent-planes/SPEC.md
+++ b/src/exhibits/tangent-planes/SPEC.md
@@ -318,3 +318,56 @@ path. 8 evenly-spaced posts around the cutout circumference (radius
 `BOUND = 1.5`) + 1 `TorusGeometry` top-rail. Same height + color as
 the outer railing. The torus provides a clean curved top rail without
 piecewise approximation.
+
+### Staging — Control plinth (#225 / E1.4)
+
+Interactive UI (θ / φ sliders + per-slider labels + tangent-plane
+readout + math-frame axis indicator) lifts onto the cluster-shared
+`createPlinth` primitive from `src/scaffold/staging/Plinth.ts`,
+matching quadrics' PR1 ship and the master plan
+(`_private/plans/225-control-plinth.md` §4.2 PR2 / `251-cluster-on-
+plinth.md` §3.1). Drafting-table-console silhouette anchored at world
+`(0, 0, 0.05)` — cluster-uniform anchor; the railing/floor clearance
+checked for quadrics' v2 smoke applies here too (shared backExtension
++ inner-railing geometry). Working-surface depth = `Plinth.ts`
+default 0.5 m: the 2-slider rack at `SLIDER_ROW_PITCH = 0.14 m` fits
+comfortably in slot-Y ∈ [0.205, 0.345], well inside [0, 0.5].
+
+Every UI primitive's `group` is reparented under `plinth.group` via
+the slot manifest in `mount()`; positions are slot-local (origin at
+the working-surface front-edge center, +X right, +Y up the tilted
+face toward the back, +Z out from the surface normal). Slot manifest:
+
+- **θ slider** at slot-local `(0, 0.345, 0)`.
+- **φ slider** at slot-local `(0, 0.205, 0)` — inter-slider distance
+  0.14 m, matching the pre-plinth `thetaY - phiY = 0.14 m` straddle.
+- **θ label** at slot-local `(SLIDER_LABEL_X_OFFSET, 0.345, 0)`.
+- **φ label** at slot-local `(SLIDER_LABEL_X_OFFSET, 0.205, 0)`.
+- **Tangent-plane readout** at slot-local `(0, 0.57, 0)` — floats
+  above the working-surface back edge at slot-Y = 0.5, mirroring
+  quadrics' "readout above back edge" pattern.
+- **WorldAxes** at slot-local `(0.42, 0.275, 0)`, `orientation:
+  'world'` — keeps the math-frame X/Y/Z arrows aligned to the math
+  frame regardless of plinth tilt; WorldAxes' own `faceCamera`
+  rotates only its child letter-`Text` nodes, so the world-aligned
+  slot survives across frames.
+
+**Math-object affordances stay in world frame.** `surfaceMesh`,
+`tangentPlane`, and `indicator` are children of `ctx.group`, never
+reparented under `plinth.group`. The #197 VR controller-aim sphere
+picker is unchanged: it raycasts world rays against the implicit
+surface, decoupled from the plinth scene graph.
+
+**Readout billboard carve-out.** `TangentPlaneReadout` overwrites
+`group.rotation` every frame via `faceCamera`, so the slot's default
+`'surface'` orientation is documentation-only — the readout yaw-
+billboards regardless. The slot position binds the readout to the
+plinth's slot-Y axis above the rack; the yaw-billboarding keeps text
+legible across pancake and headset viewing distances rather than
+foreshortening with the surface tilt.
+
+**Grab radius.** All interactive primitives (both sliders) use
+`GRAB_RADIUS_MULTIPLIER_PLINTH = 1.5` from
+`scaffold/ui/clusterRackTokens.ts`, the cluster-uniform plinth-mounted
+value. The pre-plinth mid-air `2.75` constant was deleted at PR2
+(#251) once all four cluster scenes ported onto the plinth.

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -9,14 +9,13 @@ import { formatAnglePiFraction } from '@/scaffold/ui/formatAnglePiFraction';
 import { Label } from '@/scaffold/ui/Label';
 import { Slider } from '@/scaffold/ui/Slider';
 import {
-  GRAB_RADIUS_MULTIPLIER,
+  GRAB_RADIUS_MULTIPLIER_PLINTH,
   SLIDER_LABEL_LINE_GAP,
   SLIDER_LABEL_PRIMARY_FONT_SIZE,
   SLIDER_LABEL_SECONDARY_FONT_SIZE,
   SLIDER_LABEL_X_OFFSET,
   SLIDER_ROW_PITCH,
   SLIDER_SNAP_DETENT,
-  createSliderRackCenter,
 } from '@/scaffold/ui/clusterRackTokens';
 import { WorldAxes, type AxisName } from '@/scaffold/ui/WorldAxes';
 import {
@@ -44,6 +43,11 @@ import {
   createStageInnerRailing,
   type StageInnerRailingHandles,
 } from '@/scaffold/staging/StageInnerRailing';
+import {
+  createPlinth,
+  type PlinthHandles,
+  type PlinthSlot,
+} from '@/scaffold/staging/Plinth';
 import { createTangentPlane, type TangentPlaneHandles } from './TangentPlane';
 import { TangentPlaneReadout } from './TangentPlaneReadout';
 
@@ -67,24 +71,35 @@ import { TangentPlaneReadout } from './TangentPlaneReadout';
 // Constants
 // ────────────────────────────────────────────────────────────────────
 
-// Match quadrics' SURFACE_CENTER + SLIDER_RACK_CENTER + axis-indicator
-// position so navigating between cluster siblings doesn't visually
-// relocate the surface. The same arm's-length depth (z = -0.7) carries
-// across all rack tiers (slider rack, SectionTab rack, SceneRack).
+// Cluster-shared math-object anchor so SceneRack swaps don't visually
+// relocate the surface across sibling scenes.
 const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
-// Per-file fresh THREE.Vector3 from scaffold/ui/clusterRackTokens
-// (#201 PR 4). Shared canonical value is the immutable
-// SLIDER_RACK_CENTER_COORDS tuple; the factory builds a fresh instance
-// so mutation in one scene can't leak to another.
-const SLIDER_RACK_CENTER = createSliderRackCenter();
-const AXIS_INDICATOR_POSITION = new THREE.Vector3(0.35, 1.17, -0.7);
 
-// Tangent-plane readout (#149) sits above the slider rack, on the same
-// z-plane. y = 1.32 mirrors quadrics' EQUATION_READOUT_POSITION; clears
-// the θ slider's top (y ≈ 1.07) by ~0.25 m — enough vertical breathing
-// room for the two-line stack at fontSize 0.028 (line pitch 0.06, total
-// height ~0.06 m).
-const READOUT_POSITION = new THREE.Vector3(0, 1.32, -0.7);
+// Plinth (#225 / E1.4 PR2). Anchor + working-surface depth match
+// quadrics' PR1 ship — the railing/floor geometry is cluster-uniform
+// (backExtension: 3, inner-railing perimeter at the cutout) so the
+// anchor that cleared quadrics' inner railing tube clears the same
+// geometry here. Working-surface depth default 0.5 m fits the 2-row
+// slider rack at SLIDER_ROW_PITCH = 0.14 m with breathing room above
+// and below.
+const PLINTH_ANCHOR_WORLD_XYZ = [0, 0, 0.05] as const;
+
+// Slot-local layout (slot-local +X right, +Y up the tilted face toward
+// the back, +Z out from the surface normal). Two-row rack centered on
+// slot-Y = 0.275 (mid-surface for the default 0.5 m depth): θ at 0.345,
+// φ at 0.205 — inter-slider distance 0.14 m, matching the pre-plinth
+// `thetaY - phiY = 0.14 m` straddle (see `_private/plans/251-cluster-
+// on-plinth.md` §3.1). Per-slider labels at slot-X = SLIDER_LABEL_X_
+// OFFSET = -0.2. Readout floats above the working-surface back edge at
+// slot-Y = 0.57 (mirrors quadrics' "readout above back edge" pattern,
+// with the smaller 0.07 m offset that fits the default 0.5 m depth).
+// Math-frame axis indicator at the right edge with orientation:
+// 'world' so the X/Y/Z arrows read in the math frame, not the
+// tabletop frame.
+const PLINTH_SLIDER_TOP_Y = 0.345;
+const PLINTH_READOUT_Y = 0.57;
+const PLINTH_AXIS_INDICATOR_X = 0.42;
+const PLINTH_AXIS_INDICATOR_Y = 0.275;
 
 // Tighter than quadrics' BOUND=3.5: the unit sphere fits in [-1, 1]³ with
 // room to spare; no coefficient-driven expansion to budget for.
@@ -232,6 +247,7 @@ let stageFloor: StageFloorHandles | undefined;
 let contrastPit: ContrastPitHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
 let stageInnerRailing: StageInnerRailingHandles | undefined;
+let plinth: PlinthHandles | undefined;
 let pointers: readonly Pointer[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
 // yaw-billboarding in update().
@@ -375,12 +391,10 @@ const tangentPlanesExhibit: Exhibit = {
     surfaceMaterial = surfaceHandles.material;
     group.add(surfaceHandles.mesh);
 
-    // θ slider on top, φ below. Centered horizontally on the rack;
-    // pitch matches quadrics' SLIDER_ROW_PITCH so the rack reads as a
-    // sibling.
-    const thetaY = SLIDER_RACK_CENTER.y + 0.5 * SLIDER_ROW_PITCH;
-    const phiY = SLIDER_RACK_CENTER.y - 0.5 * SLIDER_ROW_PITCH;
-
+    // θ slider on top, φ below. Slot-Y positions set via the slot
+    // manifest at the end of this function — createPlinth reparents
+    // each slider's group under plinth.group, so we construct without
+    // positions and without adding to ctx.group here.
     thetaSlider = new Slider({
       label: 'θ',
       min: 0,
@@ -388,16 +402,10 @@ const tangentPlanesExhibit: Exhibit = {
       initial: THETA_INITIAL,
       snapDetent: SLIDER_SNAP_DETENT,
       snapPoints: THETA_SNAP_POINTS,
-      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER,
+      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER_PLINTH,
       baseColor: SLIDER_BASE_COLOR,
       thumbShape: 'sphere',
     });
-    thetaSlider.group.position.set(
-      SLIDER_RACK_CENTER.x,
-      thetaY,
-      SLIDER_RACK_CENTER.z,
-    );
-    group.add(thetaSlider.group);
 
     phiSlider = new Slider({
       label: 'φ',
@@ -406,23 +414,14 @@ const tangentPlanesExhibit: Exhibit = {
       initial: PHI_INITIAL,
       snapDetent: SLIDER_SNAP_DETENT,
       snapPoints: PHI_SNAP_POINTS,
-      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER,
+      grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER_PLINTH,
       baseColor: SLIDER_BASE_COLOR,
       thumbShape: 'sphere',
     });
-    phiSlider.group.position.set(
-      SLIDER_RACK_CENTER.x,
-      phiY,
-      SLIDER_RACK_CENTER.z,
-    );
-    group.add(phiSlider.group);
 
-    // Per-slider variable + value labels (#170). Two-line billboarded
-    // text: primary line is the variable name (set once at mount);
-    // secondary line is the live value (updated each frame in update()).
-    // Right-aligned so the rendered text right-edge stays fixed at
-    // SLIDER_LABEL_X_OFFSET regardless of value-string length, keeping
-    // worst-case secondary text clear of the slider thumb at slider min.
+    // Per-slider variable + value labels (#170). Right-anchored so
+    // worst-case secondary text "−0.80π" stays clear of the slider
+    // thumb at slider min.
     thetaLabel = new Label({
       primaryFontSize: SLIDER_LABEL_PRIMARY_FONT_SIZE,
       secondaryFontSize: SLIDER_LABEL_SECONDARY_FONT_SIZE,
@@ -430,12 +429,6 @@ const tangentPlanesExhibit: Exhibit = {
       anchorX: 'right',
     });
     thetaLabel.setPrimary('θ');
-    thetaLabel.group.position.set(
-      SLIDER_RACK_CENTER.x + SLIDER_LABEL_X_OFFSET,
-      thetaY,
-      SLIDER_RACK_CENTER.z,
-    );
-    group.add(thetaLabel.group);
 
     phiLabel = new Label({
       primaryFontSize: SLIDER_LABEL_PRIMARY_FONT_SIZE,
@@ -444,46 +437,84 @@ const tangentPlanesExhibit: Exhibit = {
       anchorX: 'right',
     });
     phiLabel.setPrimary('φ');
-    phiLabel.group.position.set(
-      SLIDER_RACK_CENTER.x + SLIDER_LABEL_X_OFFSET,
-      phiY,
-      SLIDER_RACK_CENTER.z,
-    );
-    group.add(phiLabel.group);
 
-    // Point indicator. Positioned in update() each frame.
+    // Point indicator. Math-object affordance — stays a child of
+    // ctx.group at world frame, positioned in update() each frame.
+    // Not slotted: the indicator is the rendered location of the
+    // selected point ON the math surface, not a UI control.
     indicator = new THREE.Mesh(
       new THREE.SphereGeometry(INDICATOR_RADIUS, 16, 12),
       new THREE.MeshStandardMaterial({ color: INDICATOR_COLOR }),
     );
     group.add(indicator);
 
-    // Tangent-plane mesh. Constructed with `group.visible = false` so
-    // the renderer can't paint a stale construction-time pose between
-    // mount and the first update tick — the first hit frame in update
-    // calls setPose then setVisible(true) to uncloak. (Insertion order
-    // in the scene graph doesn't drive Three's render order; that's
-    // governed by renderOrder + opaque/transparent pass sorting. We add
-    // it here only as a human-reader breadcrumb.)
+    // Tangent-plane mesh — math-object affordance, same lifetime as
+    // surface mesh. Stays world-anchored at SURFACE_CENTER (not
+    // slotted). Constructed with `group.visible = false` so the
+    // renderer can't paint a stale construction-time pose between
+    // mount and the first update tick.
     tangentPlane = createTangentPlane({
       surfaceCenter: SURFACE_CENTER,
       halfExtent: TANGENT_PLANE_HALF_EXTENT,
     });
     group.add(tangentPlane.group);
 
-    // Live readout of the plane equation + normal (#149). Anchored above
-    // the slider rack on the same z-plane; updated each hit frame from
-    // the same raymarch result that drives the indicator + tangent plane.
+    // Live readout of the plane equation + normal (#149). Slotted on
+    // the plinth at slot-Y = PLINTH_READOUT_Y. EquationReadout-style
+    // billboard carve-out: faceCamera overwrites group.rotation every
+    // frame, so the slot's default 'surface' orientation is
+    // documentation-only — the readout yaw-billboards regardless.
     tangentPlaneReadout = new TangentPlaneReadout({
       axisColors: [VERMILLION, BLUISH_GREEN, SKY_BLUE],
     });
-    tangentPlaneReadout.group.position.copy(READOUT_POSITION);
-    group.add(tangentPlaneReadout.group);
 
-    // Math-frame axis indicator — same anchor as quadrics.
+    // Math-frame axis indicator. orientation: 'world' so the X/Y/Z
+    // arrows read in the math frame, not the tabletop frame —
+    // WorldAxes' faceCamera rotates only its child letter-Text nodes,
+    // so the world-aligned slot survives across frames.
     worldAxes = new WorldAxes({ axisColors: AXIS_COLORS });
-    worldAxes.group.position.copy(AXIS_INDICATOR_POSITION);
-    group.add(worldAxes.group);
+
+    // Slot manifest (#225 / E1.4 PR2). createPlinth reparents each
+    // target under plinth.group at construction. Ids are required +
+    // uniqueness-validated by the plinth.
+    const slots: PlinthSlot[] = [
+      {
+        id: 'slider-theta',
+        target: thetaSlider.group,
+        localXYZ: [0, PLINTH_SLIDER_TOP_Y, 0],
+      },
+      {
+        id: 'slider-phi',
+        target: phiSlider.group,
+        localXYZ: [0, PLINTH_SLIDER_TOP_Y - SLIDER_ROW_PITCH, 0],
+      },
+      {
+        id: 'label-theta',
+        target: thetaLabel.group,
+        localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_SLIDER_TOP_Y, 0],
+      },
+      {
+        id: 'label-phi',
+        target: phiLabel.group,
+        localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_SLIDER_TOP_Y - SLIDER_ROW_PITCH, 0],
+      },
+      {
+        id: 'readout',
+        target: tangentPlaneReadout.group,
+        localXYZ: [0, PLINTH_READOUT_Y, 0],
+      },
+      {
+        id: 'world-axes',
+        target: worldAxes.group,
+        localXYZ: [PLINTH_AXIS_INDICATOR_X, PLINTH_AXIS_INDICATOR_Y, 0],
+        orientation: 'world',
+      },
+    ];
+    plinth = createPlinth({
+      anchorWorldXYZ: PLINTH_ANCHOR_WORLD_XYZ,
+      slots,
+    });
+    group.add(plinth.group);
   },
 
   update() {
@@ -626,6 +657,10 @@ const tangentPlanesExhibit: Exhibit = {
     if (stageInnerRailing) {
       stageInnerRailing.dispose();
       stageInnerRailing = undefined;
+    }
+    if (plinth) {
+      plinth.dispose();
+      plinth = undefined;
     }
 
     // 3. Drop external references so a re-mount starts clean. The shell

--- a/src/scaffold/ui/clusterRackTokens.ts
+++ b/src/scaffold/ui/clusterRackTokens.ts
@@ -1,36 +1,26 @@
-import * as THREE from 'three';
-
-// Cluster slider-rack geometry + design feel — duplicated bit-identical
-// across the four cluster scenes' index.ts (quadrics manipulator,
-// tangent-planes, gradient-levels, saddle-extrema). Lifted per the
-// extract-on-Nth-use rule for load-bearing scaffold (#201 PR 4).
+// Cluster slider-rack geometry + design feel — values inherited by
+// every cluster scene's index.ts (quadrics manipulator, tangent-planes,
+// gradient-levels, saddle-extrema). Lifted per the extract-on-Nth-use
+// rule for load-bearing scaffold (#201 PR 4).
 //
 // Future cluster scenes inherit these as the rack template. Scenes
 // pedagogically needing a different feel pass their own constants
 // explicitly — the Slider API requires snapDetent + grabRadiusMultiplier
 // as ctor opts per #120.
-//
-// Canonical surface is immutable: tuple (`readonly` via `as const`) for
-// the rack-center coordinate + factory function for the Vector3
-// instance. THREE.Vector3 has no internal cloning protection at consumer
-// call sites (unlike THREE.Color, which createTranslucentRect clones at
-// its boundary); the factory pattern eliminates the shared-mutable-
-// singleton footgun.
 
-export const SLIDER_RACK_CENTER_COORDS = [0, 1.0, -0.7] as const;
 export const SLIDER_ROW_PITCH = 0.14;
 export const SLIDER_SNAP_DETENT = 0.05;
-export const GRAB_RADIUS_MULTIPLIER = 2.75;
 
 /**
- * Plinth-mounted UI variant of `GRAB_RADIUS_MULTIPLIER` (#225 / E1.4).
- * The 2.75 above was tuned for mid-air sphere-aim ergonomics — the
- * user's hand aims AT a small floating sphere from across the room
- * and a generous hit radius forgives drift on re-grab. Plinth-mounted
- * UI changes the kinematics: the user's hand goes TO the working
- * surface (hover-near-surface, touch-on-surface) so a tighter radius
- * reads as precise rather than imprecise, especially in quadrics'
- * dense rack.
+ * Grab-radius multiplier for plinth-mounted UI (#225 / E1.4). Every
+ * cluster scene's interactive primitives — sliders, presets, tabs,
+ * cross-section toggles — pass this to their ctor's
+ * `grabRadiusMultiplier` opt. The pre-plinth mid-air multiplier
+ * (2.75) was deleted at PR2 (#251) once all four cluster scenes
+ * ported onto the plinth; the kinematics changed from
+ * controller-aim-AT (a small floating sphere across the room needed
+ * a generous hit radius) to hand-TO-surface (touch-on-surface) where
+ * a tighter radius reads as precise rather than imprecise.
  *
  * First-pass smoke-tunable (feedback_staging_dimensions_first_pass).
  * Bracket [1.25, 2.0]: bump up if smoke flags too tight, bump down if
@@ -51,7 +41,3 @@ export const SLIDER_LABEL_X_OFFSET = -0.2;
 export const SLIDER_LABEL_PRIMARY_FONT_SIZE = 0.05;
 export const SLIDER_LABEL_SECONDARY_FONT_SIZE = 0.035;
 export const SLIDER_LABEL_LINE_GAP = 0.008;
-
-export function createSliderRackCenter(): THREE.Vector3 {
-  return new THREE.Vector3(...SLIDER_RACK_CENTER_COORDS);
-}

--- a/test/exhibits/cluster-on-plinth.test.ts
+++ b/test/exhibits/cluster-on-plinth.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+// Static-grep regression guards for the #225 / E1.4 PR2 cluster-on-plinth
+// port (`_private/plans/251-cluster-on-plinth.md` §5).
+//
+// These tests catch the easy mechanical regression class — a future
+// scene copying the old grab-radius import from a sibling, or a refactor
+// reintroducing a world-frame UI anchor — that would not visibly
+// misplace any primitive in headset smoke. They run as part of the
+// standard Vitest invocation; Vite's `import.meta.glob` enumerates the
+// repo at config-resolution time, so no Three.js context or filesystem
+// API is required.
+
+// Every .ts file under src/ as { path -> contents } at config time.
+// `eager: true` makes the glob synchronous; `query: '?raw'` returns the
+// raw file text; `import: 'default'` unwraps the default export.
+const allSrcTsFiles = import.meta.glob<string>('../../src/**/*.ts', {
+  eager: true,
+  query: '?raw',
+  import: 'default',
+});
+
+// Subset of the same map restricted to the three target scene files —
+// the world-frame UI anchors that the port deletes are scoped to these
+// files only.
+const targetScenePaths = [
+  '../../src/exhibits/tangent-planes/index.ts',
+  '../../src/exhibits/gradient-levels/index.ts',
+  '../../src/exhibits/saddle-extrema/index.ts',
+] as const;
+
+// ────────────────────────────────────────────────────────────────────
+// Sanity — a future repo restructure that breaks the glob should fail
+// loudly here rather than silently passing zero assertions.
+// ────────────────────────────────────────────────────────────────────
+
+describe('cluster-on-plinth — test setup', () => {
+  it('glob collects .ts files from src/', () => {
+    expect(Object.keys(allSrcTsFiles).length).toBeGreaterThan(50);
+  });
+
+  it.each(targetScenePaths)('target scene exists: %s', (path) => {
+    expect(allSrcTsFiles[path]).toBeTypeOf('string');
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// Static-grep assertions
+// ────────────────────────────────────────────────────────────────────
+
+function findMatches(
+  pattern: RegExp,
+  files: Record<string, string>,
+): { path: string; line: number; text: string }[] {
+  const hits: { path: string; line: number; text: string }[] = [];
+  for (const [path, src] of Object.entries(files)) {
+    const lines = src.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      if (pattern.test(lines[i])) {
+        hits.push({ path, line: i + 1, text: lines[i].trim() });
+      }
+    }
+  }
+  return hits;
+}
+
+describe('cluster-on-plinth — static-grep regression guards', () => {
+  // Scope explicitly `.ts` only — `quadrics/SPEC.md`'s pre-PR2 prose
+  // is rewritten in PR2 per the plan's §2.0, but the test's regression
+  // target is import-by-source, not doc text. Plan v3 §5 / §6 narrows
+  // the assertion scope explicitly.
+  it('zero `GRAB_RADIUS_MULTIPLIER` references in .ts files repo-wide', () => {
+    // Negative lookahead so `GRAB_RADIUS_MULTIPLIER_PLINTH` (the
+    // successor constant) doesn't match.
+    const pattern = /\bGRAB_RADIUS_MULTIPLIER\b(?!_PLINTH)/;
+    const hits = findMatches(pattern, allSrcTsFiles);
+    expect(hits, JSON.stringify(hits, null, 2)).toEqual([]);
+  });
+
+  // Scaffold-level legacy anchors: `SLIDER_RACK_CENTER` (the named
+  // handle), `SLIDER_RACK_CENTER_COORDS` (the tuple), and
+  // `createSliderRackCenter` (its factory) all lived in
+  // `clusterRackTokens.ts` alongside the deleted `GRAB_RADIUS_MULTIPLIER`
+  // and were deleted at PR2. Checked repo-wide so a future scene
+  // author can't reintroduce them by re-extracting a factory into
+  // scaffold.
+  const scaffoldLegacy = [
+    'SLIDER_RACK_CENTER',
+    'SLIDER_RACK_CENTER_COORDS',
+    'createSliderRackCenter',
+  ];
+  it.each(scaffoldLegacy)(
+    'zero `%s` references in .ts files repo-wide',
+    (symbol) => {
+      const pattern = new RegExp(`\\b${symbol}\\b`);
+      const hits = findMatches(pattern, allSrcTsFiles);
+      expect(hits, JSON.stringify(hits, null, 2)).toEqual([]);
+    },
+  );
+
+  // Scene-local legacy anchors: `READOUT_POSITION` and
+  // `AXIS_INDICATOR_POSITION` were per-scene world-frame `Vector3`s,
+  // never in scaffold. The regression class is "a target scene
+  // re-introduces a world-frame position," so the guard is scoped to
+  // the three target scenes' index.ts files. (Quadrics has historical
+  // doc-comments listing the names — those are intentional change
+  // notes, not regressions.)
+  const sceneLocalLegacy = ['READOUT_POSITION', 'AXIS_INDICATOR_POSITION'];
+  const targetSceneFiles = Object.fromEntries(
+    targetScenePaths
+      .map((p) => [p, allSrcTsFiles[p]] as const)
+      .filter(([, src]) => typeof src === 'string'),
+  );
+  it.each(sceneLocalLegacy)(
+    'zero `%s` references in the three target scene index.ts files',
+    (symbol) => {
+      const pattern = new RegExp(`\\b${symbol}\\b`);
+      const hits = findMatches(pattern, targetSceneFiles);
+      expect(hits, JSON.stringify(hits, null, 2)).toEqual([]);
+    },
+  );
+});


### PR DESCRIPTION
Closes #251

## Summary

PR2 of the #225 / E1.4 sub-epic — closes the cluster sweep that started in PR1 (#250). Ports `tangent-planes`, `gradient-levels`, and `saddle-extrema` onto the same `createPlinth({ slots: [...] })` API quadrics adopted in PR1, reparenting sliders + per-slider labels + readouts + `WorldAxes` under `plinth.group`. Math-object affordances stay world-anchored at `SURFACE_CENTER` per the issue body's hard rule (*knobs and dials on the plinth; direct-manipulate-the-math-object affordances stay on the math object itself*). Also deletes the now-unused `GRAB_RADIUS_MULTIPLIER = 2.75` / `SLIDER_RACK_CENTER_COORDS` / `createSliderRackCenter` exports from `clusterRackTokens.ts` and updates the stale "PR2 pending" prose in `quadrics/SPEC.md`.

Cluster-uniform plinth anchor `(0, 0, 0.05)` matches quadrics' v2 smoke landing; default 0.5 m working-surface depth fits each scene's slider rack. Per-scene `SPEC.md` sub-sections ("Staging — Control plinth (#225 / E1.4)") mirror quadrics' PR1 SPEC. New `test/exhibits/cluster-on-plinth.test.ts` adds static-grep regression guards for the deleted symbols.

## Test plan

- [x] `npm test` — 529/529 passing including new `cluster-on-plinth.test.ts` guards.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run build` — clean.
- [x] `npm run lint` — clean.
- [x] Pre-commit (gitleaks + standard fixers + eslint) — passed at commit time.
- [ ] **Headset smoke (Cloudflare PR preview):** for each of `tangent-planes`, `gradient-levels`, `saddle-extrema`:
  - [x] Plinth body visible from default pancake camera; no intersection with floor cutout or inner railing.
  - [x] Sliders sit on the tilted working surface; per-slider labels read at the left of each row; readout floats above the back edge; WorldAxes at the right edge with math-frame X/Y/Z arrows aligned to the world (not the tabletop) frame.
  - [x] Quest 3S: 72 Hz hold preserved on all three scenes; grab/release ergonomics ≥ pre-plinth feel at the new `GRAB_RADIUS_MULTIPLIER_PLINTH = 1.5`.
  - [x] **Tangent-planes:** VR controller-aim sphere picker (#197) still grabs the unit sphere; the picker + plinth-hand combination reads as kin to a slider grab (haptic pulse on pick start/end).
  - [x] **Saddle-extrema:** preset row sits at slot-Y = 0.55 in single horizontal row; tapping a preset rebuilds `graphSurface` / `criticalPointMarkers` / `taylorOverlay` while the sliders stay reference-stable under `plinth.group`.
  - [x] Side-by-side check against PR1-merged build: all four scenes read as visually coherent (sliders at the same slot-Y rows, axis indicators at the same edge, readouts in the same band).

Plan: \`_private/plans/251-cluster-on-plinth.md\` (v3, post-three-vendor roundtable + second-Sonnet sanity check + \`/spar\` adversarial review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)