### PR TITLE
feat(perf): wire FpsOverlay into the three target scenes (#261 stopgap; stacked on #260)

### DIFF
--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -48,6 +48,7 @@ import {
   type PlinthHandles,
   type PlinthSlot,
 } from '@/scaffold/staging/Plinth';
+import { FpsOverlay } from '@/scaffold/perf/FpsOverlay';
 import { createGradientArrow, type GradientArrowHandles } from './GradientArrow';
 import { GradientLevelsReadout } from './GradientLevelsReadout';
 import { BOUND, fJsRaw, gradJs } from './surfaceModel';
@@ -97,6 +98,12 @@ const PLINTH_SLIDER_MID_Y = 0.275;
 const PLINTH_READOUT_Y = 0.57;
 const PLINTH_AXIS_INDICATOR_X = 0.42;
 const PLINTH_AXIS_INDICATOR_Y = 0.275;
+
+// Debug-only FPS readout (#99), gated behind `?fps=1`. World-anchored
+// above the plinth, not slotted — dev tooling, not user-facing UI.
+// Stopgap per-scene wiring (#261); the proper shell-owned lift is a
+// future PR.
+const FPS_OVERLAY_POSITION = new THREE.Vector3(0, 1.85, 0.05);
 
 // Per-slider variable + value labels (#170). All three sliders (θ/φ/k)
 // carry a two-line right-aligned label anchored ~0.05 m left of each
@@ -279,6 +286,7 @@ let contrastPit: ContrastPitHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
 let stageInnerRailing: StageInnerRailingHandles | undefined;
 let plinth: PlinthHandles | undefined;
+let fpsOverlay: FpsOverlay | undefined;
 let pointers: readonly Pointer[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
 // yaw-billboarding in update().
@@ -489,9 +497,18 @@ const gradientLevelsExhibit: Exhibit = {
       slots,
     });
     group.add(plinth.group);
+
+    // Optional in-VR FPS readout (#99), gated behind `?fps=1` on the
+    // URL. Stopgap per-scene wiring per #261; proper shell-owned lift
+    // is a future PR.
+    if (isFpsOverlayEnabled()) {
+      fpsOverlay = new FpsOverlay();
+      fpsOverlay.group.position.copy(FPS_OVERLAY_POSITION);
+      group.add(fpsOverlay.group);
+    }
   },
 
-  update() {
+  update({ delta }) {
     // Per-slider labels (θ/φ/k) are accessory (#170) — handled by per-call
     // guards below; not gated here so a missing label never blocks
     // slider/raycast updates.
@@ -595,6 +612,10 @@ const gradientLevelsExhibit: Exhibit = {
     //    (Per-slider label faceCamera calls live in step 2b above.)
     if (worldAxes && camera) worldAxes.faceCamera(camera);
     if (camera) gradientLevelsReadout.faceCamera(camera);
+    if (fpsOverlay) {
+      fpsOverlay.update(delta, performance.now());
+      if (camera) fpsOverlay.faceCamera(camera);
+    }
   },
 
   unmount() {
@@ -666,6 +687,10 @@ const gradientLevelsExhibit: Exhibit = {
       plinth.dispose();
       plinth = undefined;
     }
+    if (fpsOverlay) {
+      fpsOverlay.dispose();
+      fpsOverlay = undefined;
+    }
 
     // 3. Drop external references so a re-mount starts clean. The shell
     //    removes ctx.group and its descendants automatically.
@@ -688,6 +713,11 @@ const gradientLevelsExhibit: Exhibit = {
     kSlider?.releaseFromPointer(pointer);
   },
 };
+
+function isFpsOverlayEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  return new URLSearchParams(window.location.search).get('fps') === '1';
+}
 
 registerExhibit(gradientLevelsExhibit);
 

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -42,6 +42,7 @@ import {
   type PlinthHandles,
   type PlinthSlot,
 } from '@/scaffold/staging/Plinth';
+import { FpsOverlay } from '@/scaffold/perf/FpsOverlay';
 import {
   createCriticalPointMarkers,
   type CriticalPointMarkersHandles,
@@ -114,6 +115,12 @@ const PLINTH_PRESET_ROW_START_X = -2 * PLINTH_PRESET_COL_PITCH;
 const PLINTH_READOUT_Y = 0.70;
 const PLINTH_AXIS_INDICATOR_X = 0.42;
 const PLINTH_AXIS_INDICATOR_Y = 0.275;
+
+// Debug-only FPS readout (#99), gated behind `?fps=1`. World-anchored
+// above the plinth, not slotted — dev tooling, not user-facing UI.
+// Stopgap per-scene wiring (#261); the proper shell-owned lift is a
+// future PR.
+const FPS_OVERLAY_POSITION = new THREE.Vector3(0, 1.85, 0.05);
 
 // Stage floor cutout half-extent (#238 / E1.1) — derived from the
 // widest preset domain so a future preset with a wider (x, y) window
@@ -211,6 +218,7 @@ let contrastPit: ContrastPitHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
 let stageInnerRailing: StageInnerRailingHandles | undefined;
 let plinth: PlinthHandles | undefined;
+let fpsOverlay: FpsOverlay | undefined;
 let activePresetIndex = DEFAULT_PRESET_INDEX;
 let saddleExtremaReadout: SaddleExtremaReadout | undefined;
 let camera: THREE.Camera | undefined;
@@ -469,9 +477,18 @@ const saddleExtremaExhibit: Exhibit = {
       slots,
     });
     group.add(plinth.group);
+
+    // Optional in-VR FPS readout (#99), gated behind `?fps=1` on the
+    // URL. Stopgap per-scene wiring per #261; proper shell-owned lift
+    // is a future PR.
+    if (isFpsOverlayEnabled()) {
+      fpsOverlay = new FpsOverlay();
+      fpsOverlay.group.position.copy(FPS_OVERLAY_POSITION);
+      group.add(fpsOverlay.group);
+    }
   },
 
-  update() {
+  update({ delta }) {
     const activePreset = PRESETS[activePresetIndex];
 
     if (xSlider && ySlider) {
@@ -539,6 +556,10 @@ const saddleExtremaExhibit: Exhibit = {
     // Yaw-only billboard on the WorldAxes letter labels so they read at
     // any user yaw. Same per-frame contract as cluster siblings.
     if (worldAxes && camera) worldAxes.faceCamera(camera);
+    if (fpsOverlay) {
+      fpsOverlay.update(delta, performance.now());
+      if (camera) fpsOverlay.faceCamera(camera);
+    }
   },
 
   unmount() {
@@ -596,6 +617,10 @@ const saddleExtremaExhibit: Exhibit = {
     if (plinth) {
       plinth.dispose();
       plinth = undefined;
+    }
+    if (fpsOverlay) {
+      fpsOverlay.dispose();
+      fpsOverlay = undefined;
     }
 
     // 3. Drop external references so a re-mount starts clean.
@@ -709,6 +734,11 @@ function applyPreset(idx: number): void {
     xSlider?.value ?? 0,
     ySlider?.value ?? 0,
   );
+}
+
+function isFpsOverlayEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  return new URLSearchParams(window.location.search).get('fps') === '1';
 }
 
 registerExhibit(saddleExtremaExhibit);

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -48,6 +48,7 @@ import {
   type PlinthHandles,
   type PlinthSlot,
 } from '@/scaffold/staging/Plinth';
+import { FpsOverlay } from '@/scaffold/perf/FpsOverlay';
 import { createTangentPlane, type TangentPlaneHandles } from './TangentPlane';
 import { TangentPlaneReadout } from './TangentPlaneReadout';
 
@@ -100,6 +101,14 @@ const PLINTH_SLIDER_TOP_Y = 0.345;
 const PLINTH_READOUT_Y = 0.57;
 const PLINTH_AXIS_INDICATOR_X = 0.42;
 const PLINTH_AXIS_INDICATOR_Y = 0.275;
+
+// Debug-only FPS readout (#99), gated behind `?fps=1`. Kept at its
+// world-frame position rather than going through the plinth slot
+// manifest — `?fps=1`-gated dev tooling, not user-facing UI (see §5
+// acceptance carve-out in `_private/plans/225-control-plinth.md`).
+// Stopgap per-scene wiring (#261); the proper shell-owned lift is a
+// future PR.
+const FPS_OVERLAY_POSITION = new THREE.Vector3(0, 1.85, 0.05);
 
 // Tighter than quadrics' BOUND=3.5: the unit sphere fits in [-1, 1]³ with
 // room to spare; no coefficient-driven expansion to budget for.
@@ -248,6 +257,7 @@ let contrastPit: ContrastPitHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
 let stageInnerRailing: StageInnerRailingHandles | undefined;
 let plinth: PlinthHandles | undefined;
+let fpsOverlay: FpsOverlay | undefined;
 let pointers: readonly Pointer[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
 // yaw-billboarding in update().
@@ -515,9 +525,19 @@ const tangentPlanesExhibit: Exhibit = {
       slots,
     });
     group.add(plinth.group);
+
+    // Optional in-VR FPS readout (#99), gated behind `?fps=1` on the
+    // URL. Stopgap per-scene wiring per #261; proper shell-owned lift
+    // is a future PR. World-anchored above the plinth, not slotted —
+    // dev tooling shouldn't ride along with user-facing UI.
+    if (isFpsOverlayEnabled()) {
+      fpsOverlay = new FpsOverlay();
+      fpsOverlay.group.position.copy(FPS_OVERLAY_POSITION);
+      group.add(fpsOverlay.group);
+    }
   },
 
-  update() {
+  update({ delta }) {
     // Labels are accessory (#170) — handled by per-call guards below;
     // not gated here so a missing label never blocks slider/raycast updates.
     if (!thetaSlider || !phiSlider || !indicator || !tangentPlane) return;
@@ -601,6 +621,10 @@ const tangentPlanesExhibit: Exhibit = {
     // they read at any user yaw. Same per-frame contract as quadrics.
     if (worldAxes && camera) worldAxes.faceCamera(camera);
     if (tangentPlaneReadout && camera) tangentPlaneReadout.faceCamera(camera);
+    if (fpsOverlay) {
+      fpsOverlay.update(delta, performance.now());
+      if (camera) fpsOverlay.faceCamera(camera);
+    }
   },
 
   unmount() {
@@ -662,6 +686,10 @@ const tangentPlanesExhibit: Exhibit = {
       plinth.dispose();
       plinth = undefined;
     }
+    if (fpsOverlay) {
+      fpsOverlay.dispose();
+      fpsOverlay = undefined;
+    }
 
     // 3. Drop external references so a re-mount starts clean. The shell
     //    removes ctx.group and its descendants automatically. Clear the
@@ -706,6 +734,11 @@ const tangentPlanesExhibit: Exhibit = {
     }
   },
 };
+
+function isFpsOverlayEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  return new URLSearchParams(window.location.search).get('fps') === '1';
+}
 
 registerExhibit(tangentPlanesExhibit);
 


### PR DESCRIPTION
Refs #261. Stacked on #260 (\`--base 251-three-scenes-on-plinth\`) — retarget to \`main\` after #260 merges.

## Summary

The URL \`?fps=1\` query param already survives SceneRack hops (\`shell/url-routing.ts:103–107\` mode-preservation invariant), but only quadrics' \`mount()\` constructed an \`FpsOverlay\`. Hopping to the other three cluster scenes silently dropped the FPS readout. This PR wires \`FpsOverlay\` into \`tangent-planes\` / \`gradient-levels\` / \`saddle-extrema\` mirroring quadrics' pattern, so #260's in-headset smoke validates frame rate across all four cluster scenes.

Stopgap by design — the proper shell-owned lift (so every future exhibit gets it for free, no per-scene wiring) is tracked in #261. This PR is what lands so smoke isn't blind right now.

## Test plan

- [x] \`npm test\` — 529/529 passing (no new test files needed; \`?fps=1\` runtime behavior is exercised in-headset).
- [x] \`npx tsc --noEmit\` — clean.
- [x] \`npm run build\` — clean.
- [x] \`npm run lint\` — clean.
- [x] Pre-commit (gitleaks + standard fixers + eslint) — passed at commit time.
- [x] **Headset smoke (Cloudflare PR preview)** — load any URL with \`?fps=1\` appended; hop between all four cluster scenes via SceneRack; verify:
  - [x] FPS overlay visible above the plinth on every scene.
  - [x] No flicker / re-allocation when the URL param survives the hop.
  - [x] Quest 3S: 72 Hz hold visible on each scene's FPS readout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)