### PR TITLE
fix(staging): re-center section-tab + canonical-forms rack on the plinth (#255 PR1)

### DIFF
--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -467,6 +467,31 @@ still binds them to the plinth's slot-Y axis above the rack; the
 yaw-billboarding keeps text legible across pancake and headset
 viewing distances rather than foreshortening with the surface tilt.
 
+**Section-tab + canonical-forms-heading anchoring (#255 PR1).** The
+4-element vertical rack at the left of the plinth (canonical-forms
+heading + 3 SectionTabs) is centered on the working-surface
+mid-Y = 0.275. Constants in `index.ts`:
+
+- `PLINTH_SECTION_TAB_HEADING_Y = 0.44`
+- `PLINTH_SECTION_TAB_TOP_Y = 0.31`
+- `PLINTH_SECTION_TAB_PITCH = 0.13` (unchanged)
+
+Tabs land at slot-Y `0.31 / 0.18 / 0.05`. The geometry honors the
+fact that SectionTab labels sit ABOVE their button bodies (per
+`SectionTab.ts:34–36`: `labelOffsetY = +0.04`, `labelAnchorY =
+'bottom'`, `labelFontSize = 0.035`), so the tight edges are the
+**heading label vs slab back edge** (top of rack) and the **bottom
+tab sphere vs slab front edge** (bottom of rack). With these
+constants: heading label top at slot-Y `0.518` (32 mm clear of back
+edge); bottom-tab sphere bottom at slot-Y `0.029` (29 mm clear of
+front edge); rack envelope `[0.029, 0.518]` centered on `0.275`. See
+the bracket + next-step doc comment on the constants for the
+binary-search bracket.
+
+Pre-PR1 (`main`): HEADING_Y was at 0.55 (flush with the back edge),
+so the heading button's upper hemisphere read as floating in air
+behind the surface and the rack as a whole bunched against the back.
+
 **Grab radius retune.** `GRAB_RADIUS_MULTIPLIER_PLINTH = 1.5`
 (`scaffold/ui/clusterRackTokens.ts`) replaces the mid-air `2.75` for
 every interactive primitive on the plinth — sliders / presets /

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -111,10 +111,37 @@ const PLINTH_SLIDER_TOP_Y = 0.485;
 // the left edge of the 0.9 m surface). Pitch compressed from the
 // pre-plinth 0.23 m to 0.13 m so the full 4-element stack fits the
 // surface depth.
+//
+// Vertical anchoring (#255 PR1). SectionTab labels sit ABOVE their
+// buttons (labelOffsetY = +0.04, labelAnchorY = 'bottom'; see
+// `SectionTab.ts:34–36`), so the tight edge for the heading is its
+// label TOP vs the slab BACK edge; for the bottom tab it's the
+// sphere bottom vs the slab FRONT edge. With labelFontSize 0.035 +
+// 8% outline, label extends ~0.078 m above its button center; sphere
+// half-extent in slot-Y is `r_proj = buttonRadius × cos(tilt) =
+// 0.022 × cos(20°) ≈ 0.0207 m`.
+//
+// Centering the rack ENVELOPE (heading label top down to bottom-tab
+// sphere bottom) within `[0, PLINTH_WORKING_HEIGHT_QUADRICS = 0.55]`:
+//   envelope_top    = HEADING_Y + 0.078
+//   envelope_bottom = (HEADING_Y − 3 × pitch) − 0.0207
+//   center          = (top + bottom) / 2 = 0.275 (mid-surface)
+// At pitch 0.13 ⇒ HEADING_Y = 0.44, TOP_Y = 0.31, bottom tab at 0.05.
+// Heading label top = 0.518 (32 mm clear of back edge); bottom-tab
+// sphere bottom = 0.029 (29 mm clear of front edge).
+//
+// Brackets (binary-search-visual-constants; one dial per round):
+//   • If heading label visually grazes back edge → HEADING_Y → 0.42
+//     (clearance 52 mm), bottom recomputes to 0.03 (clearance 9 mm).
+//   • If bottom tab visually too close to front edge → tighten
+//     PITCH from 0.13 to 0.12, HEADING_Y stays at 0.44, bottom
+//     becomes 0.08 (clearance 60 mm).
+//   • Documented invariants: HEADING_Y + 0.078 ≤ 0.55 − 0.01;
+//     BOTTOM_Y (= HEADING_Y − 3 × PITCH) − 0.0207 ≥ 0.01.
 const PLINTH_SECTION_TAB_X = -0.42;
 const PLINTH_SECTION_TAB_PITCH = 0.13;
-const PLINTH_SECTION_TAB_HEADING_Y = 0.55;
-const PLINTH_SECTION_TAB_TOP_Y = 0.42;
+const PLINTH_SECTION_TAB_HEADING_Y = 0.44;
+const PLINTH_SECTION_TAB_TOP_Y = 0.31;
 
 // Preset 2 × 4 grid placed ABOVE the working-surface back edge in
 // slot-local +Y space (the grid is hidden by default and only

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -107,10 +107,24 @@ const PLINTH_SLIDER_ROW_PITCH = 0.14;
 // 0.14 the top slider 'a' sits at 0.485 and the bottom 'd' at 0.065.
 const PLINTH_SLIDER_TOP_Y = 0.485;
 
-// 3 section tabs + 1 heading stacked at slot-X = −0.42 (just inside
-// the left edge of the 0.9 m surface). Pitch compressed from the
+// 3 section tabs + 1 heading stacked at slot-X = −0.37 (was −0.42 in
+// #255 PR1 v1; PR1 headset-smoke nudged the column 0.05 m in +slot-X
+// so the rack reads as INTERIOR to the working surface rather than
+// hugging the left edge of the 0.9 m slab). Pitch compressed from the
 // pre-plinth 0.23 m to 0.13 m so the full 4-element stack fits the
 // surface depth.
+//
+// Horizontal placement (#255 PR1 v2):
+//   • Button centers at slot-X = -0.37; sphere extent ~[-0.392, -0.348]
+//     (buttonRadius 0.022). Slab left edge at -0.45, so the sphere
+//     clears the slab edge by ~58 mm.
+//   • Slider rack is centered on slot-X = 0; the closest leftward
+//     slider geometry stays clear of slot-X ≈ -0.3 in practice, so
+//     the section-tab column at -0.37 keeps a comfortable 30+ mm
+//     horizontal gap from the slider rack.
+//   • Bracket: if labels still feel too edge-y → -0.34 or -0.32; if
+//     the rack starts crowding the slider track → step back toward
+//     -0.40. One dial per round.
 //
 // Vertical anchoring (#255 PR1). SectionTab labels sit ABOVE their
 // buttons (labelOffsetY = +0.04, labelAnchorY = 'bottom'; see
@@ -130,7 +144,7 @@ const PLINTH_SLIDER_TOP_Y = 0.485;
 // Heading label top = 0.518 (32 mm clear of back edge); bottom-tab
 // sphere bottom = 0.029 (29 mm clear of front edge).
 //
-// Brackets (binary-search-visual-constants; one dial per round):
+// Vertical brackets (binary-search-visual-constants; one dial per round):
 //   • If heading label visually grazes back edge → HEADING_Y → 0.42
 //     (clearance 52 mm), bottom recomputes to 0.03 (clearance 9 mm).
 //   • If bottom tab visually too close to front edge → tighten
@@ -138,7 +152,7 @@ const PLINTH_SLIDER_TOP_Y = 0.485;
 //     becomes 0.08 (clearance 60 mm).
 //   • Documented invariants: HEADING_Y + 0.078 ≤ 0.55 − 0.01;
 //     BOTTOM_Y (= HEADING_Y − 3 × PITCH) − 0.0207 ≥ 0.01.
-const PLINTH_SECTION_TAB_X = -0.42;
+const PLINTH_SECTION_TAB_X = -0.37;
 const PLINTH_SECTION_TAB_PITCH = 0.13;
 const PLINTH_SECTION_TAB_HEADING_Y = 0.44;
 const PLINTH_SECTION_TAB_TOP_Y = 0.31;


### PR DESCRIPTION
Refs #255 (this is PR1 of 2 — anchoring half only; label-rendering follows on its own branch).

## Summary

The 4-element vertical rack at the left of the quadrics plinth (canonical-forms heading + 3 section tabs) was anchored with `PLINTH_SECTION_TAB_HEADING_Y = 0.55`, exactly at the slab back edge — so the heading sphere's upper hemisphere visually floated behind the surface, and the bottom tab at slot-Y 0.16 bunched against the front edge. Surfaced from #260 post-merge headset smoke.

This PR re-centers the rack ENVELOPE (heading label top down to bottom-tab sphere bottom) on slot-Y 0.275 (mid-surface): `HEADING_Y` 0.55 → 0.44, `TOP_Y` 0.42 → 0.31, pitch unchanged at 0.13. Tabs land at 0.31 / 0.18 / 0.05; heading label top at 0.518 (32 mm clear of back edge); bottom-tab sphere bottom at 0.029 (29 mm clear of front edge).

The geometry honors that SectionTab labels sit ABOVE their button bodies (per `SectionTab.ts:34–36`: `labelOffsetY = +0.04`, `labelAnchorY = 'bottom'`), so the tight edges are heading-label-vs-back and bottom-tab-sphere-vs-front. Constants' doc comment records the envelope derivation + binary-search brackets for the smoke next-step rule.

PR2 (label-rendering opt-in for plinth-mounted TapButton instances — fixes the related label-clipping issue surfaced in the same smoke) follows.

## Test plan

UI change — primary surface is the Cloudflare PR preview.

- [x] Pancake (`?exhibit=quadrics`) — the 4-element section-tab rack reads as one centered column; canonical-forms heading no longer flush with the back edge; bottom tab no longer crammed near the front edge.
- [x] Pancake — slider rack / preset grid / readouts / world-axes indicator visually unchanged (no regression in unrelated UI).
- [x] Quest 3S standing height (~1.6 m) — same checks; the heading sphere's upper hemisphere no longer reads as floating behind the surface; bottom tab clears the front edge comfortably.
- [x] All four cluster scenes still mount cleanly (no shared scaffold touched in this PR; only `quadrics/index.ts` + `quadrics/SPEC.md`).
- [x] `npm test` — 529/529 pass.
- [x] `npx tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)