### PR TITLE
feat(scaffold): TapButtonVisuals.labelOrientation opt-out for surface-mounted labels (#255 PR2)

### DIFF
--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -467,6 +467,26 @@ still binds them to the plinth's slot-Y axis above the rack; the
 yaw-billboarding keeps text legible across pancake and headset
 viewing distances rather than foreshortening with the surface tilt.
 
+**SectionTab label rendering on the tilted surface (#255 PR2).**
+SectionTab + canonical-forms heading sit ON the slab (not in mid-air
+above it like the readouts), so the carve-out above doesn't fit —
+yaw-billboarding their text labels would produce a compound rotation
+(label inherits surface tilt from parent group, AND yaws about that
+tilted local-Y axis) that clips text into the slab volume. The fix:
+`SectionTab.ts` opts its module-level VISUALS into
+`labelOrientation: 'surface'` (a new `TapButtonVisuals` field added
+in PR2). `TapButton` reads this at ctor time, identity-sets
+`label.rotation`, and short-circuits the yaw-billboard write in
+`faceCamera`. Labels co-tilt with the slab through the parent
+group's transform — no plane divergence, no clipping. Worst-case
+viewer-relative foreshortening across plausible head poses is ~8%
+(per the §3.2 pose matrix in
+`_private/plans/255-section-tab-anchoring-labels.md`), well below
+the legibility floor at the existing 0.035 m font + 8% troika
+outline. Preset / SceneTab keep the default `'face-camera'` — they
+mount in mid-air above the slab where yaw-billboard is desired
+(audited as part of PR2's subclass option-forwarding sweep).
+
 **Grab radius retune.** `GRAB_RADIUS_MULTIPLIER_PLINTH = 1.5`
 (`scaffold/ui/clusterRackTokens.ts`) replaces the mid-air `2.75` for
 every interactive primitive on the plinth — sliders / presets /

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -107,24 +107,36 @@ const PLINTH_SLIDER_ROW_PITCH = 0.14;
 // 0.14 the top slider 'a' sits at 0.485 and the bottom 'd' at 0.065.
 const PLINTH_SLIDER_TOP_Y = 0.485;
 
-// 3 section tabs + 1 heading stacked at slot-X = −0.37 (was −0.42 in
-// #255 PR1 v1; PR1 headset-smoke nudged the column 0.05 m in +slot-X
-// so the rack reads as INTERIOR to the working surface rather than
-// hugging the left edge of the 0.9 m slab). Pitch compressed from the
-// pre-plinth 0.23 m to 0.13 m so the full 4-element stack fits the
-// surface depth.
+// 3 section tabs + 1 heading stacked at slot-X = −0.32 (was −0.37 in
+// #255 PR1 v2 / −0.42 in v1). Two rounds of PR1 headset-smoke nudges
+// in +slot-X so the rack reads as INTERIOR to the working surface
+// rather than hugging the −math-X edge of the 0.9 m slab. Pitch
+// compressed from the pre-plinth 0.23 m to 0.13 m so the full
+// 4-element stack fits the surface depth.
 //
-// Horizontal placement (#255 PR1 v2):
-//   • Button centers at slot-X = -0.37; sphere extent ~[-0.392, -0.348]
+// Horizontal placement (#255 PR1 v3):
+//   • Button centers at slot-X = -0.32; sphere extent ~[-0.342, -0.298]
 //     (buttonRadius 0.022). Slab left edge at -0.45, so the sphere
-//     clears the slab edge by ~58 mm.
-//   • Slider rack is centered on slot-X = 0; the closest leftward
-//     slider geometry stays clear of slot-X ≈ -0.3 in practice, so
-//     the section-tab column at -0.37 keeps a comfortable 30+ mm
-//     horizontal gap from the slider rack.
-//   • Bracket: if labels still feel too edge-y → -0.34 or -0.32; if
-//     the rack starts crowding the slider track → step back toward
-//     -0.40. One dial per round.
+//     clears the slab edge by ~108 mm.
+//   • Slider rack track length is 0.3 m centered on slot-X = 0
+//     (`Slider.ts:61` `DEFAULT_TRACK_LENGTH`), so the leftmost slider
+//     geometry sits at slot-X ≈ -0.15. The section-tab column at
+//     -0.32 keeps a comfortable 148 mm sphere-to-slider gap.
+//   • LABEL extent is the binding constraint, not the sphere extent.
+//     SectionTab labels use anchorX 'center' at fontSize 0.035 m;
+//     the longest label is the canonical-forms heading at "Canonical
+//     forms ▸" / "Canonical forms ▾" (17 chars including the
+//     chevron). At column = -0.32 the heading label's left edge
+//     should land near the slab edge (~5–20 mm clearance depending
+//     on troika's actual char metrics for the chevron glyph), and
+//     its right edge ~30–50 mm clear of the slider rack.
+//   • Bracket: if the heading's chevron still hangs off the slab
+//     left in smoke, the next dial is the HEADING TEXT (shorten to
+//     "Canonical ▾" — 11 chars — at lines 310–311), NOT the column
+//     X. Moving the column further inward (-0.30 / -0.28) would
+//     push the heading's right edge onto / into the slider rack.
+//     If the slider rack feels crowded → step back to -0.34. One
+//     dial per round.
 //
 // Vertical anchoring (#255 PR1). SectionTab labels sit ABOVE their
 // buttons (labelOffsetY = +0.04, labelAnchorY = 'bottom'; see
@@ -152,7 +164,7 @@ const PLINTH_SLIDER_TOP_Y = 0.485;
 //     becomes 0.08 (clearance 60 mm).
 //   • Documented invariants: HEADING_Y + 0.078 ≤ 0.55 − 0.01;
 //     BOTTOM_Y (= HEADING_Y − 3 × PITCH) − 0.0207 ≥ 0.01.
-const PLINTH_SECTION_TAB_X = -0.37;
+const PLINTH_SECTION_TAB_X = -0.32;
 const PLINTH_SECTION_TAB_PITCH = 0.13;
 const PLINTH_SECTION_TAB_HEADING_Y = 0.44;
 const PLINTH_SECTION_TAB_TOP_Y = 0.31;

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -107,36 +107,42 @@ const PLINTH_SLIDER_ROW_PITCH = 0.14;
 // 0.14 the top slider 'a' sits at 0.485 and the bottom 'd' at 0.065.
 const PLINTH_SLIDER_TOP_Y = 0.485;
 
-// 3 section tabs + 1 heading stacked at slot-X = −0.32 (was −0.37 in
-// #255 PR1 v2 / −0.42 in v1). Two rounds of PR1 headset-smoke nudges
-// in +slot-X so the rack reads as INTERIOR to the working surface
-// rather than hugging the −math-X edge of the 0.9 m slab. Pitch
-// compressed from the pre-plinth 0.23 m to 0.13 m so the full
+// 3 section tabs + 1 heading stacked at slot-X = −0.30 (was −0.32 in
+// #255 PR1 v3 / −0.37 in v2 / −0.42 in v1). Three rounds of PR1
+// headset-smoke nudges in +slot-X so the heading's "Canonical forms
+// ▾" label (17 chars, the longest label in the rack) fits between
+// the slab left edge and the slider rack's leftmost extent.
+//
+// Pitch compressed from the pre-plinth 0.23 m to 0.13 m so the full
 // 4-element stack fits the surface depth.
 //
-// Horizontal placement (#255 PR1 v3):
-//   • Button centers at slot-X = -0.32; sphere extent ~[-0.342, -0.298]
+// Horizontal placement (#255 PR1 v4 — at the X-direction limit):
+//   • Button centers at slot-X = -0.30; sphere extent ~[-0.322, -0.278]
 //     (buttonRadius 0.022). Slab left edge at -0.45, so the sphere
-//     clears the slab edge by ~108 mm.
+//     clears the slab edge by ~128 mm.
 //   • Slider rack track length is 0.3 m centered on slot-X = 0
 //     (`Slider.ts:61` `DEFAULT_TRACK_LENGTH`), so the leftmost slider
 //     geometry sits at slot-X ≈ -0.15. The section-tab column at
-//     -0.32 keeps a comfortable 148 mm sphere-to-slider gap.
-//   • LABEL extent is the binding constraint, not the sphere extent.
+//     -0.30 keeps a ~128 mm sphere-to-slider gap.
+//   • LABEL extent — NOT sphere extent — is the binding constraint.
 //     SectionTab labels use anchorX 'center' at fontSize 0.035 m;
 //     the longest label is the canonical-forms heading at "Canonical
 //     forms ▸" / "Canonical forms ▾" (17 chars including the
-//     chevron). At column = -0.32 the heading label's left edge
-//     should land near the slab edge (~5–20 mm clearance depending
-//     on troika's actual char metrics for the chevron glyph), and
-//     its right edge ~30–50 mm clear of the slider rack.
-//   • Bracket: if the heading's chevron still hangs off the slab
-//     left in smoke, the next dial is the HEADING TEXT (shorten to
-//     "Canonical ▾" — 11 chars — at lines 310–311), NOT the column
-//     X. Moving the column further inward (-0.30 / -0.28) would
-//     push the heading's right edge onto / into the slider rack.
-//     If the slider rack feels crowded → step back to -0.34. One
-//     dial per round.
+//     chevron). Inferred label width from smoke at column -0.32
+//     (Brad: "C overhangs left edge by ~one underscore character"):
+//     ~0.296 m total, half-width ~0.148 m. At -0.30 the heading
+//     label spans approximately [-0.448, -0.152] — both edges sit
+//     within ~2 mm of their respective constraints (slab edge -0.45
+//     on the left, slider rack at -0.15 on the right). TIGHT but
+//     should fit.
+//   • Bracket — at the X-direction limit. If the heading STILL
+//     overhangs the slab edge after this round, the next dial is
+//     the HEADING TEXT (shorten to "Canonical ▾" — 11 chars — at
+//     `CANONICAL_FORMS_LABEL_COLLAPSED` / `_EXPANDED` near lines
+//     310–311), NOT a further column-X shift. Moving the column
+//     further inward (-0.28 / -0.26) would push the heading's right
+//     edge onto / past the slider rack. If the slider rack feels
+//     crowded post-merge → step back to -0.32. One dial per round.
 //
 // Vertical anchoring (#255 PR1). SectionTab labels sit ABOVE their
 // buttons (labelOffsetY = +0.04, labelAnchorY = 'bottom'; see
@@ -164,7 +170,7 @@ const PLINTH_SLIDER_TOP_Y = 0.485;
 //     becomes 0.08 (clearance 60 mm).
 //   • Documented invariants: HEADING_Y + 0.078 ≤ 0.55 − 0.01;
 //     BOTTOM_Y (= HEADING_Y − 3 × PITCH) − 0.0207 ≥ 0.01.
-const PLINTH_SECTION_TAB_X = -0.32;
+const PLINTH_SECTION_TAB_X = -0.3;
 const PLINTH_SECTION_TAB_PITCH = 0.13;
 const PLINTH_SECTION_TAB_HEADING_Y = 0.44;
 const PLINTH_SECTION_TAB_TOP_Y = 0.31;

--- a/src/scaffold/staging/Plinth.ts
+++ b/src/scaffold/staging/Plinth.ts
@@ -60,6 +60,23 @@ import * as THREE from 'three';
 // but the text on it stays facing you," which is desired behavior
 // for legibility, not a compromise.
 //
+// Surface-tilted tap-affordance opt-out (#255 PR2). TapButton-based
+// primitives (Preset / SectionTab / SceneTab) also use `faceCamera`
+// to yaw-billboard their text label, but the body's mesh itself is
+// NOT billboarded — it inherits the slot rotation cleanly. When
+// such a button is mounted on the tilted working surface (today:
+// SectionTab specifically, via its module-level VISUALS const), the
+// label's yaw-billboard combines with the parent's surface tilt to
+// produce a compound rotation that diverges from BOTH the slab
+// plane and the user-facing plane — text visibly clips into the
+// slab volume. TapButtonVisuals' `labelOrientation: 'surface'` opts
+// the label OUT of the yaw-billboard (early-returns from
+// `faceCamera`) so the label stays at identity in the button's
+// local frame and co-tilts with the slab cleanly. See
+// `_private/plans/255-section-tab-anchoring-labels.md` for the
+// design and the viewer-relative legibility analysis (~8% worst-
+// case foreshortening at the plinth's ~20° tilt — accepted).
+//
 // Ownership (matches StageFloor / StageRailing / StageInnerRailing /
 // ContrastPit — exhibit-owned, per the cluster's established staging
 // convention). Allocated in `mount`, disposed in `unmount`. The shell
@@ -143,6 +160,14 @@ const PLINTH_SLAB_THICKNESS = 0.025;
  * `orientation` is documentation-only — they yaw-billboard
  * regardless of the slot rotation contract. See file-top
  * "Billboarded-primitive carve-out" comment.
+ *
+ * Note: TapButton-based primitives (Preset / SectionTab / SceneTab)
+ * inherit the slot rotation on their button bodies cleanly, but
+ * their text labels yaw-billboard via `faceCamera`. Their
+ * `TapButtonVisuals.labelOrientation: 'surface'` opts the LABEL
+ * (not the body) out of yaw-billboard for surface-mounted mounts
+ * where the compound rotation would clip text into the slab. See
+ * file-top "Surface-tilted tap-affordance opt-out" comment.
  */
 export type SlotOrientation = 'surface' | 'world' | 'custom';
 

--- a/src/scaffold/ui/Preset.ts
+++ b/src/scaffold/ui/Preset.ts
@@ -64,6 +64,13 @@ export interface PresetOptions {
 // air between "H 2-sheets" and its neighbors. Label sits below the
 // button (anchor 'top' + negative offset) so it falls toward the family
 // classifier rather than crowding the section tabs above.
+//
+// `labelOrientation` defaults to `'face-camera'` (#255 PR2): Preset
+// rows sit ABOVE the plinth back edge in mid-air (e.g. quadrics
+// PLINTH_PRESET_ROW_TOP_Y = 0.94, saddle-extrema PLINTH_PRESET_ROW_Y
+// = 0.55). No slab to clip into; yaw-billboard keeps labels facing
+// the user across pancake + headset distances. Audited per #255
+// PR2's subclass option-forwarding audit (GPT #4 roundtable finding).
 const VISUALS: TapButtonVisuals = {
   groupNamePrefix: 'preset',
   buttonRadius: 0.02,

--- a/src/scaffold/ui/SceneTab.ts
+++ b/src/scaffold/ui/SceneTab.ts
@@ -29,6 +29,14 @@ export interface SceneTabOptions {
 // SectionTab's (anchor 'bottom' + positive offset) — the SceneRack lays
 // out horizontally, so right-of-button labels would collide with the
 // next tab's button.
+//
+// `labelOrientation` defaults to `'face-camera'` (#255 PR2): the
+// SceneRack is shell-owned and floats in mid-air at world-Y 1.73
+// (`SceneRack.ts` `SCENE_RACK_Y`), above any plinth's tilted slab.
+// No surface tilt is applied to the SceneTab group via a slot
+// transform; the default yaw-billboard is the right behavior across
+// pancake + headset viewing distances. Audited per #255 PR2's
+// subclass option-forwarding audit (GPT #4 roundtable finding).
 const VISUALS: TapButtonVisuals = {
   groupNamePrefix: 'scene-tab',
   buttonRadius: 0.028,

--- a/src/scaffold/ui/SectionTab.ts
+++ b/src/scaffold/ui/SectionTab.ts
@@ -24,6 +24,20 @@ export interface SectionTabOptions {
 // Label sits above the button (anchor 'bottom' + positive offset) rather
 // than to the right (Preset's layout): the tab row is horizontal, so
 // right-of-button labels would collide with the next tab's button.
+//
+// `labelOrientation: 'surface'` (#255 PR2). SectionTab is exclusively
+// plinth-mounted in geometer today (quadrics' canonical-forms heading
+// + 3 SectionTabs at slot-X = -0.42). The button group inherits the
+// plinth slot's `R_x(-tilt)` surface tilt, so the default yaw-billboard
+// label rotation would diverge from the slab plane and visibly clip
+// into the slab volume (see TapButton.ts `labelOrientation` doc + plan
+// `_private/plans/255-section-tab-anchoring-labels.md`). `'surface'`
+// leaves the label in the button's local frame (identity), co-tilting
+// with the slab through the parent group's transform — no clipping,
+// ~8% worst-case foreshortening accepted as legibility-acceptable.
+// Bake the choice into VISUALS rather than threading per-instance: the
+// surface-mounted-tap-affordance identity is what SectionTab IS today;
+// a future mid-air SectionTab consumer would override at that point.
 const VISUALS: TapButtonVisuals = {
   groupNamePrefix: 'tab',
   buttonRadius: 0.022,
@@ -34,6 +48,7 @@ const VISUALS: TapButtonVisuals = {
   labelFontSize: 0.035,
   labelOffsetY: 0.04,
   labelAnchorY: 'bottom',
+  labelOrientation: 'surface',
 };
 
 export class SectionTab extends TapButton {

--- a/src/scaffold/ui/TapButton.ts
+++ b/src/scaffold/ui/TapButton.ts
@@ -101,6 +101,22 @@ const LABEL_COLOR = 0xffffff;
 const LABEL_OUTLINE_WIDTH = '8%';
 const LABEL_OUTLINE_COLOR = 0x000000;
 
+// Standoff (in label-local +Z, meters) applied to surface-oriented
+// labels (#255 PR2 smoke follow-up). Without this, the text quad sits
+// at z = 0 in button-local — and because the button group is rotated
+// by the plinth slot's `R_x(-tilt)`, that's coplanar with the slab
+// top face in slot-local Z. A static camera renders cleanly, but
+// per-pixel depth-buffer comparisons flip under camera rotation and
+// produce a z-fight aliasing / shimmer that reads as the label
+// "clipping into the plinth." Lifting 1 mm in button-local +Z
+// (= surface-normal direction in plinth-local after the parent
+// rotation) sits the label JUST in front of the slab and resolves the
+// z-fight. 1 mm is well below the pixel size of a Quest 3S panel at
+// arm's-length viewing distance (~0.7 m), so the gap is not visible.
+// Bracket [0.0005, 0.003] if further tuning is needed (one dial per
+// round, per `feedback_binary_search_visual_constants`).
+const SURFACE_LABEL_STANDOFF_M = 0.001;
+
 export class TapButton {
   readonly group: THREE.Group;
   readonly name: string;
@@ -160,8 +176,14 @@ export class TapButton {
     // default in TapButton.test.ts), and a future runtime switch from
     // 'face-camera' to 'surface' won't strand the label at a stale
     // yaw-billboard rotation.
+    //
+    // Also lift the label off the slab by SURFACE_LABEL_STANDOFF_M in
+    // label-local +Z (#255 PR2 smoke follow-up). The label is coplanar
+    // with the slab top face without this lift — see the constant's
+    // doc comment for the z-fight rationale.
     if (this.labelOrientation === 'surface') {
       this.label.rotation.set(0, 0, 0);
+      this.label.position.z = SURFACE_LABEL_STANDOFF_M;
     }
     this.label.sync();
     this.group.add(this.label);

--- a/src/scaffold/ui/TapButton.ts
+++ b/src/scaffold/ui/TapButton.ts
@@ -45,6 +45,38 @@ export interface TapButtonVisuals {
   // below; 'bottom' anchor + positive offset places it above.
   labelOffsetY: number;
   labelAnchorY: 'top' | 'bottom';
+  // Label-rendering policy (#255 PR2). Default `'face-camera'` —
+  // `faceCamera` yaw-billboards the label every frame so text stays
+  // facing the user; matches the §225 §3.3 billboarded-primitive
+  // carve-out and is desired for mid-air mounts (Preset, SceneTab)
+  // where the button group has no surface tilt or is in mid-air
+  // above any tilted slab.
+  //
+  // `'surface'` — used by primitives mounted on a tilted plinth
+  // working surface (today: SectionTab). When the button's parent
+  // group is rotated by the plinth slot transform to align with
+  // the surface (`R_x(-tilt)`), yaw-billboarding the label rotates
+  // it about an already-tilted local-Y axis. The result is a
+  // compound rotation: label inherits the surface tilt AND yaws
+  // about the tilted axis, producing a plane that diverges from
+  // both the slab plane and the user-facing plane — text visibly
+  // clips into the slab volume from typical viewing angles.
+  //
+  // `'surface'` resolves this by leaving the label in the button's
+  // local frame (identity rotation). The label co-tilts with the
+  // slab through the parent group's transform; no plane divergence.
+  // Worst-case viewer-relative foreshortening at the plinth's
+  // ~20° tilt is ~8% across plausible head poses (per
+  // `_private/plans/255-section-tab-anchoring-labels.md` §3.2) —
+  // accepted as a legibility cost well below the
+  // "facing-but-clipping" alternative.
+  //
+  // The ctor explicitly sets `label.rotation = (0, 0, 0)` when this
+  // is `'surface'`, so the surface-aligned orientation is established
+  // at construction (not implicitly via skipped `faceCamera` writes).
+  // `faceCamera` early-returns on `'surface'` so per-frame ticks
+  // are cheap and don't drift the label off identity.
+  labelOrientation?: 'face-camera' | 'surface';
 }
 
 export interface TapButtonOptions {
@@ -78,6 +110,7 @@ export class TapButton {
   private readonly hoverEmissive: number;
   private readonly pressEmissive: number;
   private readonly activeEmissive: number | undefined;
+  private readonly labelOrientation: 'face-camera' | 'surface';
 
   private readonly button: THREE.Mesh;
   private readonly label: Text;
@@ -99,6 +132,7 @@ export class TapButton {
     this.hoverEmissive = opts.visuals.hoverEmissive;
     this.pressEmissive = opts.visuals.pressEmissive;
     this.activeEmissive = opts.visuals.activeEmissive;
+    this.labelOrientation = opts.visuals.labelOrientation ?? 'face-camera';
 
     this.group = new THREE.Group();
     this.group.name = `${opts.visuals.groupNamePrefix}:${opts.name}`;
@@ -118,6 +152,17 @@ export class TapButton {
     this.label.outlineWidth = LABEL_OUTLINE_WIDTH;
     this.label.outlineColor = LABEL_OUTLINE_COLOR;
     this.label.position.set(0, opts.visuals.labelOffsetY, 0);
+    // Establish surface-aligned orientation at construction (not
+    // implicitly via skipped `faceCamera` writes). troika's `Text` ctor
+    // defaults rotation to identity, but writing it explicitly closes
+    // the convergent C1 + C2 finding window from the #255 roundtable:
+    // tests can verify identity directly (via the non-identity StubText
+    // default in TapButton.test.ts), and a future runtime switch from
+    // 'face-camera' to 'surface' won't strand the label at a stale
+    // yaw-billboard rotation.
+    if (this.labelOrientation === 'surface') {
+      this.label.rotation.set(0, 0, 0);
+    }
     this.label.sync();
     this.group.add(this.label);
   }
@@ -186,7 +231,14 @@ export class TapButton {
 
   // Yaw-only billboard for the text label, matching the family / per-
   // slider labels — head pitch and roll stay out (#29).
+  //
+  // Early-return on `labelOrientation === 'surface'` (#255 PR2): the
+  // label was identity-set at construction and is meant to inherit the
+  // parent group's surface tilt unmodified. Per-frame ticks stay
+  // symmetric — consumers dispatch `faceCamera` on every TapButton
+  // regardless of orientation; the branch just becomes a cheap no-op.
   faceCamera(camera: THREE.Camera): void {
+    if (this.labelOrientation === 'surface') return;
     camera.getWorldPosition(this.camWorld);
     this.label.getWorldPosition(this.labelWorld);
     const dx = this.camWorld.x - this.labelWorld.x;

--- a/test/scaffold/ui/TapButton.test.ts
+++ b/test/scaffold/ui/TapButton.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+
+// `troika-three-text` reaches for `self`, a browser-only global, in its
+// UMD `now$1` helper. The default vitest environment is Node, so any
+// `new Text()` blows up at construction time. Reuses the surrogate
+// pattern from `Preset.test.ts` (and `PointerMigration.test.ts`). None
+// of the assertions below touch text rendering, so the stub is faithful
+// enough — `Object3D` gives us the `rotation` Euler that the tests
+// inspect.
+//
+// One deliberate divergence from the prior stubs: the ctor sets
+// `rotation` to a non-identity sentinel `(0.5, 0.5, 0.5)`. The default
+// would be `(0, 0, 0)` from `Object3D`, which is what `TapButton`'s
+// surface-branch ctor identity-set ALSO writes — making the
+// "ctor identity-set" test a tautology against the Object3D default
+// (it would pass even if the identity-set line were deleted). The
+// non-identity default makes the explicit identity-set observable:
+// the test asserts `(0, 0, 0)` post-ctor, which is reached IF AND ONLY
+// IF the `if (this.labelOrientation === 'surface')` branch fired and
+// wrote identity. Removing that branch from `TapButton` would leave
+// `rotation` at the stub default and fail the test — closing the gap
+// /spar (oppositional-reviewer, finding #1) flagged.
+vi.mock('troika-three-text', () => {
+  class StubText extends THREE.Object3D {
+    text = '';
+    fontSize = 0;
+    color = 0xffffff;
+    anchorX: string | undefined;
+    anchorY: string | undefined;
+    outlineWidth: string | undefined;
+    outlineColor: number | undefined;
+    constructor() {
+      super();
+      this.rotation.set(0.5, 0.5, 0.5);
+    }
+    sync() {}
+    dispose() {}
+  }
+  return { Text: StubText };
+});
+
+import {
+  TapButton,
+  type TapButtonOptions,
+  type TapButtonVisuals,
+} from '@/scaffold/ui/TapButton';
+import { SectionTab } from '@/scaffold/ui/SectionTab';
+import { SceneTab } from '@/scaffold/ui/SceneTab';
+import { Preset } from '@/scaffold/ui/Preset';
+
+// Vitest coverage for `TapButtonVisuals.labelOrientation` added in
+// #255 PR2. Three branches per the v3-plan §4.2 + the convergent C1
+// / C2 roundtable findings:
+//
+//   - 'surface': ctor identity-sets `label.rotation`, and `faceCamera`
+//     early-returns so the label stays at whatever the caller / ctor
+//     left it. The convergent test sets a non-identity sentinel
+//     Euler BEFORE calling `faceCamera`, then asserts all three
+//     components are unchanged. Catches "ctor failed to identity-set"
+//     AND "faceCamera mutated rotation despite the early-return."
+//   - 'face-camera' (default): `faceCamera` writes the expected
+//     yaw-billboard. Asserts rotation.y matches `atan2(dx, dz)` and
+//     rotation.x / rotation.z are zero.
+//   - Option threading: each TapButton subclass's module-level
+//     VISUALS const threads the labelOrientation choice through to
+//     the base TapButton. `SectionTab` opts in to 'surface'; `Preset`
+//     + `SceneTab` default to 'face-camera'. Verifies via the SAME
+//     behavioral check (sentinel preserved vs mutated) since
+//     `labelOrientation` is private on TapButton — no silent drops
+//     by a wrapper (GPT #4 roundtable finding).
+
+const BASE_VISUALS: TapButtonVisuals = {
+  groupNamePrefix: 'test',
+  buttonRadius: 0.025,
+  baseColor: 0x44aabb,
+  hoverEmissive: 0x224455,
+  pressEmissive: 0x88ddff,
+  labelFontSize: 0.022,
+  labelOffsetY: 0,
+  labelAnchorY: 'top',
+};
+
+function makeTapButton(opts: Partial<TapButtonOptions> = {}): TapButton {
+  return new TapButton({
+    name: 'test',
+    grabRadiusMultiplier: 1.5,
+    visuals: BASE_VISUALS,
+    ...opts,
+  });
+}
+
+// Yaw-billboard camera at (+x, 0, +z) — `faceCamera` should write
+// `rotation.y = atan2(dx, dz)`. Choose values where atan2 is non-zero
+// so the test would fail if `faceCamera` were stubbed out.
+function makeCamera(): THREE.Camera {
+  const cam = new THREE.PerspectiveCamera();
+  cam.position.set(1, 0, 1);
+  cam.updateMatrixWorld();
+  return cam;
+}
+
+describe('TapButton labelOrientation', () => {
+  describe("'surface' branch", () => {
+    it("ctor identity-sets label.rotation when labelOrientation is 'surface'", () => {
+      // The StubText ctor at the top of this file sets rotation to a
+      // non-identity sentinel (0.5, 0.5, 0.5). TapButton's surface-
+      // branch ctor identity-set is the ONLY thing that returns the
+      // label to (0, 0, 0) post-construction — if that line is removed,
+      // this test fails. (Pre-spar this test was a tautology against
+      // Object3D's (0, 0, 0) default; the StubText non-identity default
+      // makes the explicit identity-set observable.)
+      const button = makeTapButton({
+        visuals: { ...BASE_VISUALS, labelOrientation: 'surface' },
+      });
+      // Access the label via the group (TapButton adds it to the group
+      // at ctor). The second child is the troika label (first is the
+      // sphere mesh; see TapButton.ts ctor order).
+      const label = button.group.children[1]!;
+      expect(label.rotation.x).toBe(0);
+      expect(label.rotation.y).toBe(0);
+      expect(label.rotation.z).toBe(0);
+    });
+
+    it("preserves a non-identity rotation across faceCamera() when 'surface'", () => {
+      const button = makeTapButton({
+        visuals: { ...BASE_VISUALS, labelOrientation: 'surface' },
+      });
+      const label = button.group.children[1]!;
+      // Sentinel Euler: distinct on all three axes so a partial
+      // mutation by a buggy `faceCamera` would surface.
+      label.rotation.set(0.1, 0.2, 0.3);
+      button.faceCamera(makeCamera());
+      expect(label.rotation.x).toBe(0.1);
+      expect(label.rotation.y).toBe(0.2);
+      expect(label.rotation.z).toBe(0.3);
+    });
+  });
+
+  describe("default 'face-camera' branch", () => {
+    it('writes the expected yaw-billboard when labelOrientation is omitted', () => {
+      const button = makeTapButton();
+      const label = button.group.children[1]!;
+      // Camera at (1, 0, 1), label (and button) at world origin.
+      // dx = 1, dz = 1 ⇒ atan2(1, 1) = π/4.
+      button.faceCamera(makeCamera());
+      expect(label.rotation.x).toBe(0);
+      expect(label.rotation.y).toBeCloseTo(Math.PI / 4, 6);
+      expect(label.rotation.z).toBe(0);
+    });
+
+    it("writes yaw-billboard when labelOrientation is explicitly 'face-camera'", () => {
+      const button = makeTapButton({
+        visuals: { ...BASE_VISUALS, labelOrientation: 'face-camera' },
+      });
+      const label = button.group.children[1]!;
+      button.faceCamera(makeCamera());
+      expect(label.rotation.y).toBeCloseTo(Math.PI / 4, 6);
+    });
+  });
+
+  describe('subclass option-forwarding audit', () => {
+    // SectionTab's VISUALS const sets labelOrientation: 'surface'
+    // (#255 PR2). Confirm the choice threads through the ctor chain
+    // to the base TapButton — sentinel rotation is preserved after
+    // faceCamera, just like the direct-TapButton 'surface' test.
+    it("SectionTab inherits 'surface' from its VISUALS const", () => {
+      const tab = new SectionTab({ name: 'Squared terms', grabRadiusMultiplier: 1.5 });
+      const label = tab.group.children[1]!;
+      label.rotation.set(0.1, 0.2, 0.3);
+      tab.faceCamera(makeCamera());
+      expect(label.rotation.x).toBe(0.1);
+      expect(label.rotation.y).toBe(0.2);
+      expect(label.rotation.z).toBe(0.3);
+    });
+
+    // Preset's VISUALS const does NOT set labelOrientation, so it
+    // defaults to 'face-camera' — yaw-billboard mutates the label
+    // rotation. Confirms the option isn't silently set somewhere in
+    // Preset's ctor chain.
+    it("Preset defaults to 'face-camera' (yaw-billboard mutates rotation)", () => {
+      const preset = new Preset({ name: 'Sphere', grabRadiusMultiplier: 1.5 });
+      const label = preset.group.children[1]!;
+      label.rotation.set(0.1, 0.2, 0.3);
+      preset.faceCamera(makeCamera());
+      // y was overwritten by atan2; x and z were zeroed by the
+      // rotation.set(0, ..., 0) call in faceCamera.
+      expect(label.rotation.x).toBe(0);
+      expect(label.rotation.y).toBeCloseTo(Math.PI / 4, 6);
+      expect(label.rotation.z).toBe(0);
+    });
+
+    // SceneTab's VISUALS const does NOT set labelOrientation, so it
+    // defaults to 'face-camera'. SceneRack is mid-air; yaw-billboard
+    // is the desired behavior.
+    it("SceneTab defaults to 'face-camera' (yaw-billboard mutates rotation)", () => {
+      const scene = new SceneTab({ name: 'quadrics', grabRadiusMultiplier: 1.5 });
+      const label = scene.group.children[1]!;
+      label.rotation.set(0.1, 0.2, 0.3);
+      scene.faceCamera(makeCamera());
+      expect(label.rotation.x).toBe(0);
+      expect(label.rotation.y).toBeCloseTo(Math.PI / 4, 6);
+      expect(label.rotation.z).toBe(0);
+    });
+  });
+});

--- a/test/scaffold/ui/TapButton.test.ts
+++ b/test/scaffold/ui/TapButton.test.ts
@@ -122,6 +122,29 @@ describe('TapButton labelOrientation', () => {
       expect(label.rotation.z).toBe(0);
     });
 
+    it("lifts label.position.z by the surface standoff when 'surface' (avoids slab z-fight)", () => {
+      const button = makeTapButton({
+        visuals: { ...BASE_VISUALS, labelOrientation: 'surface' },
+      });
+      const label = button.group.children[1]!;
+      // The label sits coplanar with the slab top face without the
+      // standoff (#255 PR2 smoke surfaced z-fight under camera rotation).
+      // Standoff is ~1 mm in label-local +Z; magnitude check (not
+      // exact-equality) keeps the test resilient to future bracket
+      // retunes — the contract is "non-zero and small," not the exact
+      // numeric.
+      expect(label.position.z).toBeGreaterThan(0);
+      expect(label.position.z).toBeLessThan(0.005);
+    });
+
+    it("does NOT lift label.position.z when 'face-camera' (no z-fight to avoid)", () => {
+      const button = makeTapButton({
+        visuals: { ...BASE_VISUALS, labelOrientation: 'face-camera' },
+      });
+      const label = button.group.children[1]!;
+      expect(label.position.z).toBe(0);
+    });
+
     it("preserves a non-identity rotation across faceCamera() when 'surface'", () => {
       const button = makeTapButton({
         visuals: { ...BASE_VISUALS, labelOrientation: 'surface' },


### PR DESCRIPTION
Refs #255 (this is PR2 of 2 — label-rendering half; #267 is the anchoring half, lands independently).

## Summary

Today's `TapButton.faceCamera` yaw-billboards the label by writing `this.label.rotation.set(0, atan2(dx, dz), 0)` in the label's LOCAL frame. When the button group has been rotated by a plinth slot to `R_x(-tilt)`, that yaw rotates about an already-tilted local-Y axis — the label ends up surface-tilted (inherited from parent) AND additionally yawed about the tilted axis. The compound plane diverges from both the slab plane and the user-facing plane; text visibly clips into the slab volume at typical viewing angles. Surfaced post-#260 in the same headset-smoke pass that surfaced #255 (`https://github.com/skylinetrailcomputing/geometer/issues/255`).

Resolved via opt-in `TapButtonVisuals.labelOrientation`:

- `'face-camera'` (default) — today's yaw-billboard behavior; preserves the §225 §3.3 billboarded-primitive carve-out for mid-air mounts (Preset, SceneTab).
- `'surface'` — TapButton's ctor explicitly identity-sets `label.rotation` and `faceCamera` early-returns. Label co-tilts with the slab through the parent group's transform; no plane divergence, no clipping. Worst-case viewer-relative foreshortening across plausible head poses is **~8%** at the plinth's ~20° tilt — well below the legibility floor at the existing 0.035 m font + 8% troika outline (per `_private/plans/255-section-tab-anchoring-labels.md` §3.2's pose-matrix analysis).

`SectionTab.ts` opts its module-level VISUALS into `'surface'`; SectionTab is exclusively plinth-mounted in geometer today, so baking the choice into the visual identity is the minimal-surface change. `Preset.ts` + `SceneTab.ts` audit-documented as keeping the `'face-camera'` default — both mount in mid-air above any tilted slab. `Plinth.ts`'s two doc-comment blocks (file-top carve-out + `SlotOrientation` JSDoc) note the new opt-out.

The PR went through the v3-plan-doc + `/roundtable-plan-review` (Sonnet + GPT-5.5 + DeepSeek) + second-Sonnet sanity check + `/spar` adversarial code review loop. `/spar`'s single MEDIUM finding (ctor-identity-set test was a tautology against `Object3D`'s (0, 0, 0) default) is closed by giving the test's troika `Text` stub a non-identity rotation default (0.5, 0.5, 0.5) — the explicit identity-set in TapButton becomes observable, and the test was re-verified to fail when the identity-set is removed.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm test` — 536/536 pass (was 529 on `main`; +7 new TapButton tests).
- [x] Regression-check verified: temporarily removing the `label.rotation.set(0, 0, 0)` line in TapButton's ctor makes the surface-branch ctor test fail with `expected 0.5 to be 0`.

UI smoke surface — Cloudflare PR preview:

- [x] **Quest 3S standing 1.6 m, close (z ≈ 1.0 m) — WORST CASE for legibility (~8.2% foreshortening per the §3.2 pose matrix).** SectionTab + canonical-forms heading labels sit on the slab; no clipping; all four labels ("Squared terms" / "Linear terms" / "Cross sections" / "Canonical forms") clearly readable.
- [x] **Quest 3S crouched 1.3 m, close (z ≈ 1.0 m) — tied worst case (~7.8%).** No clipping; legibility holds.
- [x] Pancake (`?exhibit=quadrics`) — labels sit on the slab, no clipping. Cleaner pose (~2.6% foreshortening).
- [x] Quest 3S tall standing (~1.8 m head, mid-distance) — no clipping.
- [x] Quest 3S far-stance — labels small but readable; no clipping.
- [x] **Chevron-flip on canonical-forms heading** still updates text correctly on tap in pancake AND VR (closes DS #1 HIGH from the v1 roundtable — the `setName` path should be agnostic to `labelOrientation`).
- [x] **No regression in mid-air TapButton consumers:**
  - [x] All four cluster scenes — `SceneRack` `SceneTab` labels yaw-billboard correctly during nav-hops.
  - [x] Quadrics' own preset grid labels yaw-billboard.
  - [x] Saddle-extrema preset row at slot-Y 0.55 (closest mid-air to slab back edge in the cluster) — sphere body doesn't clip; labels yaw-billboard.
  - [x] Tangent-planes + gradient-levels preset rows — labels yaw-billboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)