### PR TITLE
feat(staging): panel-backed readouts on the plinth (#252)

### DIFF
--- a/src/exhibits/gradient-levels/GradientLevelsReadout.ts
+++ b/src/exhibits/gradient-levels/GradientLevelsReadout.ts
@@ -1,6 +1,6 @@
-import * as THREE from 'three';
 import { Text } from 'troika-three-text';
 import type { MathVec3 } from '@/scaffold/math/frames';
+import { PanelReadout } from '@/scaffold/ui/PanelReadout';
 import {
   READOUT_FONT_SIZE,
   READOUT_LINE_PITCH,
@@ -78,9 +78,27 @@ const SEPARATOR_COLOR = 0xffffff;
 const AXIS_X = 0;
 const AXIS_Z = 2;
 
-export class GradientLevelsReadout {
-  readonly group: THREE.Group;
+// Plinth panel-backing dims (#252 / E1.4c). Computed from this readout's
+// own em constants × READOUT_FONT_SIZE per plan §3.3 methodology — see
+// the envelope-assertion test in PanelReadout.test.ts for the bound.
+//
+// Worst-case line: top — PREFIX_GRAD_EM(2.8) + 3 × NUMERIC_SIGNED_EM(2.6)
+// + 2 × COMMA_EM(1.0) + CLOSE_PAREN_EM(1.0)
+//                 = 2.8 + 7.8 + 2.0 + 1.0 = 13.6 em
+//                 × 0.028 = 0.381 m
+// Half-width = 0.381 / 2 + 0.012 padding = 0.202 → rounded 0.200.
+//
+// Worst-case top-line string corpus:
+//   `∇f = ( -2.50 , -2.50 , -2.50 )`
+//
+// Bracket [0.195, 0.220]; first-pass smoke-tunable per
+// feedback_staging_dimensions_first_pass. One dial per round.
+export const READOUT_PANEL_HALF_WIDTH_GRADIENT_LEVELS = 0.2;
 
+// 2-line layout, rows at ±LINE_PITCH/2 = ±0.03; glyph + padding → 0.055.
+export const READOUT_PANEL_HALF_HEIGHT_GRADIENT_LEVELS = 0.055;
+
+export class GradientLevelsReadout extends PanelReadout {
   private readonly fontSize: number;
 
   // Top-line component numerics: [∂f/∂x, ∂f/∂y, ∂f/∂z].
@@ -98,21 +116,18 @@ export class GradientLevelsReadout {
   private bottomNumericCache = '';
 
   private lastSyncMs = 0;
-
-  // Hoisted out of `faceCamera` so per-frame billboarding does no
-  // allocation. Same convention as `TangentPlaneReadout`.
-  private readonly camWorld = new THREE.Vector3();
-  private readonly groupWorld = new THREE.Vector3();
+  // Visibility-bootstrap guard (#252 §3.6 cloak normalization). Boots
+  // `group.visible = false` (set by PanelReadout base ctor); flips to
+  // `true` AFTER the first `setValues` writes real text + .sync()s,
+  // not before. Matches the EquationReadout / TangentPlaneReadout
+  // throttle-bypass-on-first-call pattern. Avoids a first-frame paint
+  // where the dark back-plate would render BEFORE the numeric Text
+  // geometries resolve (#252 plan §3.6).
+  private hasBootstrapped = false;
 
   constructor(opts: GradientLevelsReadoutOptions) {
+    super('gradient-levels-readout');
     this.fontSize = opts.fontSize ?? READOUT_FONT_SIZE;
-
-    this.group = new THREE.Group();
-    this.group.name = 'gradient-levels-readout';
-    // Stay hidden until the first setValues() populates the numerics.
-    // The first update() tick uncloaks; deep-link/state-restore to a
-    // miss state stays hidden gracefully.
-    this.group.visible = false;
 
     const numericSignedW = NUMERIC_SIGNED_EM * this.fontSize;
     const numericUnsignedW = NUMERIC_UNSIGNED_EM * this.fontSize;
@@ -185,6 +200,13 @@ export class GradientLevelsReadout {
     this.bottomNumeric = this.makeNumericText(this.fontSize, opts.magnitudeColor);
     this.bottomNumeric.position.set(cursor + numericUnsignedW / 2, bottomY, 0);
     this.group.add(this.bottomNumeric);
+
+    // Plinth back-plate (#252 / E1.4c). See parent §3.5 v3 (option-c)
+    // billboarding lock; back-plate inherits per-frame yaw transitively.
+    this.createPanel({
+      halfWidth: READOUT_PANEL_HALF_WIDTH_GRADIENT_LEVELS,
+      halfHeight: READOUT_PANEL_HALF_HEIGHT_GRADIENT_LEVELS,
+    });
   }
 
   private makeNumericText(fontSize: number, color: number): Text {
@@ -216,16 +238,22 @@ export class GradientLevelsReadout {
    * skips the .text + .sync() write when the formatted string hasn't
    * changed.
    *
-   * On first call, uncloaks `group.visible = true` — the readout boots
-   * hidden so it can't paint empty strings before the first hit frame.
+   * Cloak normalization (#252 §3.6): `group.visible = true` flips AFTER
+   * the first .sync()-resolving write — the throttle gate is bypassed
+   * on the bootstrap call (`hasBootstrapped` is false) so the first
+   * call always paints. Same shape as EquationReadout / TangentPlaneReadout.
    */
   setValues(gradient: MathVec3): void {
-    // First-call uncloak: before throttle gate so the readout becomes
-    // visible on the first tick regardless of throttle timing.
-    if (!this.group.visible) this.group.visible = true;
-
     const now = performance.now();
-    if (now - this.lastSyncMs < READOUT_SYNC_INTERVAL_MS) return;
+    // First call bypasses the throttle so the readout uncloaks with
+    // real text on frame 1 even if `lastSyncMs` was set elsewhere (in
+    // practice `lastSyncMs = 0` and `now - 0` is always >> 33 ms).
+    if (
+      this.hasBootstrapped &&
+      now - this.lastSyncMs < READOUT_SYNC_INTERVAL_MS
+    ) {
+      return;
+    }
     this.lastSyncMs = now;
 
     const strings: GradientLevelsReadoutStrings = formatGradientLevelsReadout(gradient);
@@ -244,21 +272,22 @@ export class GradientLevelsReadout {
       this.bottomNumeric.text = strings.magnitude;
       this.bottomNumeric.sync();
     }
+
+    // First-call uncloak — after all .sync() writes above. Flipping
+    // `group.visible = true` here paints the first real frame with
+    // both panel + populated text, not panel + empty text.
+    if (!this.hasBootstrapped) {
+      this.group.visible = true;
+      this.hasBootstrapped = true;
+    }
   }
 
-  // Yaw-only billboard, matching TangentPlaneReadout / EquationReadout /
-  // Label. World-up stays world-up; head pitch and roll don't tilt.
-  faceCamera(camera: THREE.Camera): void {
-    camera.getWorldPosition(this.camWorld);
-    this.group.getWorldPosition(this.groupWorld);
-    const dx = this.camWorld.x - this.groupWorld.x;
-    const dz = this.camWorld.z - this.groupWorld.z;
-    this.group.rotation.set(0, Math.atan2(dx, dz), 0);
-  }
+  // Yaw-only billboard inherited from PanelReadout base (#252).
 
   dispose(): void {
     for (const t of this.topNumerics) t.dispose();
     this.bottomNumeric.dispose();
     for (const t of this.separators) t.dispose();
+    this.disposePanel();
   }
 }

--- a/src/exhibits/gradient-levels/SPEC.md
+++ b/src/exhibits/gradient-levels/SPEC.md
@@ -478,3 +478,32 @@ slot-Y axis above the rack.
 `scaffold/ui/clusterRackTokens.ts`. The pre-plinth mid-air `2.75`
 constant was deleted at PR2 (#251) once all four cluster scenes
 ported onto the plinth.
+
+## Plinth panel-backing (#252)
+
+`GradientLevelsReadout` extends the shared `PanelReadout` base
+(`scaffold/ui/PanelReadout.ts`) which contributes the cluster-shared
+THREE.Group + boot-cloak + per-frame yaw `faceCamera` + dark
+`MeshBasicMaterial` back-plate quad.
+
+Per parent plan #225 §3.5 v3 lock (option-c), the back-plate is a
+child of the readout's group, inheriting the yaw-billboard
+transitively — panel + text face the user together.
+
+**Panel dimensions:** `READOUT_PANEL_HALF_WIDTH_GRADIENT_LEVELS =
+0.200 m`, `READOUT_PANEL_HALF_HEIGHT_GRADIENT_LEVELS = 0.055 m`.
+Computed from worst-case top line `PREFIX_GRAD_EM (2.8) + 3 ×
+NUMERIC_SIGNED_EM (2.6) + 2 × COMMA_EM (1.0) + CLOSE_PAREN_EM (1.0)
+= 13.6 em × 0.028 = 0.381 m`, half + 0.012 m padding = 0.202 → 0.200.
+Envelope test in `test/scaffold/ui/PanelReadout.test.ts` locks
+against formatter drift. Bracket [0.195, 0.220]; smoke-tunable.
+
+**Cloak normalization (#252 §3.6).** GradientLevelsReadout's
+`setValues()` was restructured at PR3 to match the
+Equation/TangentPlane pattern — added a `hasBootstrapped: boolean`
+field, replaced the pre-throttle `if (!this.group.visible)
+this.group.visible = true;` with a post-`.sync()` block guarded by
+`hasBootstrapped`, and gated the throttle return with
+`this.hasBootstrapped && ...` so the first call always paints.
+Without this, the dark back-plate would render BEFORE the numeric
+Text geometries resolve on first uncloak.

--- a/src/exhibits/quadrics/EquationReadout.ts
+++ b/src/exhibits/quadrics/EquationReadout.ts
@@ -1,6 +1,6 @@
-import * as THREE from 'three';
 import { Text } from 'troika-three-text';
 import { formatSignedMagnitude } from '@/scaffold/ui/formatSignedMagnitude';
+import { PanelReadout } from '@/scaffold/ui/PanelReadout';
 import {
   READOUT_FONT_SIZE,
   READOUT_LINE_PITCH,
@@ -87,9 +87,31 @@ const BOTTOM_NON_D_SLOTS: readonly number[] = [SLOT_U, SLOT_V, SLOT_W];
 const TOP_SEPARATOR_POOL = 3;
 const BOTTOM_SEPARATOR_POOL = 3;
 
-export class EquationReadout {
-  readonly group: THREE.Group;
+// Plinth panel-backing dims (#252 / E1.4c). Computed from this readout's
+// own em constants × READOUT_FONT_SIZE per plan §3.3 methodology — see
+// the envelope-assertion test in PanelReadout.test.ts for the bound.
+//
+// Worst-case line: bottom, all-non-d slots visible — 4 numerics + 3
+// separators = 4 × NUMERIC_SLOT_EM(2.6) + 3 × SEPARATOR_SLOT_EM(2.4)
+//             = 10.4 + 7.2 = 17.6 em × 0.028 m/em = 0.493 m
+// Half-width = 0.493 / 2 + 0.012 padding = 0.258 → rounded 0.260.
+//
+// Worst-case strings (corpus this constant covers):
+//   bottom: `-2.50 u + -2.50 v + -2.50 w = -2.50`
+//   top:    `-2.50 x² + -2.50 y² + -2.50 z²` (narrower than bottom)
+//
+// First-pass smoke-tunable per feedback_staging_dimensions_first_pass.
+// Bracket [0.255, 0.280]; one dial per round (feedback_binary_search_
+// visual_constants). If smoke shows clipping → bump up; if too loose →
+// shrink; if a formatter changes worst-case width, the envelope test
+// fires.
+export const READOUT_PANEL_HALF_WIDTH_EQUATION = 0.26;
 
+// 2-line layout: rows at ±LINE_PITCH/2 = ±0.03; glyph half-height
+// ~0.014; padding 0.008. Total = 0.052 → rounded 0.055.
+export const READOUT_PANEL_HALF_HEIGHT_EQUATION = 0.055;
+
+export class EquationReadout extends PanelReadout {
   private readonly fontSize: number;
   private readonly numericTexts: readonly Text[];
   private readonly numericValues: number[] = new Array<number>(
@@ -104,26 +126,15 @@ export class EquationReadout {
   ).fill(true);
   private lastSyncMs = 0;
   // Visibility-bootstrap guard (#201 PR 3). The readout boots with
-  // `group.visible = false` so the first frame doesn't paint empty
-  // troika `Text` slots. The first `setValues` call writes real values
-  // and then flips `group.visible = true`; subsequent calls are no-op
-  // on visibility.
+  // `group.visible = false` (set by PanelReadout base ctor) so the
+  // first frame doesn't paint empty troika `Text` slots. The first
+  // `setValues` call writes real values and then flips
+  // `group.visible = true`; subsequent calls are no-op on visibility.
   private hasBootstrapped = false;
 
-  // Hoisted out of `faceCamera` so per-frame billboarding does no allocation.
-  private readonly camWorld = new THREE.Vector3();
-  private readonly groupWorld = new THREE.Vector3();
-
   constructor(opts: EquationReadoutOptions) {
+    super('equation-readout');
     this.fontSize = opts.fontSize ?? READOUT_FONT_SIZE;
-
-    this.group = new THREE.Group();
-    this.group.name = 'equation-readout';
-    // Boot hidden — uncloaks on first setValues (#201 PR 3). Avoids
-    // a first-frame paint of empty troika `Text` slots between mount
-    // and the first update() tick. Bypassed once `hasBootstrapped`
-    // flips on the first real value write.
-    this.group.visible = false;
 
     // Numerics — one per slot, color baked in. Position is assigned by
     // applyLayout(); kept at origin until the first layout pass.
@@ -157,6 +168,16 @@ export class EquationReadout {
     // setValues call will flip u/v/w to hidden (their initial value is 0)
     // and reflow once; that's a deliberately small cost paid at startup.
     this.applyLayout();
+
+    // Plinth back-plate (#252 / E1.4c). Per parent §3.5 v3 lock
+    // (option-c), the panel mesh is a child of `group` and inherits
+    // the per-frame yaw-billboard from PanelReadout.faceCamera()
+    // transitively. Sized to the readout's widest-line worst case +
+    // padding; see READOUT_PANEL_HALF_WIDTH_EQUATION above.
+    this.createPanel({
+      halfWidth: READOUT_PANEL_HALF_WIDTH_EQUATION,
+      halfHeight: READOUT_PANEL_HALF_HEIGHT_EQUATION,
+    });
   }
 
   private makeNumericText(fontSize: number, color: number): Text {
@@ -368,20 +389,12 @@ export class EquationReadout {
     }
   }
 
-  // Yaw-only billboard, matching the family-classifier label behavior
-  // (#29). The whole equation reads from one consistent direction — head
-  // pitch and roll stay out.
-  faceCamera(camera: THREE.Camera): void {
-    camera.getWorldPosition(this.camWorld);
-    this.group.getWorldPosition(this.groupWorld);
-    const dx = this.camWorld.x - this.groupWorld.x;
-    const dz = this.camWorld.z - this.groupWorld.z;
-    this.group.rotation.set(0, Math.atan2(dx, dz), 0);
-  }
+  // Yaw-only billboard inherited from PanelReadout base (#252).
 
   dispose(): void {
     for (const t of this.numericTexts) t.dispose();
     for (const t of this.topSeparators) t.dispose();
     for (const t of this.bottomSeparators) t.dispose();
+    this.disposePanel();
   }
 }

--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -539,3 +539,32 @@ under their own plinth. The pre-plinth `GRAB_RADIUS_MULTIPLIER = 2.75`
 export was deleted from `scaffold/ui/clusterRackTokens.ts` at the
 same PR; the static-grep regression test in `test/exhibits/`
 enforces zero references in `.ts` files repo-wide.
+
+## Plinth panel-backing (#252)
+
+`EquationReadout` extends the shared `PanelReadout` base
+(`scaffold/ui/PanelReadout.ts`) which contributes (1) the THREE.Group
+construction + boot-cloak, (2) the per-frame yaw-only `faceCamera`
+billboard (formerly duplicated identical-by-copy across the four
+cluster readouts), and (3) a dark `MeshBasicMaterial` back-plate quad
+sized to the readout's worst-case content + padding.
+
+Per parent plan #225 §3.5 v3 lock (option-c), the back-plate sits as
+a child of the readout's group, so it inherits the yaw-billboard
+rotation transitively — panel + text yaw-billboard together as a
+single facing-the-user panel. PR3 does NOT counter-rotate the panel
+to surface-tilt with the plinth slab; that path is reserved as a
+smoke-escape follow-up if the option-c read disagrees in headset.
+
+**Panel dimensions:** `READOUT_PANEL_HALF_WIDTH_EQUATION = 0.260 m`,
+`READOUT_PANEL_HALF_HEIGHT_EQUATION = 0.055 m`. Computed from the
+existing em-width constants — worst-case bottom line `4 × NUMERIC_SLOT_EM
+(2.6) + 3 × SEPARATOR_SLOT_EM (2.4) = 17.6 em × 0.028 m = 0.493 m`,
+half + 0.012 m padding = 0.258 → rounded 0.260. The envelope assertion
+in `test/scaffold/ui/PanelReadout.test.ts` locks the math against
+future formatter drift. Bracket [0.255, 0.280]; smoke-tunable.
+
+**Cloak normalization.** EquationReadout was already at the
+target pattern pre-#252 — `hasBootstrapped` field + throttle-bypass
+on first call + post-sync `group.visible = true`. No setValues
+changes in this scene.

--- a/src/exhibits/saddle-extrema/SPEC.md
+++ b/src/exhibits/saddle-extrema/SPEC.md
@@ -820,3 +820,35 @@ presets) use `GRAB_RADIUS_MULTIPLIER_PLINTH = 1.5` from
 `scaffold/ui/clusterRackTokens.ts`. The pre-plinth mid-air `2.75`
 constant was deleted at PR2 (#251) once all four cluster scenes
 ported onto the plinth.
+
+## Plinth panel-backing (#252)
+
+`SaddleExtremaReadout` extends the shared `PanelReadout` base
+(`scaffold/ui/PanelReadout.ts`) which contributes the cluster-shared
+THREE.Group + boot-cloak + per-frame yaw `faceCamera` + dark
+`MeshBasicMaterial` back-plate quad.
+
+Per parent plan #225 §3.5 v3 lock (option-c), the back-plate is a
+child of the readout's group, inheriting the yaw-billboard
+transitively — panel + text face the user together.
+
+**Panel dimensions:** `READOUT_PANEL_HALF_WIDTH_SADDLE_EXTREMA =
+0.325 m`, `READOUT_PANEL_HALF_HEIGHT_SADDLE_EXTREMA = 0.090 m`.
+Computed from worst-case top line `3 × PREFIX_ENTRY_EM (3.5) + 3 ×
+NUMERIC_ENTRY_EM (3.2) + 2 × TOP_ENTRY_GAP_EM (1.2) = 22.5 em ×
+0.028 = 0.630 m`, half + 0.012 m padding = 0.327 → 0.325. Three-line
+layout (`topY = +LINE_PITCH`, `midY = 0`, `bottomY = -LINE_PITCH`)
+drives the 0.090 m half-height; vertical span 0.12 m + glyph +
+padding. The verdict ('inconclusive' worst case, anchorX:'center',
+not em-slot-allocated) is comfortably narrower than the top line.
+Envelope test in `test/scaffold/ui/PanelReadout.test.ts` locks
+against formatter drift. Bracket [0.320, 0.345]; smoke-tunable.
+
+**Cloak normalization (#252 §3.6).** SaddleExtremaReadout's
+`setValues()` was restructured at PR3 to match the
+Equation/TangentPlane pattern — added a `hasBootstrapped: boolean`
+field, replaced the pre-throttle uncloak with a post-`.sync()` block
+guarded by `hasBootstrapped`, and gated the throttle return with
+`this.hasBootstrapped && ...` so the first call always paints.
+Without this, the dark back-plate would render BEFORE the numeric
+Text geometries resolve on first uncloak.

--- a/src/exhibits/saddle-extrema/SaddleExtremaReadout.ts
+++ b/src/exhibits/saddle-extrema/SaddleExtremaReadout.ts
@@ -1,5 +1,5 @@
-import * as THREE from 'three';
 import { Text } from 'troika-three-text';
+import { PanelReadout } from '@/scaffold/ui/PanelReadout';
 import {
   READOUT_FONT_SIZE,
   READOUT_LINE_PITCH,
@@ -96,9 +96,31 @@ const SEPARATOR_COLOR = 0xffffff;
 const ENTRY_XX = 0;
 const ENTRY_YY = 2;
 
-export class SaddleExtremaReadout {
-  readonly group: THREE.Group;
+// Plinth panel-backing dims (#252 / E1.4c). Computed from this readout's
+// own em constants × READOUT_FONT_SIZE per plan §3.3 methodology — see
+// the envelope-assertion test in PanelReadout.test.ts for the bound.
+//
+// Worst-case line: top — 3 × PREFIX_ENTRY_EM(3.5) + 3 × NUMERIC_ENTRY_EM(3.2)
+// + 2 × TOP_ENTRY_GAP_EM(1.2) = 10.5 + 9.6 + 2.4 = 22.5 em × 0.028 = 0.630 m
+// Half-width = 0.630 / 2 + 0.012 padding = 0.327 → rounded 0.325.
+//
+// Worst-case string corpus:
+//   top:     `f_xx = -2.50   f_xy = -2.50   f_yy = -2.50`
+//   middle:  `D = -103.68`  (monkey-saddle corner per NUMERIC_D_EM doc)
+//   bottom:  verdict ∈ { 'saddle', 'local max', 'local min',
+//                        'inconclusive', 'degenerate' }  (max 12 chars
+//            `inconclusive` — anchorX: 'center', not em-slot-allocated,
+//            ~0.20 m wide ≪ 0.63 m top line, panel covers easily)
+//
+// Bracket [0.320, 0.345]; first-pass smoke-tunable.
+export const READOUT_PANEL_HALF_WIDTH_SADDLE_EXTREMA = 0.325;
 
+// 3-line layout: rows at +LINE_PITCH (0.06), 0, -LINE_PITCH (-0.06) ⇒
+// vertical span 0.12 m + glyph ~0.034 + padding 0.008 = ~0.162 m, half =
+// ~0.081 → rounded 0.090.
+export const READOUT_PANEL_HALF_HEIGHT_SADDLE_EXTREMA = 0.09;
+
+export class SaddleExtremaReadout extends PanelReadout {
   private readonly fontSize: number;
 
   // Top-line entry numerics: [f_xx, f_xy, f_yy].
@@ -120,20 +142,17 @@ export class SaddleExtremaReadout {
   private verdictCache = '';
 
   private lastSyncMs = 0;
-
-  // Hoisted scratch for per-frame yaw billboarding — no allocation.
-  private readonly camWorld = new THREE.Vector3();
-  private readonly groupWorld = new THREE.Vector3();
+  // Visibility-bootstrap guard (#252 §3.6 cloak normalization). Boots
+  // `group.visible = false` (set by PanelReadout base ctor); flips to
+  // `true` AFTER the first `setValues` writes real text + .sync()s,
+  // not before. Matches the Equation/TangentPlane throttle-bypass-on-
+  // first-call pattern so the dark back-plate never renders before
+  // the numeric Text geometries resolve.
+  private hasBootstrapped = false;
 
   constructor(opts: SaddleExtremaReadoutOptions) {
+    super('saddle-extrema-readout');
     this.fontSize = opts.fontSize ?? READOUT_FONT_SIZE;
-
-    this.group = new THREE.Group();
-    this.group.name = 'saddle-extrema-readout';
-    // Hidden until first setValues() populates the numerics. Avoids
-    // painting empty strings on the first frame between mount and
-    // first update().
-    this.group.visible = false;
 
     const numericEntryW = NUMERIC_ENTRY_EM * this.fontSize;
     const numericDW = NUMERIC_D_EM * this.fontSize;
@@ -206,6 +225,13 @@ export class SaddleExtremaReadout {
     this.verdictText = this.makeNumericText(this.fontSize, opts.accentColor);
     this.verdictText.position.set(0, bottomY, 0);
     this.group.add(this.verdictText);
+
+    // Plinth back-plate (#252 / E1.4c). Sized to the top-line worst
+    // case (the widest of the three lines); verdict + D fit easily.
+    this.createPanel({
+      halfWidth: READOUT_PANEL_HALF_WIDTH_SADDLE_EXTREMA,
+      halfHeight: READOUT_PANEL_HALF_HEIGHT_SADDLE_EXTREMA,
+    });
   }
 
   private makeNumericText(fontSize: number, color: number): Text {
@@ -235,14 +261,21 @@ export class SaddleExtremaReadout {
    * ≈30 Hz via READOUT_SYNC_INTERVAL_MS, with per-slot caching so unchanged
    * strings don't re-trigger troika's `.sync()`.
    *
-   * On first call, uncloaks `group.visible = true` — the readout
-   * boots hidden so empty-string frames never paint.
+   * Cloak normalization (#252 §3.6): `group.visible = true` flips AFTER
+   * the first .sync()-resolving write — the throttle gate is bypassed
+   * on the bootstrap call so the first call always paints. Same shape
+   * as EquationReadout / TangentPlaneReadout.
    */
   setValues(hessian: Hessian): void {
-    if (!this.group.visible) this.group.visible = true;
-
     const now = performance.now();
-    if (now - this.lastSyncMs < READOUT_SYNC_INTERVAL_MS) return;
+    // First call bypasses the throttle so the readout uncloaks with
+    // real text on frame 1.
+    if (
+      this.hasBootstrapped &&
+      now - this.lastSyncMs < READOUT_SYNC_INTERVAL_MS
+    ) {
+      return;
+    }
     this.lastSyncMs = now;
 
     const s: SaddleExtremaReadoutStrings = formatSaddleExtremaReadout(hessian);
@@ -267,23 +300,23 @@ export class SaddleExtremaReadout {
       this.verdictText.text = s.verdict;
       this.verdictText.sync();
     }
+
+    // First-call uncloak — after all .sync() writes above. Flipping
+    // `group.visible = true` here paints the first real frame with
+    // both panel + populated text together, not panel + empty text.
+    if (!this.hasBootstrapped) {
+      this.group.visible = true;
+      this.hasBootstrapped = true;
+    }
   }
 
-  // Yaw-only billboard. World-up stays world-up; head pitch/roll don't
-  // tilt the readout. Mirrors GradientLevelsReadout / TangentPlaneReadout
-  // / Label.
-  faceCamera(camera: THREE.Camera): void {
-    camera.getWorldPosition(this.camWorld);
-    this.group.getWorldPosition(this.groupWorld);
-    const dx = this.camWorld.x - this.groupWorld.x;
-    const dz = this.camWorld.z - this.groupWorld.z;
-    this.group.rotation.set(0, Math.atan2(dx, dz), 0);
-  }
+  // Yaw-only billboard inherited from PanelReadout base (#252).
 
   dispose(): void {
     for (const t of this.entryNumerics) t.dispose();
     this.dNumeric.dispose();
     this.verdictText.dispose();
     for (const t of this.separators) t.dispose();
+    this.disposePanel();
   }
 }

--- a/src/exhibits/tangent-planes/SPEC.md
+++ b/src/exhibits/tangent-planes/SPEC.md
@@ -371,3 +371,27 @@ foreshortening with the surface tilt.
 `scaffold/ui/clusterRackTokens.ts`, the cluster-uniform plinth-mounted
 value. The pre-plinth mid-air `2.75` constant was deleted at PR2
 (#251) once all four cluster scenes ported onto the plinth.
+
+## Plinth panel-backing (#252)
+
+`TangentPlaneReadout` extends the shared `PanelReadout` base
+(`scaffold/ui/PanelReadout.ts`) which contributes the cluster-shared
+THREE.Group + boot-cloak + per-frame yaw `faceCamera` + dark
+`MeshBasicMaterial` back-plate quad.
+
+Per parent plan #225 §3.5 v3 lock (option-c), the back-plate is a
+child of the readout's group, inheriting the yaw-billboard
+transitively — panel + text face the user together.
+
+**Panel dimensions:** `READOUT_PANEL_HALF_WIDTH_TANGENT_PLANE = 0.380
+m`, `READOUT_PANEL_HALF_HEIGHT_TANGENT_PLANE = 0.055 m`. Computed
+from worst-case top line `6 × NUMERIC_SLOT_EM (2.6) + 3 × OPEN_PAREN_EM
+(1.8) + 2 × CLOSE_PAREN_OP_EM (1.6) + CLOSE_PAREN_EQ_EM (1.9) = 26.1
+em × 0.028 = 0.731 m`, half + 0.012 m padding = 0.378 → 0.380.
+Envelope test in `test/scaffold/ui/PanelReadout.test.ts` locks
+against formatter drift. Bracket [0.375, 0.395]; smoke-tunable.
+
+**Cloak normalization.** TangentPlaneReadout was already at the
+target pattern pre-#252 — `hasBootstrapped` field + throttle-bypass
+on first call + post-sync `group.visible = true`. No setValues
+changes in this scene.

--- a/src/exhibits/tangent-planes/TangentPlaneReadout.ts
+++ b/src/exhibits/tangent-planes/TangentPlaneReadout.ts
@@ -1,6 +1,6 @@
-import * as THREE from 'three';
 import { Text } from 'troika-three-text';
 import type { MathVec3 } from '@/scaffold/math/frames';
+import { PanelReadout } from '@/scaffold/ui/PanelReadout';
 import {
   READOUT_FONT_SIZE,
   READOUT_LINE_PITCH,
@@ -76,9 +76,27 @@ const SEPARATOR_COLOR = 0xffffff;
 const AXIS_X = 0;
 const AXIS_Z = 2;
 
-export class TangentPlaneReadout {
-  readonly group: THREE.Group;
+// Plinth panel-backing dims (#252 / E1.4c). Computed from this readout's
+// own em constants × READOUT_FONT_SIZE per plan §3.3 methodology — see
+// the envelope-assertion test in PanelReadout.test.ts for the bound.
+//
+// Worst-case line: top — 6 numerics + 3 open-paren + 2 close-paren-op
+// + 1 close-paren-eq = 6 × 2.6 + 3 × 1.8 + 2 × 1.6 + 1.9
+//                    = 15.6 + 5.4 + 3.2 + 1.9 = 26.1 em
+//                    × 0.028 = 0.731 m
+// Half-width = 0.731 / 2 + 0.012 padding = 0.378 → rounded 0.380.
+//
+// Worst-case top-line string corpus:
+//   `-2.50 (x -2.50) + -2.50 (y -2.50) + -2.50 (z -2.50) = 0`
+//
+// First-pass smoke-tunable per feedback_staging_dimensions_first_pass.
+// Bracket [0.375, 0.395]; one dial per round.
+export const READOUT_PANEL_HALF_WIDTH_TANGENT_PLANE = 0.38;
 
+// 2-line layout, rows at ±LINE_PITCH/2 = ±0.03; glyph + padding → 0.055.
+export const READOUT_PANEL_HALF_HEIGHT_TANGENT_PLANE = 0.055;
+
+export class TangentPlaneReadout extends PanelReadout {
   private readonly fontSize: number;
 
   // Six top-line numerics in visual reading order:
@@ -103,25 +121,13 @@ export class TangentPlaneReadout {
 
   private lastSyncMs = 0;
   // Visibility-bootstrap guard (#201 PR 3). Boots `group.visible =
-  // false`; flips to `true` after the first `setValues` writes real
-  // text into the troika `Text` slots. Avoids a first-frame paint of
-  // empty strings between mount and the first update() tick.
+  // false` (set by PanelReadout base ctor); flips to `true` after the
+  // first `setValues` writes real text into the troika `Text` slots.
   private hasBootstrapped = false;
 
-  // Hoisted out of `faceCamera` so per-frame billboarding does no
-  // allocation. Same convention as `EquationReadout.ts:115-116`.
-  private readonly camWorld = new THREE.Vector3();
-  private readonly groupWorld = new THREE.Vector3();
-
   constructor(opts: TangentPlaneReadoutOptions) {
+    super('tangent-plane-readout');
     this.fontSize = opts.fontSize ?? READOUT_FONT_SIZE;
-
-    this.group = new THREE.Group();
-    this.group.name = 'tangent-plane-readout';
-    // Boot hidden — uncloaks on first setValues (#201 PR 3). Avoids
-    // a first-frame paint of empty troika `Text` slots between mount
-    // and the first update() tick.
-    this.group.visible = false;
 
     const numericW = NUMERIC_SLOT_EM * this.fontSize;
     const openParenW = OPEN_PAREN_EM * this.fontSize;
@@ -228,6 +234,14 @@ export class TangentPlaneReadout {
       this.separators.push(sep);
     }
     this.bottomNumerics = bottomNumerics;
+
+    // Plinth back-plate (#252 / E1.4c). See parent §3.5 v3 (option-c)
+    // billboarding lock — back-plate inherits the per-frame yaw from
+    // PanelReadout.faceCamera() transitively via group-child reparenting.
+    this.createPanel({
+      halfWidth: READOUT_PANEL_HALF_WIDTH_TANGENT_PLANE,
+      halfHeight: READOUT_PANEL_HALF_HEIGHT_TANGENT_PLANE,
+    });
   }
 
   private makeNumericText(fontSize: number, color: number): Text {
@@ -313,19 +327,12 @@ export class TangentPlaneReadout {
     }
   }
 
-  // Yaw-only billboard, matching EquationReadout (#29) and Label.
-  // World-up stays world-up; head pitch and roll don't tilt the readout.
-  faceCamera(camera: THREE.Camera): void {
-    camera.getWorldPosition(this.camWorld);
-    this.group.getWorldPosition(this.groupWorld);
-    const dx = this.camWorld.x - this.groupWorld.x;
-    const dz = this.camWorld.z - this.groupWorld.z;
-    this.group.rotation.set(0, Math.atan2(dx, dz), 0);
-  }
+  // Yaw-only billboard inherited from PanelReadout base (#252).
 
   dispose(): void {
     for (const t of this.topNumerics) t.dispose();
     for (const t of this.bottomNumerics) t.dispose();
     for (const t of this.separators) t.dispose();
+    this.disposePanel();
   }
 }

--- a/src/scaffold/ui/PanelReadout.ts
+++ b/src/scaffold/ui/PanelReadout.ts
@@ -1,0 +1,128 @@
+// PanelReadout — shared base class for the four cluster readouts
+// (EquationReadout, TangentPlaneReadout, GradientLevelsReadout,
+// SaddleExtremaReadout). Extracted under #225's E1.4c (PR3 of the
+// control-plinth sub-epic, issue #252) per the extract-on-Nth-use
+// rule (N=4).
+//
+// Contributes three responsibilities each subclass formerly handled
+// itself (identical-by-copy across the four files pre-extraction):
+//
+//   1. THREE.Group construction + cloak-at-boot (`group.visible =
+//      false` until the subclass's first setValues() uncloaks).
+//   2. Yaw-only billboard via faceCamera(camera) — `group.rotation`
+//      written every frame. Per parent-plan §3.5 v3 lock (option-c),
+//      the back-plate inherits this rotation transitively as a child
+//      of `group`, so panel + text yaw-billboard together.
+//   3. Back-plate quad construction + dispose — a dark MeshBasicMaterial
+//      PlaneGeometry sized to the subclass-supplied worst-case text
+//      bounds + padding. Subclass calls createPanel(dims) once during
+//      its ctor after laying out text children; subclass's dispose()
+//      chains disposePanel() after disposing text children.
+//
+// What this base does NOT do:
+//   - The text children themselves (subclass-specific layouts).
+//   - The 33ms-throttle / per-slot string caching path in each
+//     subclass's setValues() — that stays in the subclass.
+//   - Per-frame back-plate-vs-text bounds-sync. Plan §3.3 amends parent
+//     §3.5 v3 to drop per-frame sync in favor of static, em-derived
+//     sizing; "breathing" panels as digit counts change read as UX
+//     jitter.
+
+import * as THREE from 'three';
+import { READOUT_PANEL_COLOR_RGB } from './readoutTokens';
+
+export interface PanelReadoutPanelDimensions {
+  /** Half-width of the back-plate quad in group-local meters. */
+  readonly halfWidth: number;
+  /** Half-height of the back-plate quad in group-local meters. */
+  readonly halfHeight: number;
+  /** Group-local (x, y) center of the back-plate. Defaults to (0, 0).
+   *  Used when text is offset from group origin. */
+  readonly center?: readonly [number, number];
+  /** Recess in group-local +Z. Defaults to -0.001 m (text in front). */
+  readonly localZ?: number;
+}
+
+export abstract class PanelReadout {
+  /** Plinth-slot target group. Children: subclass text children +
+   *  (after createPanel) the back-plate mesh. Position written by the
+   *  plinth slot; rotation overwritten per frame by faceCamera(). */
+  readonly group: THREE.Group;
+
+  private panel: THREE.Mesh<
+    THREE.PlaneGeometry,
+    THREE.MeshBasicMaterial
+  > | null = null;
+  private readonly camWorld = new THREE.Vector3();
+  private readonly groupWorld = new THREE.Vector3();
+
+  protected constructor(groupName: string) {
+    this.group = new THREE.Group();
+    this.group.name = groupName;
+    // Hidden until subclass's first setValues() populates text +
+    // uncloaks. Avoids painting empty strings on the first frame.
+    this.group.visible = false;
+  }
+
+  /** Subclass calls ONCE during ctor, after constructing + positioning
+   *  its text children, with worst-case dims derived from the
+   *  subclass's own em-width constants × READOUT_FONT_SIZE (see plan
+   *  §3.3 methodology). Throws on second call (single-shot guard). */
+  protected createPanel(dims: PanelReadoutPanelDimensions): void {
+    if (this.panel !== null) {
+      throw new Error('PanelReadout.createPanel: already created');
+    }
+    const geometry = new THREE.PlaneGeometry(
+      dims.halfWidth * 2,
+      dims.halfHeight * 2,
+    );
+    const material = new THREE.MeshBasicMaterial({
+      color: new THREE.Color(...READOUT_PANEL_COLOR_RGB),
+      depthWrite: true,
+      transparent: false,
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    // Back-plate renders BEFORE text (which has default renderOrder 0).
+    // Defensive against three.js's render-order-vs-scene-graph subtlety.
+    mesh.renderOrder = -1;
+    const [cx, cy] = dims.center ?? [0, 0];
+    mesh.position.set(cx, cy, dims.localZ ?? -0.001);
+    this.group.add(mesh);
+    this.panel = mesh;
+  }
+
+  /** Yaw-only billboard. Per parent-plan §3.5 v3 lock (option-c), the
+   *  back-plate (a child of `group`) inherits the rotation
+   *  transitively — panel and text yaw-billboard together. */
+  faceCamera(camera: THREE.Camera): void {
+    camera.getWorldPosition(this.camWorld);
+    this.group.getWorldPosition(this.groupWorld);
+    const dx = this.camWorld.x - this.groupWorld.x;
+    const dz = this.camWorld.z - this.groupWorld.z;
+    this.group.rotation.set(0, Math.atan2(dx, dz), 0);
+  }
+
+  /** Subclass dispose() MUST call this to clean up the back-plate.
+   *  Removes the mesh from the group BEFORE disposing GPU resources —
+   *  THREE.js's geometry/material.dispose() frees GPU buffers but does
+   *  NOT remove the mesh from its parent. Without the explicit remove,
+   *  the dead mesh stays attached and any later render would hit a
+   *  "disposed material" WebGL error.
+   *
+   *  Idempotent: safe to call when createPanel was never invoked, or
+   *  when disposePanel was already called.
+   *
+   *  Post-dispose contract: this PanelReadout instance is UNUSABLE.
+   *  Do not call createPanel again. The subclass discards the
+   *  instance; the shell tears down ctx.group on unmount. */
+  protected disposePanel(): void {
+    if (this.panel !== null) {
+      this.group.remove(this.panel);
+      this.panel.geometry.dispose();
+      this.panel.material.dispose();
+      this.panel = null;
+    }
+  }
+
+  abstract dispose(): void;
+}

--- a/src/scaffold/ui/readoutTokens.ts
+++ b/src/scaffold/ui/readoutTokens.ts
@@ -28,3 +28,13 @@ export const READOUT_OUTLINE_COLOR = 0x000000;
 // during fast drags. ≈30 Hz is the cap shared by every readout (#38
 // rationale, originally calibrated on Slider's per-slider label cap).
 export const READOUT_SYNC_INTERVAL_MS = 33;
+
+// Back-plate base color for plinth-mounted readouts (#252 / E1.4c).
+// Near-black with a slight cool bias — reads as an LCD-off panel
+// against the dark warm-purple plinth surface (PLINTH_BASE_COLOR_RGB),
+// not as a hole. Calibrated against axis-tinted troika text (vermillion
+// / bluish-green / sky-blue / yellow). First-pass smoke-tunable per
+// feedback_staging_dimensions_first_pass; bracket [0.05, 0.12] each
+// component. Immutable tuple per feedback_threejs_token_exports_
+// immutable — produce a fresh THREE.Color in each consumer.
+export const READOUT_PANEL_COLOR_RGB = [0.08, 0.08, 0.1] as const;

--- a/test/exhibits/quadrics/EquationReadout.test.ts
+++ b/test/exhibits/quadrics/EquationReadout.test.ts
@@ -68,4 +68,22 @@ describe('EquationReadout visibility-bootstrap', () => {
     readout.setValues(2, 0, 0, 0, 0, 0, 0);
     expect(readout.group.visible).toBe(true);
   });
+
+  it('mounts the plinth back-plate as a child of group (#252)', () => {
+    const readout = new EquationReadout({
+      coefficientColors: [
+        0xd55e00, 0x009e73, 0x56b4e9, 0xd55e00, 0x009e73, 0x56b4e9,
+        0xf0e442,
+      ],
+    });
+    // Per #252 plan §3.5 v3 (option-c), the back-plate is a direct
+    // child of `group` so it inherits the per-frame yaw-billboard
+    // transitively. Asserting via a single THREE.Mesh child is the
+    // minimal observable surface (text Texts are stubbed to Object3D
+    // by the test mock; the panel is the only real THREE.Mesh).
+    const meshChildren = readout.group.children.filter(
+      (c) => c.type === 'Mesh',
+    );
+    expect(meshChildren.length).toBe(1);
+  });
 });

--- a/test/exhibits/tangent-planes/TangentPlaneReadout.test.ts
+++ b/test/exhibits/tangent-planes/TangentPlaneReadout.test.ts
@@ -51,4 +51,12 @@ describe('TangentPlaneReadout visibility-bootstrap', () => {
     readout.setValues(point, normal);
     expect(readout.group.visible).toBe(true);
   });
+
+  it('mounts the plinth back-plate as a child of group (#252)', () => {
+    const readout = makeReadout();
+    const meshChildren = readout.group.children.filter(
+      (c) => c.type === 'Mesh',
+    );
+    expect(meshChildren.length).toBe(1);
+  });
 });

--- a/test/scaffold/ui/PanelReadout.test.ts
+++ b/test/scaffold/ui/PanelReadout.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+
+// `troika-three-text` reaches for `self`, a browser-only global, in its
+// UMD `now$1` helper. The default vitest environment is Node, so any
+// `new Text()` blows up at module load. The four readout subclasses
+// instantiate Text in their ctors (and at module-level field
+// initializers), so importing them — even just to inspect their
+// `.prototype` — triggers the stub. Pattern reused from TapButton.test.ts.
+vi.mock('troika-three-text', () => {
+  class StubText extends THREE.Object3D {
+    text = '';
+    fontSize = 0;
+    color = 0xffffff;
+    anchorX: string | undefined;
+    anchorY: string | undefined;
+    outlineWidth: string | undefined;
+    outlineColor: number | undefined;
+    sync(): void {}
+    dispose(): void {}
+  }
+  return { Text: StubText };
+});
+
+import {
+  PanelReadout,
+  type PanelReadoutPanelDimensions,
+} from '@/scaffold/ui/PanelReadout';
+import {
+  READOUT_FONT_SIZE,
+  READOUT_PANEL_COLOR_RGB,
+} from '@/scaffold/ui/readoutTokens';
+import { EquationReadout } from '@/exhibits/quadrics/EquationReadout';
+import { TangentPlaneReadout } from '@/exhibits/tangent-planes/TangentPlaneReadout';
+import { GradientLevelsReadout } from '@/exhibits/gradient-levels/GradientLevelsReadout';
+import { SaddleExtremaReadout } from '@/exhibits/saddle-extrema/SaddleExtremaReadout';
+import {
+  READOUT_PANEL_HALF_WIDTH_EQUATION,
+  READOUT_PANEL_HALF_HEIGHT_EQUATION,
+} from '@/exhibits/quadrics/EquationReadout';
+import {
+  READOUT_PANEL_HALF_WIDTH_TANGENT_PLANE,
+  READOUT_PANEL_HALF_HEIGHT_TANGENT_PLANE,
+} from '@/exhibits/tangent-planes/TangentPlaneReadout';
+import {
+  READOUT_PANEL_HALF_WIDTH_GRADIENT_LEVELS,
+  READOUT_PANEL_HALF_HEIGHT_GRADIENT_LEVELS,
+} from '@/exhibits/gradient-levels/GradientLevelsReadout';
+import {
+  READOUT_PANEL_HALF_WIDTH_SADDLE_EXTREMA,
+  READOUT_PANEL_HALF_HEIGHT_SADDLE_EXTREMA,
+} from '@/exhibits/saddle-extrema/SaddleExtremaReadout';
+
+// Test harness: PanelReadout's createPanel + disposePanel are protected;
+// expose them via public wrappers so the test file can drive them. The
+// wrapper-class pattern keeps the production base's invariant (only
+// subclasses see the protected surface) while making the tests
+// type-check (per roundtable GPT #5).
+class TestReadout extends PanelReadout {
+  constructor() {
+    super('test-readout');
+  }
+  public makePanel(dims: PanelReadoutPanelDimensions): void {
+    this.createPanel(dims);
+  }
+  public dropPanel(): void {
+    this.disposePanel();
+  }
+  dispose(): void {
+    this.disposePanel();
+  }
+}
+
+describe('PanelReadout', () => {
+  describe('createPanel', () => {
+    it('adds a back-plate mesh with the documented defaults', () => {
+      const r = new TestReadout();
+      r.makePanel({ halfWidth: 0.1, halfHeight: 0.05 });
+      expect(r.group.children.length).toBe(1);
+      const child = r.group.children[0];
+      expect(child).toBeInstanceOf(THREE.Mesh);
+      const mesh = child as THREE.Mesh<
+        THREE.PlaneGeometry,
+        THREE.MeshBasicMaterial
+      >;
+      expect(mesh.geometry).toBeInstanceOf(THREE.PlaneGeometry);
+      expect(mesh.geometry.parameters.width).toBeCloseTo(0.2, 6);
+      expect(mesh.geometry.parameters.height).toBeCloseTo(0.1, 6);
+      expect(mesh.material).toBeInstanceOf(THREE.MeshBasicMaterial);
+      const expectedColor = new THREE.Color(...READOUT_PANEL_COLOR_RGB);
+      expect(mesh.material.color.equals(expectedColor)).toBe(true);
+      expect(mesh.renderOrder).toBe(-1);
+      expect(mesh.position.x).toBeCloseTo(0, 6);
+      expect(mesh.position.y).toBeCloseTo(0, 6);
+      expect(mesh.position.z).toBeCloseTo(-0.001, 6);
+    });
+
+    it('honors center and localZ overrides', () => {
+      const r = new TestReadout();
+      r.makePanel({
+        halfWidth: 0.1,
+        halfHeight: 0.05,
+        center: [0.03, -0.02],
+        localZ: -0.005,
+      });
+      const mesh = r.group.children[0] as THREE.Mesh;
+      expect(mesh.position.x).toBeCloseTo(0.03, 6);
+      expect(mesh.position.y).toBeCloseTo(-0.02, 6);
+      expect(mesh.position.z).toBeCloseTo(-0.005, 6);
+    });
+
+    it('throws on a second call (single-shot guard)', () => {
+      const r = new TestReadout();
+      r.makePanel({ halfWidth: 0.1, halfHeight: 0.05 });
+      expect(() => r.makePanel({ halfWidth: 0.2, halfHeight: 0.1 })).toThrow(
+        /already created/,
+      );
+    });
+  });
+
+  describe('faceCamera', () => {
+    it('writes yaw-only rotation derived from camera world position', () => {
+      const r = new TestReadout();
+      r.group.position.set(0, 1, 0);
+      r.group.updateMatrixWorld(true);
+      const camera = new THREE.PerspectiveCamera();
+      // dx = 1, dz = 1 → atan2 = π/4.
+      camera.position.set(1, 1, 1);
+      r.faceCamera(camera);
+      expect(r.group.rotation.x).toBe(0);
+      expect(r.group.rotation.z).toBe(0);
+      expect(r.group.rotation.y).toBeCloseTo(Math.PI / 4, 6);
+
+      // dx = -1, dz = 1 → atan2 = -π/4.
+      camera.position.set(-1, 1, 1);
+      r.faceCamera(camera);
+      expect(r.group.rotation.y).toBeCloseTo(-Math.PI / 4, 6);
+    });
+
+    it('does not throw after disposePanel (defends a future null-check mistake)', () => {
+      const r = new TestReadout();
+      r.makePanel({ halfWidth: 0.1, halfHeight: 0.05 });
+      r.dropPanel();
+      const camera = new THREE.PerspectiveCamera();
+      camera.position.set(1, 1, 1);
+      expect(() => r.faceCamera(camera)).not.toThrow();
+    });
+  });
+
+  describe('disposePanel', () => {
+    it('removes the mesh from the group and disposes GPU resources', () => {
+      const r = new TestReadout();
+      r.makePanel({ halfWidth: 0.1, halfHeight: 0.05 });
+      const mesh = r.group.children[0] as THREE.Mesh<
+        THREE.PlaneGeometry,
+        THREE.MeshBasicMaterial
+      >;
+      const geomSpy = vi.spyOn(mesh.geometry, 'dispose');
+      const matSpy = vi.spyOn(mesh.material, 'dispose');
+      r.dropPanel();
+      expect(r.group.children.length).toBe(0);
+      expect(geomSpy).toHaveBeenCalledTimes(1);
+      expect(matSpy).toHaveBeenCalledTimes(1);
+
+      // Idempotent: second call is a no-op, no re-fire.
+      expect(() => r.dropPanel()).not.toThrow();
+      expect(geomSpy).toHaveBeenCalledTimes(1);
+      expect(matSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('is a safe no-op when createPanel was never called', () => {
+      const r = new TestReadout();
+      // panel === null from construction; should not throw on either call.
+      expect(() => r.dropPanel()).not.toThrow();
+      expect(() => r.dropPanel()).not.toThrow();
+      expect(r.group.children.length).toBe(0);
+    });
+  });
+
+  describe('subclass faceCamera deletion (mixin lift enforcement)', () => {
+    // Locks the four readout subclasses to inherit faceCamera from the
+    // base; a future maintainer reintroducing a per-class faceCamera
+    // override would silently defeat the lift. Tested via prototype
+    // ownership rather than behavior so instance construction isn't
+    // required (the readout ctors run troika Text init code; the stub
+    // mock above keeps that safe but the prototype check is independent).
+    it('EquationReadout does not own faceCamera', () => {
+      expect(
+        Object.prototype.hasOwnProperty.call(
+          EquationReadout.prototype,
+          'faceCamera',
+        ),
+      ).toBe(false);
+    });
+    it('TangentPlaneReadout does not own faceCamera', () => {
+      expect(
+        Object.prototype.hasOwnProperty.call(
+          TangentPlaneReadout.prototype,
+          'faceCamera',
+        ),
+      ).toBe(false);
+    });
+    it('GradientLevelsReadout does not own faceCamera', () => {
+      expect(
+        Object.prototype.hasOwnProperty.call(
+          GradientLevelsReadout.prototype,
+          'faceCamera',
+        ),
+      ).toBe(false);
+    });
+    it('SaddleExtremaReadout does not own faceCamera', () => {
+      expect(
+        Object.prototype.hasOwnProperty.call(
+          SaddleExtremaReadout.prototype,
+          'faceCamera',
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('worst-case-string envelope assertions', () => {
+    // Static safety net per plan §3.3: each readout's hard-coded panel
+    // half-width must be ≥ the worst-case em-derived width of its own
+    // widest line. If a formatter or layout changes, this fires and
+    // someone recomputes the constant.
+
+    it('EquationReadout panel half-width covers worst bottom-line content', () => {
+      // Bottom line all-non-d-visible: 4 numerics + 3 separators.
+      // NUMERIC_SLOT_EM = 2.6, SEPARATOR_SLOT_EM = 2.4.
+      const worstEm = 4 * 2.6 + 3 * 2.4; // = 17.6
+      const worstMeters = worstEm * READOUT_FONT_SIZE;
+      expect(READOUT_PANEL_HALF_WIDTH_EQUATION * 2).toBeGreaterThanOrEqual(
+        worstMeters,
+      );
+      // Sanity: half-height covers the 2-line vertical extent.
+      expect(READOUT_PANEL_HALF_HEIGHT_EQUATION).toBeGreaterThan(0);
+    });
+
+    it('TangentPlaneReadout panel half-width covers worst top-line content', () => {
+      // Top line: [n_x] " (x " [x₀] ") + " [n_y] " (y " [y₀] ") + " [n_z] " (z " [z₀] ") = 0"
+      // NUMERIC_SLOT_EM=2.6, OPEN_PAREN_EM=1.8, CLOSE_PAREN_OP_EM=1.6,
+      // CLOSE_PAREN_EQ_EM=1.9.
+      const worstEm = 6 * 2.6 + 3 * 1.8 + 2 * 1.6 + 1.9; // = 26.1
+      const worstMeters = worstEm * READOUT_FONT_SIZE;
+      expect(
+        READOUT_PANEL_HALF_WIDTH_TANGENT_PLANE * 2,
+      ).toBeGreaterThanOrEqual(worstMeters);
+      expect(READOUT_PANEL_HALF_HEIGHT_TANGENT_PLANE).toBeGreaterThan(0);
+    });
+
+    it('GradientLevelsReadout panel half-width covers worst top-line content', () => {
+      // Top: `∇f = ( ±n.nn , ±n.nn , ±n.nn )`
+      // PREFIX_GRAD_EM=2.8, NUMERIC_SIGNED_EM=2.6, COMMA_EM=1.0,
+      // CLOSE_PAREN_EM=1.0.
+      const worstEm = 2.8 + 3 * 2.6 + 2 * 1.0 + 1.0; // = 13.6
+      const worstMeters = worstEm * READOUT_FONT_SIZE;
+      expect(
+        READOUT_PANEL_HALF_WIDTH_GRADIENT_LEVELS * 2,
+      ).toBeGreaterThanOrEqual(worstMeters);
+      expect(READOUT_PANEL_HALF_HEIGHT_GRADIENT_LEVELS).toBeGreaterThan(0);
+    });
+
+    it('SaddleExtremaReadout panel half-width covers worst top-line content', () => {
+      // Top: `f_xx = [n_xx]   f_xy = [n_xy]   f_yy = [n_yy]`
+      // PREFIX_ENTRY_EM=3.5, NUMERIC_ENTRY_EM=3.2, TOP_ENTRY_GAP_EM=1.2.
+      const worstEm = 3 * 3.5 + 3 * 3.2 + 2 * 1.2; // = 22.5
+      const worstMeters = worstEm * READOUT_FONT_SIZE;
+      expect(
+        READOUT_PANEL_HALF_WIDTH_SADDLE_EXTREMA * 2,
+      ).toBeGreaterThanOrEqual(worstMeters);
+      expect(READOUT_PANEL_HALF_HEIGHT_SADDLE_EXTREMA).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
Closes #252
Closes #258

## Summary

Third PR in the E1.4 sub-epic implementation chain under v1.0 staging epic #221 / control-plinth sub-epic #225. Lifts a shared `PanelReadout` base into `src/scaffold/ui/` that the four cluster readouts (`EquationReadout`, `TangentPlaneReadout`, `GradientLevelsReadout`, `SaddleExtremaReadout`) now extend — the base contributes the THREE.Group construction + boot-cloak, the per-frame yaw-only `faceCamera` billboard (formerly identical-by-copy across all four), and a dark `MeshBasicMaterial` back-plate quad sized per-readout to its worst-case content + padding.

Per parent §3.5 v3 lock (option-c), the back-plate is a direct child of each readout's group, inheriting the yaw-billboard transitively — panel + text yaw-billboard together as a single facing-the-user panel. The two smoke-escape paths (option-(a) two-slot, option-(b) counter-rotate) are preserved as post-merge follow-ups against #225 if smoke disagrees; PR3 ships the panel regardless. Panel dimensions derive from each readout's existing em-width constants × `READOUT_FONT_SIZE` (not hand-estimates); an envelope assertion in `PanelReadout.test.ts` locks the math against future formatter drift. Cloak normalization: `GradientLevelsReadout` and `SaddleExtremaReadout` gained a `hasBootstrapped` field + restructured `setValues()` throttle preamble so `group.visible` flips AFTER the first `.sync()` resolves — avoids a "panel + half-filled text" flash on first uncloak with the new dark back-plate.

Closes #258 (equation readout plinth-surface anchoring) — consolidated into this PR per #258's own recommendation.

## Test plan

Automated (already green on the branch):

- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run` — 555/555 tests pass (15 new `PanelReadout` tests covering createPanel / faceCamera / disposePanel / subclass faceCamera-deletion × 4 / worst-case envelope × 4; 2 new panel-mesh-in-group assertions in existing Equation/TangentPlane readout tests).
- [x] `npm run lint` clean; pre-commit (gitleaks + standard fixers + eslint) passed.

Smoke (Cloudflare PR preview — `?exhibit=<id>` per scene + Quest 3S):

Pancake — all four scenes:
- [x] Each readout shows a dark back-plate behind its text; axis-color story holds; text readable.
- [x] **No "panel-without-text" flash on first uncloak** (Ctrl-Shift-R fresh load; first frame after readout appears should be panel + populated text together).
- [x] No flicker / z-fight between back-plate and text outline.
- [x] Drive sliders / presets / section-tabs to extremes — readout text approaches but does not clip the panel edges (static-sizing envelope check).
- [x] Back-plate doesn't visually shift / shimmer as text content changes (static sizing working).

Quest 3S — per pose matrix (#255 plan §3.2):
- [x] Standing 1.6 m close (z ≈ 1.0 m) — readouts legible; panel reads as a panel-on-plinth.
- [x] Crouched 1.3 m close — same.
- [x] Tall 1.8 m mid — same.
- [x] Confirm option-(c) read: panel + text yaw-billboard together facing the user. *Observation, not gate* — if disagreement, file follow-up issue against #225 with the §6 trigger language; do not block this PR.

Sister-scene regression sweep:
- [x] `SceneRack` cluster-nav still works; switching between scenes shows panel-backed readouts in each.
- [x] `WorldAxes` indicator still reads as math-frame (no visual conflict from panel proximity).
- [x] `?fps=1` overlay still works in all 4 scenes; Quest 3S 72 Hz hold preserved (+1 mesh per mounted exhibit / +4 total across the four-exhibit cluster sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)