### PR TITLE
chore(ci): opt JavaScript actions into Node 24 (#265)

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -7,6 +7,11 @@ on:
 permissions:
   contents: read
 
+# Opt JavaScript actions into Node 24 ahead of GitHub's 2026-06-02 default
+# flip and 2026-09-16 Node 20 removal. See #265.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   build-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: read
 
+# Opt JavaScript actions into Node 24 ahead of GitHub's 2026-06-02 default
+# flip and 2026-09-16 Node 20 removal. See #265.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   gitleaks:
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,11 @@ permissions:
   pages: write
   id-token: write
 
+# Opt JavaScript actions into Node 24 ahead of GitHub's 2026-06-02 default
+# flip and 2026-09-16 Node 20 removal. See #265.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 concurrency:
   group: pages
   cancel-in-progress: true

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -20,6 +20,11 @@ permissions:
   contents: read
   pull-requests: write
 
+# Opt JavaScript actions into Node 24 ahead of GitHub's 2026-06-02 default
+# flip and 2026-09-16 Node 20 removal. See #265.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 concurrency:
   group: pr-preview-${{ github.event.pull_request.number }}
   cancel-in-progress: true


### PR DESCRIPTION
Closes #265

## Summary

GitHub's flipping the JS-action runner default to Node 24 on
**2026-06-02** and removing Node 20 entirely on **2026-09-16** — the
second date lands inside the fall-2026 v1.0 audition window, so CI
needs to be off Node 20 before the start-of-semester crunch.

Adds workflow-level `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'`
(GitHub's own opt-in env var) to the four workflows that actually
invoke JS actions: `build-check`, `gitleaks`, `pages`, `pr-preview`.

Drop notes vs the issue:
- **`pr-preview-cleanup` is unchanged.** #265's body listed it as
  using `actions/checkout`, but the file has no `uses:` directives —
  it's a single shell `run:` step against the Cloudflare API. No JS-
  action runtime to opt in.
- **Approach 1** from #265 (env var, not per-action version bumps).
  Reasoning called out in the commit message: single line per
  workflow vs researching version pins across `actions/*`,
  `cloudflare/*`, and `peter-evans/*`. Once each vendor ships a
  native Node-24 release the env var becomes a no-op and we can drop
  the four blocks in a follow-up sweep.

## Test plan

The signal we want: every workflow runs green under Node 24 with no
`Node.js 20 actions are deprecated` warning lines in the Actions log.

- [ ] `build-check` (pull_request) — passes on this PR.
- [ ] `gitleaks` (pull_request) — passes on this PR.
- [ ] `pr-preview` (pull_request) — deploys preview Worker; preview
      comment posts/updates; no Node 20 warning in the log.
- [ ] `pr-preview-cleanup` (on PR close) — still issues the
      idempotent DELETE successfully. *(Validates the no-change call;
      verifiable when this PR closes.)*
- [ ] `pages` (push to `main`) — only fires post-merge; verify on
      the next merge to `main` that the deploy still runs clean.
- [ ] Spot-check the Actions log on each run for residual
      `Node.js 20 actions are deprecated` warnings — should be zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)