### PR TITLE
feat(scaffold): lift FpsOverlay to shell-owned (#261)

### DIFF
--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -48,7 +48,6 @@ import {
   type PlinthHandles,
   type PlinthSlot,
 } from '@/scaffold/staging/Plinth';
-import { FpsOverlay } from '@/scaffold/perf/FpsOverlay';
 import { createGradientArrow, type GradientArrowHandles } from './GradientArrow';
 import { GradientLevelsReadout } from './GradientLevelsReadout';
 import { BOUND, fJsRaw, gradJs } from './surfaceModel';
@@ -98,12 +97,6 @@ const PLINTH_SLIDER_MID_Y = 0.275;
 const PLINTH_READOUT_Y = 0.57;
 const PLINTH_AXIS_INDICATOR_X = 0.42;
 const PLINTH_AXIS_INDICATOR_Y = 0.275;
-
-// Debug-only FPS readout (#99), gated behind `?fps=1`. World-anchored
-// above the plinth, not slotted — dev tooling, not user-facing UI.
-// Stopgap per-scene wiring (#261); the proper shell-owned lift is a
-// future PR.
-const FPS_OVERLAY_POSITION = new THREE.Vector3(0, 1.85, 0.05);
 
 // Per-slider variable + value labels (#170). All three sliders (θ/φ/k)
 // carry a two-line right-aligned label anchored ~0.05 m left of each
@@ -286,7 +279,6 @@ let contrastPit: ContrastPitHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
 let stageInnerRailing: StageInnerRailingHandles | undefined;
 let plinth: PlinthHandles | undefined;
-let fpsOverlay: FpsOverlay | undefined;
 let pointers: readonly Pointer[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
 // yaw-billboarding in update().
@@ -497,18 +489,9 @@ const gradientLevelsExhibit: Exhibit = {
       slots,
     });
     group.add(plinth.group);
-
-    // Optional in-VR FPS readout (#99), gated behind `?fps=1` on the
-    // URL. Stopgap per-scene wiring per #261; proper shell-owned lift
-    // is a future PR.
-    if (isFpsOverlayEnabled()) {
-      fpsOverlay = new FpsOverlay();
-      fpsOverlay.group.position.copy(FPS_OVERLAY_POSITION);
-      group.add(fpsOverlay.group);
-    }
   },
 
-  update({ delta }) {
+  update() {
     // Per-slider labels (θ/φ/k) are accessory (#170) — handled by per-call
     // guards below; not gated here so a missing label never blocks
     // slider/raycast updates.
@@ -612,10 +595,6 @@ const gradientLevelsExhibit: Exhibit = {
     //    (Per-slider label faceCamera calls live in step 2b above.)
     if (worldAxes && camera) worldAxes.faceCamera(camera);
     if (camera) gradientLevelsReadout.faceCamera(camera);
-    if (fpsOverlay) {
-      fpsOverlay.update(delta, performance.now());
-      if (camera) fpsOverlay.faceCamera(camera);
-    }
   },
 
   unmount() {
@@ -687,10 +666,6 @@ const gradientLevelsExhibit: Exhibit = {
       plinth.dispose();
       plinth = undefined;
     }
-    if (fpsOverlay) {
-      fpsOverlay.dispose();
-      fpsOverlay = undefined;
-    }
 
     // 3. Drop external references so a re-mount starts clean. The shell
     //    removes ctx.group and its descendants automatically.
@@ -713,11 +688,6 @@ const gradientLevelsExhibit: Exhibit = {
     kSlider?.releaseFromPointer(pointer);
   },
 };
-
-function isFpsOverlayEnabled(): boolean {
-  if (typeof window === 'undefined') return false;
-  return new URLSearchParams(window.location.search).get('fps') === '1';
-}
 
 registerExhibit(gradientLevelsExhibit);
 

--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -467,6 +467,18 @@ still binds them to the plinth's slot-Y axis above the rack; the
 yaw-billboarding keeps text legible across pancake and headset
 viewing distances rather than foreshortening with the surface tilt.
 
+**FPS-overlay carve-out: shell-owned (#261).** The `?fps=1`-gated
+dev `FpsOverlay` (#99) is intentionally NOT a plinth slot — it's
+debug-only readout, not user-facing UI. As of #261 the overlay is
+shell-owned (`src/shell/shell.ts` `FPS_OVERLAY_POSITION` at world
+`(0, 1.85, 0.05)`), allocated once at boot when the flag is set,
+ticked from the shell animation loop, and disposed via the shell's
+LIFO drain. The matching `RendererInfoProbe` console probe (#102)
+stays quadrics-local — only this scene has the raymarcher
+fragment-cost question that probe was added to answer — and still
+shares the same `?fps=1` gate via a per-scene `isFpsOverlayEnabled`
+helper. Plinth-mounted UI primitives are unaffected.
+
 **Section-tab + canonical-forms-heading anchoring (#255 PR1).** The
 4-element vertical rack at the left of the plinth (canonical-forms
 heading + 3 SectionTabs) is centered on the working-surface

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -13,7 +13,6 @@ import {
 import { classify, getPlanePose } from './classify';
 import { createDoublePlane, type DoublePlaneHandles } from './DoublePlane';
 import { EquationReadout } from './EquationReadout';
-import { FpsOverlay } from '@/scaffold/perf/FpsOverlay';
 import { Label } from '@/scaffold/ui/Label';
 import { Preset, type LinearPresetValues, type PresetValues } from '@/scaffold/ui/Preset';
 import { PresetTween } from '@/scaffold/anim/PresetTween';
@@ -200,15 +199,6 @@ const PLINTH_RACK_LABEL_Y = 0.74;
 // math-frame-aligned regardless of the working-surface tilt.
 const PLINTH_AXIS_INDICATOR_X = 0.42;
 const PLINTH_AXIS_INDICATOR_Y = 0.275;
-
-// Debug-only FPS readout (#99), gated behind `?fps=1`. Kept at its
-// world-frame position rather than going through the plinth slot
-// manifest — `?fps=1`-gated dev tooling, not user-facing UI (see §5
-// acceptance carve-out in `_private/plans/225-control-plinth.md`).
-// X / Y unchanged; Z tracks PLINTH_ANCHOR_WORLD_XYZ.z so the overlay
-// continues to sit above the slider rack rather than getting
-// stranded somewhere else in world-Z when the anchor shifts.
-const FPS_OVERLAY_POSITION = new THREE.Vector3(0, 1.85, 0.05);
 
 // Smaller than Label's 0.16 default; matches the closer ~0.7 m viewing
 // distance from the user's spawn point.
@@ -866,7 +856,6 @@ let presetsExpanded = false;
 let pointers: readonly Pointer[] = [];
 let rackLabel: Label | undefined;
 let equationReadout: EquationReadout | undefined;
-let fpsOverlay: FpsOverlay | undefined;
 let rendererInfoProbe: RendererInfoProbe | undefined;
 let worldAxes: WorldAxes | undefined;
 let camera: THREE.Camera | undefined;
@@ -1349,15 +1338,14 @@ const quadricsExhibit: Exhibit = {
     });
     group.add(plinth.group);
 
-    // Optional in-VR FPS readout (#99) + console renderer.info dump
-    // (#102). Both off by default; opt-in via a `?fps=1` query string
-    // on the URL. The console probe pairs with the in-VR overlay: FPS
-    // says how fast we're rendering, renderer.info says what we're
-    // asking the GPU to render.
+    // Optional console renderer.info dump (#102), gated by `?fps=1`
+    // — same query flag as the shell-owned FPS overlay (#261). The
+    // in-VR FPS reading lives on the shell now; this console probe
+    // is the paired complement: FPS says how fast we're rendering,
+    // renderer.info says what we're asking the GPU to render. Stays
+    // quadrics-local because only this scene has the raymarcher
+    // fragment-cost question the probe was added to answer (#102).
     if (isFpsOverlayEnabled()) {
-      fpsOverlay = new FpsOverlay();
-      fpsOverlay.group.position.copy(FPS_OVERLAY_POSITION);
-      group.add(fpsOverlay.group);
       rendererInfoProbe = new RendererInfoProbe(renderer);
     }
 
@@ -1380,7 +1368,6 @@ const quadricsExhibit: Exhibit = {
     if (rackLabel) ownedDisposables.push(rackLabel);
     if (equationReadout) ownedDisposables.push(equationReadout);
     if (worldAxes) ownedDisposables.push(worldAxes);
-    if (fpsOverlay) ownedDisposables.push(fpsOverlay);
   },
 
   update({ delta }) {
@@ -1558,10 +1545,6 @@ const quadricsExhibit: Exhibit = {
       if (camera) equationReadout.faceCamera(camera);
     }
     if (worldAxes && camera) worldAxes.faceCamera(camera);
-    if (fpsOverlay) {
-      fpsOverlay.update(delta, performance.now());
-      if (camera) fpsOverlay.faceCamera(camera);
-    }
     if (rendererInfoProbe) rendererInfoProbe.update(performance.now());
   },
 
@@ -1650,7 +1633,6 @@ const quadricsExhibit: Exhibit = {
     pointers = [];
     rackLabel = undefined;
     equationReadout = undefined;
-    fpsOverlay = undefined;
     // RendererInfoProbe holds a renderer reference for read-only stats —
     // no GPU resources to dispose. Reset to undefined so re-mount's
     // `if (isFpsOverlayEnabled())` conditional allocates fresh.

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -42,7 +42,6 @@ import {
   type PlinthHandles,
   type PlinthSlot,
 } from '@/scaffold/staging/Plinth';
-import { FpsOverlay } from '@/scaffold/perf/FpsOverlay';
 import {
   createCriticalPointMarkers,
   type CriticalPointMarkersHandles,
@@ -115,12 +114,6 @@ const PLINTH_PRESET_ROW_START_X = -2 * PLINTH_PRESET_COL_PITCH;
 const PLINTH_READOUT_Y = 0.70;
 const PLINTH_AXIS_INDICATOR_X = 0.42;
 const PLINTH_AXIS_INDICATOR_Y = 0.275;
-
-// Debug-only FPS readout (#99), gated behind `?fps=1`. World-anchored
-// above the plinth, not slotted — dev tooling, not user-facing UI.
-// Stopgap per-scene wiring (#261); the proper shell-owned lift is a
-// future PR.
-const FPS_OVERLAY_POSITION = new THREE.Vector3(0, 1.85, 0.05);
 
 // Stage floor cutout half-extent (#238 / E1.1) — derived from the
 // widest preset domain so a future preset with a wider (x, y) window
@@ -218,7 +211,6 @@ let contrastPit: ContrastPitHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
 let stageInnerRailing: StageInnerRailingHandles | undefined;
 let plinth: PlinthHandles | undefined;
-let fpsOverlay: FpsOverlay | undefined;
 let activePresetIndex = DEFAULT_PRESET_INDEX;
 let saddleExtremaReadout: SaddleExtremaReadout | undefined;
 let camera: THREE.Camera | undefined;
@@ -477,18 +469,9 @@ const saddleExtremaExhibit: Exhibit = {
       slots,
     });
     group.add(plinth.group);
-
-    // Optional in-VR FPS readout (#99), gated behind `?fps=1` on the
-    // URL. Stopgap per-scene wiring per #261; proper shell-owned lift
-    // is a future PR.
-    if (isFpsOverlayEnabled()) {
-      fpsOverlay = new FpsOverlay();
-      fpsOverlay.group.position.copy(FPS_OVERLAY_POSITION);
-      group.add(fpsOverlay.group);
-    }
   },
 
-  update({ delta }) {
+  update() {
     const activePreset = PRESETS[activePresetIndex];
 
     if (xSlider && ySlider) {
@@ -556,10 +539,6 @@ const saddleExtremaExhibit: Exhibit = {
     // Yaw-only billboard on the WorldAxes letter labels so they read at
     // any user yaw. Same per-frame contract as cluster siblings.
     if (worldAxes && camera) worldAxes.faceCamera(camera);
-    if (fpsOverlay) {
-      fpsOverlay.update(delta, performance.now());
-      if (camera) fpsOverlay.faceCamera(camera);
-    }
   },
 
   unmount() {
@@ -617,10 +596,6 @@ const saddleExtremaExhibit: Exhibit = {
     if (plinth) {
       plinth.dispose();
       plinth = undefined;
-    }
-    if (fpsOverlay) {
-      fpsOverlay.dispose();
-      fpsOverlay = undefined;
     }
 
     // 3. Drop external references so a re-mount starts clean.
@@ -734,11 +709,6 @@ function applyPreset(idx: number): void {
     xSlider?.value ?? 0,
     ySlider?.value ?? 0,
   );
-}
-
-function isFpsOverlayEnabled(): boolean {
-  if (typeof window === 'undefined') return false;
-  return new URLSearchParams(window.location.search).get('fps') === '1';
 }
 
 registerExhibit(saddleExtremaExhibit);

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -48,7 +48,6 @@ import {
   type PlinthHandles,
   type PlinthSlot,
 } from '@/scaffold/staging/Plinth';
-import { FpsOverlay } from '@/scaffold/perf/FpsOverlay';
 import { createTangentPlane, type TangentPlaneHandles } from './TangentPlane';
 import { TangentPlaneReadout } from './TangentPlaneReadout';
 
@@ -101,14 +100,6 @@ const PLINTH_SLIDER_TOP_Y = 0.345;
 const PLINTH_READOUT_Y = 0.57;
 const PLINTH_AXIS_INDICATOR_X = 0.42;
 const PLINTH_AXIS_INDICATOR_Y = 0.275;
-
-// Debug-only FPS readout (#99), gated behind `?fps=1`. Kept at its
-// world-frame position rather than going through the plinth slot
-// manifest — `?fps=1`-gated dev tooling, not user-facing UI (see §5
-// acceptance carve-out in `_private/plans/225-control-plinth.md`).
-// Stopgap per-scene wiring (#261); the proper shell-owned lift is a
-// future PR.
-const FPS_OVERLAY_POSITION = new THREE.Vector3(0, 1.85, 0.05);
 
 // Tighter than quadrics' BOUND=3.5: the unit sphere fits in [-1, 1]³ with
 // room to spare; no coefficient-driven expansion to budget for.
@@ -257,7 +248,6 @@ let contrastPit: ContrastPitHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
 let stageInnerRailing: StageInnerRailingHandles | undefined;
 let plinth: PlinthHandles | undefined;
-let fpsOverlay: FpsOverlay | undefined;
 let pointers: readonly Pointer[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
 // yaw-billboarding in update().
@@ -525,19 +515,9 @@ const tangentPlanesExhibit: Exhibit = {
       slots,
     });
     group.add(plinth.group);
-
-    // Optional in-VR FPS readout (#99), gated behind `?fps=1` on the
-    // URL. Stopgap per-scene wiring per #261; proper shell-owned lift
-    // is a future PR. World-anchored above the plinth, not slotted —
-    // dev tooling shouldn't ride along with user-facing UI.
-    if (isFpsOverlayEnabled()) {
-      fpsOverlay = new FpsOverlay();
-      fpsOverlay.group.position.copy(FPS_OVERLAY_POSITION);
-      group.add(fpsOverlay.group);
-    }
   },
 
-  update({ delta }) {
+  update() {
     // Labels are accessory (#170) — handled by per-call guards below;
     // not gated here so a missing label never blocks slider/raycast updates.
     if (!thetaSlider || !phiSlider || !indicator || !tangentPlane) return;
@@ -621,10 +601,6 @@ const tangentPlanesExhibit: Exhibit = {
     // they read at any user yaw. Same per-frame contract as quadrics.
     if (worldAxes && camera) worldAxes.faceCamera(camera);
     if (tangentPlaneReadout && camera) tangentPlaneReadout.faceCamera(camera);
-    if (fpsOverlay) {
-      fpsOverlay.update(delta, performance.now());
-      if (camera) fpsOverlay.faceCamera(camera);
-    }
   },
 
   unmount() {
@@ -686,10 +662,6 @@ const tangentPlanesExhibit: Exhibit = {
       plinth.dispose();
       plinth = undefined;
     }
-    if (fpsOverlay) {
-      fpsOverlay.dispose();
-      fpsOverlay = undefined;
-    }
 
     // 3. Drop external references so a re-mount starts clean. The shell
     //    removes ctx.group and its descendants automatically. Clear the
@@ -734,11 +706,6 @@ const tangentPlanesExhibit: Exhibit = {
     }
   },
 };
-
-function isFpsOverlayEnabled(): boolean {
-  if (typeof window === 'undefined') return false;
-  return new URLSearchParams(window.location.search).get('fps') === '1';
-}
 
 registerExhibit(tangentPlanesExhibit);
 

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -18,6 +18,7 @@ import { VRPointer } from './VRPointer';
 import { DesktopPointer } from './DesktopPointer';
 import { createCameraControls } from './cameraControls';
 import { createEnvironment } from '@/scaffold/staging/Environment';
+import { FpsOverlay } from '@/scaffold/perf/FpsOverlay';
 
 // Vite HMR can re-execute module-level code in dev. `bootShell` is
 // idempotent against double-invocation: subsequent calls early-return
@@ -65,6 +66,23 @@ const disposers: Array<() => void> = [];
  * (deriving from each scene's inner-railing geometry) is #263.
  */
 const VR_SPAWN_FORWARD_Z_M = 1.5;
+
+/**
+ * World-frame anchor for the `?fps=1`-gated dev FPS overlay (#261).
+ *
+ * Cluster-uniform: sits above the plinth front face, X-centered on
+ * the plinth midline. Z = 0.05 tracks `PLINTH_ANCHOR_WORLD_XYZ.z`
+ * so the overlay continues to sit above the slider rack rather than
+ * getting stranded in world-Z if the plinth anchor shifts. Y = 1.85
+ * keeps it ~25 cm above eye level for a 1.6 m spawn — high enough
+ * to not occlude the math object, low enough to read at a glance
+ * without breaking the user's neck.
+ *
+ * Per-scene-adaptive overlay anchor (#263 territory) is explicitly
+ * out of scope per the #261 issue body — debug-only readout is
+ * lower priority than user-facing UI.
+ */
+const FPS_OVERLAY_POSITION = new THREE.Vector3(0, 1.85, 0.05);
 
 if (import.meta.hot) {
   import.meta.hot.dispose(() => {
@@ -141,6 +159,28 @@ async function bootShellAsync(): Promise<void> {
     scene.background = null;
     environment.dispose();
   });
+
+  // Shell-owned `?fps=1`-gated dev FPS overlay (#261). Lifted from
+  // four near-identical per-scene `mount()` blocks (the #264
+  // stopgap) so future scenes get the readout for free without
+  // copy-paste. World-anchored at `FPS_OVERLAY_POSITION`; the
+  // shell drives `update()` + `faceCamera()` per render frame.
+  //
+  // Pre-mode-probe alloc on purpose: position is mode-independent,
+  // and the disposer (pushed AFTER the renderer disposer below to
+  // preserve LIFO ordering — releases troika Text GL resources
+  // BEFORE renderer.dispose() frees the GL context, mirroring the
+  // environment-disposer pattern above) drains cleanly on
+  // mid-probe HMR too.
+  const fpsOverlay = isFpsOverlayEnabled() ? new FpsOverlay() : null;
+  if (fpsOverlay) {
+    fpsOverlay.group.position.copy(FPS_OVERLAY_POSITION);
+    scene.add(fpsOverlay.group);
+    disposers.push(() => {
+      scene.remove(fpsOverlay.group);
+      fpsOverlay.dispose();
+    });
+  }
 
   const resizeHandler = (): void => {
     camera.aspect = window.innerWidth / window.innerHeight;
@@ -673,6 +713,14 @@ async function bootShellAsync(): Promise<void> {
     rack.faceCamera(camera);
     rack.updateHover(pointers);
     rack.update();
+    // `?fps=1` dev overlay tick (#261). Reads this-frame `delta`
+    // and the post-exhibit-update camera matrices (faceCamera
+    // billboard); placed before `renderer.render` so the synced
+    // text reflects the frame about to be drawn.
+    if (fpsOverlay) {
+      fpsOverlay.update(delta, performance.now());
+      fpsOverlay.faceCamera(camera);
+    }
     renderer.render(scene, camera);
   });
   // Stop the loop FIRST on HMR dispose — pushed last so it pops first
@@ -716,4 +764,21 @@ async function resolveBootMode(): Promise<Mode> {
     // permissions, etc.). Treat any throw as "no immersive support."
     return 'desktop';
   }
+}
+
+/**
+ * `?fps=1`-gated dev overlay opt-in (#261). Lifted to shell scope
+ * from four near-identical per-scene copies (#264 stopgap). The
+ * `typeof window` guard makes the helper safe in environments
+ * without a DOM (e.g., a future SSR shell-test harness); for the
+ * browser path it's a one-line URL-param read.
+ *
+ * Quadrics still has its own copy of this helper for the
+ * `RendererInfoProbe` console probe (#102) which shares the same
+ * gate but isn't lifted — see issue #261 body for the
+ * "don't break the pairing" carve-out.
+ */
+function isFpsOverlayEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  return new URLSearchParams(window.location.search).get('fps') === '1';
 }


### PR DESCRIPTION
Closes #261

## Summary

Move `FpsOverlay` allocation, scene-graph parenting, animation-loop
tick, and dispose into `src/shell/shell.ts`. Delete the four
near-identical per-scene wirings introduced by the #264 stopgap
(during #251 smoke) so future scenes (#233 capability audit,
post-1.0 portfolio) get the `?fps=1` overlay for free without
copy-paste.

`RendererInfoProbe` (#102) stays quadrics-local under the same
`?fps=1` gate per the issue carve-out — only that scene has the
raymarcher fragment-cost question the probe was added to answer.
The two `isFpsOverlayEnabled` copies (shell + quadrics) are
intentional and documented.

Disposer ordering: the new `fpsOverlay.dispose()` disposer is
pushed AFTER the renderer disposer so the LIFO drain releases
troika Text GL resources BEFORE `renderer.dispose()` frees the
GL context — mirrors the environment-disposer pattern from #224.

Acceptance map from #261:
- [x] `FpsOverlay` constructed once in `shell/shell.ts` behind `?fps=1` gate.
- [x] Per-scene FPS-overlay wiring deleted from quadrics + the three #264-stopgap scenes.
- [x] `FPS_OVERLAY_POSITION` constant lifted to the shell layer.
- [x] Mount-leak gate preserved (overlay now lives outside per-scene mount/unmount entirely).
- [x] Quadrics' `SPEC.md` "Staging — Control plinth" gains an "FPS-overlay carve-out: shell-owned" note.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm test` — 555/555 pass.
- [x] `npm run build` succeeds.
- [x] `npm run lint` clean.
- [x] Pre-commit (gitleaks + standard fixers + ESLint) passed locally.
- [x] Headset smoke on Cloudflare PR preview (`?exhibit=<id>&fps=1`): overlay renders above plinth, FPS reads plausibly (~72 Hz on Quest 3S, ≥60 on pancake), `faceCamera` keeps it legible at all orbit poses, anchor doesn't move across SceneRack switches.
- [x] Pancake smoke at `?fps=1` on default preview URL: same as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)