### PR TITLE
refactor(staging): lift the per-scene lighting pair into shared StageLighting (#248)

### DIFF
--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -44,6 +44,10 @@ import {
   type StageInnerRailingHandles,
 } from '@/scaffold/staging/StageInnerRailing';
 import {
+  createStageLighting,
+  type StageLightingHandles,
+} from '@/scaffold/staging/StageLighting';
+import {
   createPlinth,
   type PlinthHandles,
   type PlinthSlot,
@@ -278,6 +282,7 @@ let stageFloor: StageFloorHandles | undefined;
 let contrastPit: ContrastPitHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
 let stageInnerRailing: StageInnerRailingHandles | undefined;
+let stageLighting: StageLightingHandles | undefined;
 let plinth: PlinthHandles | undefined;
 let pointers: readonly Pointer[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
@@ -297,11 +302,8 @@ const gradientLevelsExhibit: Exhibit = {
     pointers = shellPointers;
     camera = cam;
 
-    // Ambient + directional lights matching cluster siblings.
-    group.add(new THREE.AmbientLight(0xffffff, 0.4));
-    const directional = new THREE.DirectionalLight(0xffffff, 0.8);
-    directional.position.copy(LIGHT_DIR).multiplyScalar(5);
-    group.add(directional);
+    stageLighting = createStageLighting({ direction: LIGHT_DIR });
+    group.add(stageLighting.group);
 
     // Stage floor with rect cutout sized to the math-frame domain
     // envelope (#238 / E1.1). Cutout reaches world Z = -7, beyond the
@@ -661,6 +663,10 @@ const gradientLevelsExhibit: Exhibit = {
     if (stageInnerRailing) {
       stageInnerRailing.dispose();
       stageInnerRailing = undefined;
+    }
+    if (stageLighting) {
+      stageLighting.dispose();
+      stageLighting = undefined;
     }
     if (plinth) {
       plinth.dispose();

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -32,6 +32,10 @@ import {
   type StageInnerRailingHandles,
 } from '@/scaffold/staging/StageInnerRailing';
 import {
+  createStageLighting,
+  type StageLightingHandles,
+} from '@/scaffold/staging/StageLighting';
+import {
   createPlinth,
   type PlinthHandles,
   type PlinthSlot,
@@ -888,6 +892,7 @@ let stageFloor: StageFloorHandles | undefined;
 let contrastPit: ContrastPitHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
 let stageInnerRailing: StageInnerRailingHandles | undefined;
+let stageLighting: StageLightingHandles | undefined;
 let plinth: PlinthHandles | undefined;
 
 const quadricsExhibit: Exhibit = {
@@ -959,10 +964,8 @@ const quadricsExhibit: Exhibit = {
     stageInnerRailing = createStageInnerRailing({ cutout: cutoutDescriptor });
     group.add(stageInnerRailing.group);
 
-    group.add(new THREE.AmbientLight(0xffffff, 0.4));
-    const directional = new THREE.DirectionalLight(0xffffff, 0.8);
-    directional.position.copy(LIGHT_DIR).multiplyScalar(5);
-    group.add(directional);
+    stageLighting = createStageLighting({ direction: LIGHT_DIR });
+    group.add(stageLighting.group);
 
     const surfaceHandles = createImplicitSurface({
       surfaceCenter: SURFACE_CENTER,
@@ -1588,6 +1591,10 @@ const quadricsExhibit: Exhibit = {
     if (stageInnerRailing) {
       stageInnerRailing.dispose();
       stageInnerRailing = undefined;
+    }
+    if (stageLighting) {
+      stageLighting.dispose();
+      stageLighting = undefined;
     }
     if (plinth) {
       plinth.dispose();

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -38,6 +38,10 @@ import {
   type StageInnerRailingHandles,
 } from '@/scaffold/staging/StageInnerRailing';
 import {
+  createStageLighting,
+  type StageLightingHandles,
+} from '@/scaffold/staging/StageLighting';
+import {
   createPlinth,
   type PlinthHandles,
   type PlinthSlot,
@@ -210,6 +214,7 @@ let stageFloor: StageFloorHandles | undefined;
 let contrastPit: ContrastPitHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
 let stageInnerRailing: StageInnerRailingHandles | undefined;
+let stageLighting: StageLightingHandles | undefined;
 let plinth: PlinthHandles | undefined;
 let activePresetIndex = DEFAULT_PRESET_INDEX;
 let saddleExtremaReadout: SaddleExtremaReadout | undefined;
@@ -237,15 +242,12 @@ const saddleExtremaExhibit: Exhibit = {
     activePresetIndex = DEFAULT_PRESET_INDEX;
     const initialPreset = PRESETS[activePresetIndex];
 
-    // Ambient + directional lights match cluster siblings. The graph
-    // surface uses a custom ShaderMaterial reproducing the cluster's
-    // lambert formula; the DirectionalLight here is decorative for the
-    // surface (ShaderMaterial doesn't auto-bind scene lights) but lights
-    // accessory geometry (indicator).
-    group.add(new THREE.AmbientLight(0xffffff, 0.4));
-    const directional = new THREE.DirectionalLight(0xffffff, 0.8);
-    directional.position.copy(LIGHT_DIR).multiplyScalar(5);
-    group.add(directional);
+    // The graph surface uses a custom ShaderMaterial reproducing the
+    // cluster's lambert formula; the DirectionalLight here is
+    // decorative for the surface (ShaderMaterial doesn't auto-bind
+    // scene lights) but lights accessory geometry (indicator).
+    stageLighting = createStageLighting({ direction: LIGHT_DIR });
+    group.add(stageLighting.group);
 
     // Stage floor with rect cutout (#238 / E1.1), sized to the widest
     // preset domain (`STAGE_CUTOUT_HALF` derived from PRESETS — see
@@ -592,6 +594,10 @@ const saddleExtremaExhibit: Exhibit = {
     if (stageInnerRailing) {
       stageInnerRailing.dispose();
       stageInnerRailing = undefined;
+    }
+    if (stageLighting) {
+      stageLighting.dispose();
+      stageLighting = undefined;
     }
     if (plinth) {
       plinth.dispose();

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -44,6 +44,10 @@ import {
   type StageInnerRailingHandles,
 } from '@/scaffold/staging/StageInnerRailing';
 import {
+  createStageLighting,
+  type StageLightingHandles,
+} from '@/scaffold/staging/StageLighting';
+import {
   createPlinth,
   type PlinthHandles,
   type PlinthSlot,
@@ -247,6 +251,7 @@ let stageFloor: StageFloorHandles | undefined;
 let contrastPit: ContrastPitHandles | undefined;
 let stageRailing: StageRailingHandles | undefined;
 let stageInnerRailing: StageInnerRailingHandles | undefined;
+let stageLighting: StageLightingHandles | undefined;
 let plinth: PlinthHandles | undefined;
 let pointers: readonly Pointer[] = [];
 // Cached at mount; cleared at unmount. Used for the WorldAxes label
@@ -328,11 +333,8 @@ const tangentPlanesExhibit: Exhibit = {
     pointers = shellPointers;
     camera = cam;
 
-    // Ambient + directional lights matching quadrics' lighting setup.
-    group.add(new THREE.AmbientLight(0xffffff, 0.4));
-    const directional = new THREE.DirectionalLight(0xffffff, 0.8);
-    directional.position.copy(LIGHT_DIR).multiplyScalar(5);
-    group.add(directional);
+    stageLighting = createStageLighting({ direction: LIGHT_DIR });
+    group.add(stageLighting.group);
 
     // Stage floor with circular cutout (#238 / E1.1). Per-scene
     // outerHalfExtent: 6 (12 × 12 m floor) so the BOUND-radius disk fits
@@ -657,6 +659,10 @@ const tangentPlanesExhibit: Exhibit = {
     if (stageInnerRailing) {
       stageInnerRailing.dispose();
       stageInnerRailing = undefined;
+    }
+    if (stageLighting) {
+      stageLighting.dispose();
+      stageLighting = undefined;
     }
     if (plinth) {
       plinth.dispose();

--- a/src/scaffold/staging/StageLighting.ts
+++ b/src/scaffold/staging/StageLighting.ts
@@ -1,0 +1,103 @@
+import * as THREE from 'three';
+
+// Cluster-wide lighting pair for the v1.0 staged-exhibit vocabulary
+// (#248 — extract-on-Nth-use lift from quadrics / tangent-planes /
+// gradient-levels / saddle-extrema, all of which declared the
+// identical `AmbientLight(0xffffff, 0.4) + DirectionalLight(0xffffff,
+// 0.8)` block in `mount()`).
+//
+// EXHIBIT-OWNED, per-scene — same ownership + lifecycle as
+// StageFloor / StageRailing / StageInnerRailing / ContrastPit
+// (allocated in `mount`, disposed in `unmount`). The shell removes
+// `ctx.group` after `unmount` returns, so `dispose()` only releases
+// owned GPU resources. Lights inherit from `Object3D` and have no
+// GPU resources to release, so `dispose()` here is a marker for
+// lifecycle symmetry rather than a real release; the idempotency
+// guard matches the rest of the staging primitives.
+//
+// Direction is REQUIRED (not defaulted): the scene's LIGHT_DIR also
+// flows into the math surface's shader as `uLightDir` so the
+// directional light and the shaded surface agree on a single
+// math-frame illumination vector. Sharing it via this scaffold +
+// re-using it scene-side as a uniform keeps that agreement
+// declarative.
+
+/** White light, on purpose. Immutable tuple per the THREE.js token
+ *  export discipline (v1.0.md §4 / feedback_threejs_token_exports_
+ *  immutable) — `0xffffff` would round-trip through every consumer's
+ *  hex parsing, but the tuple stays consistent with sibling
+ *  primitives (STAGE_FLOOR_COLOR_RGB, CONTRAST_PIT_COLOR_RGB). */
+export const STAGE_LIGHTING_COLOR_RGB = [1, 1, 1] as const;
+
+/** Ambient term intensity. Inherited verbatim from the per-scene
+ *  duplication; first-pass and smoke-tunable
+ *  (feedback_staging_dimensions_first_pass). */
+export const STAGE_LIGHTING_AMBIENT_INTENSITY_DEFAULT = 0.4;
+
+/** Directional term intensity. Inherited verbatim from the per-scene
+ *  duplication; first-pass and smoke-tunable. */
+export const STAGE_LIGHTING_DIRECTIONAL_INTENSITY_DEFAULT = 0.8;
+
+/** Distance along `direction` at which the DirectionalLight sits.
+ *  Three.js's DirectionalLight is positional only for shadow-camera
+ *  framing (which we don't use here), but keeping the established
+ *  `dir × 5` placement preserves the look across the lift. */
+export const STAGE_LIGHTING_DISTANCE_DEFAULT = 5;
+
+export interface StageLightingOptions {
+  /** Math-frame illumination direction, unit length. Also flows into
+   *  each scene's math-surface shader as `uLightDir` — that's why the
+   *  scene owns it and passes it in here rather than the scaffold
+   *  defaulting one. */
+  readonly direction: THREE.Vector3;
+  /** Default `STAGE_LIGHTING_AMBIENT_INTENSITY_DEFAULT`. */
+  readonly ambientIntensity?: number;
+  /** Default `STAGE_LIGHTING_DIRECTIONAL_INTENSITY_DEFAULT`. */
+  readonly directionalIntensity?: number;
+  /** Default `STAGE_LIGHTING_DISTANCE_DEFAULT`. */
+  readonly distance?: number;
+}
+
+export interface StageLightingHandles {
+  /** Add to the exhibit's group at mount time. */
+  readonly group: THREE.Group;
+  /** Hemispheric ambient term. Exposed for tests + smoke debugging. */
+  readonly ambient: THREE.AmbientLight;
+  /** Math-frame directional term. Exposed for tests + smoke debugging. */
+  readonly directional: THREE.DirectionalLight;
+  /** Idempotent. Exhibit calls in unmount() for lifecycle symmetry —
+   *  the underlying lights hold no GPU resources, but the guard +
+   *  call site stays consistent with sibling staging primitives. */
+  dispose(): void;
+}
+
+export function createStageLighting(
+  opts: StageLightingOptions,
+): StageLightingHandles {
+  const color = new THREE.Color(...STAGE_LIGHTING_COLOR_RGB);
+  const ambientIntensity =
+    opts.ambientIntensity ?? STAGE_LIGHTING_AMBIENT_INTENSITY_DEFAULT;
+  const directionalIntensity =
+    opts.directionalIntensity ?? STAGE_LIGHTING_DIRECTIONAL_INTENSITY_DEFAULT;
+  const distance = opts.distance ?? STAGE_LIGHTING_DISTANCE_DEFAULT;
+
+  const ambient = new THREE.AmbientLight(color, ambientIntensity);
+  const directional = new THREE.DirectionalLight(color, directionalIntensity);
+  directional.position.copy(opts.direction).multiplyScalar(distance);
+
+  const group = new THREE.Group();
+  group.name = 'stage-lighting';
+  group.add(ambient);
+  group.add(directional);
+
+  let disposed = false;
+  return {
+    group,
+    ambient,
+    directional,
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+    },
+  };
+}

--- a/src/scaffold/staging/StageLighting.ts
+++ b/src/scaffold/staging/StageLighting.ts
@@ -10,10 +10,12 @@ import * as THREE from 'three';
 // StageFloor / StageRailing / StageInnerRailing / ContrastPit
 // (allocated in `mount`, disposed in `unmount`). The shell removes
 // `ctx.group` after `unmount` returns, so `dispose()` only releases
-// owned GPU resources. Lights inherit from `Object3D` and have no
-// GPU resources to release, so `dispose()` here is a marker for
-// lifecycle symmetry rather than a real release; the idempotency
-// guard matches the rest of the staging primitives.
+// owned GPU resources. `castShadow` is unset, so today
+// `DirectionalLight.shadow.map` is `null` and `Light.dispose()` is
+// effectively a no-op — but the factory still calls it for
+// forward-safety: a future consumer flipping `castShadow = true`
+// through the exposed handle would otherwise leak the shadow map
+// silently.
 //
 // Direction is REQUIRED (not defaulted): the scene's LIGHT_DIR also
 // flows into the math surface's shader as `uLightDir` so the
@@ -61,13 +63,13 @@ export interface StageLightingOptions {
 export interface StageLightingHandles {
   /** Add to the exhibit's group at mount time. */
   readonly group: THREE.Group;
-  /** Hemispheric ambient term. Exposed for tests + smoke debugging. */
+  /** Uniform ambient term. Exposed for tests + smoke debugging. */
   readonly ambient: THREE.AmbientLight;
   /** Math-frame directional term. Exposed for tests + smoke debugging. */
   readonly directional: THREE.DirectionalLight;
-  /** Idempotent. Exhibit calls in unmount() for lifecycle symmetry —
-   *  the underlying lights hold no GPU resources, but the guard +
-   *  call site stays consistent with sibling staging primitives. */
+  /** Idempotent. Exhibit calls in unmount(). Calls `directional.dispose()`
+   *  unconditionally for forward-safety (today a no-op since `castShadow`
+   *  is unset; non-trivial if anyone later flips it). */
   dispose(): void;
 }
 
@@ -98,6 +100,7 @@ export function createStageLighting(
     dispose(): void {
       if (disposed) return;
       disposed = true;
+      directional.dispose();
     },
   };
 }

--- a/test/scaffold/staging/StageLighting.test.ts
+++ b/test/scaffold/staging/StageLighting.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import * as THREE from 'three';
+import {
+  createStageLighting,
+  STAGE_LIGHTING_AMBIENT_INTENSITY_DEFAULT,
+  STAGE_LIGHTING_DIRECTIONAL_INTENSITY_DEFAULT,
+  STAGE_LIGHTING_DISTANCE_DEFAULT,
+} from '../../../src/scaffold/staging/StageLighting.ts';
+
+const DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
+
+describe('createStageLighting (#248 — cluster-wide lighting pair)', () => {
+  it('builds an AmbientLight + DirectionalLight, both white, defaulted to the per-scene-duplication intensities', () => {
+    const lighting = createStageLighting({ direction: DIR });
+    expect(lighting.group.name).toBe('stage-lighting');
+    expect(lighting.group.children).toContain(lighting.ambient);
+    expect(lighting.group.children).toContain(lighting.directional);
+
+    expect(lighting.ambient).toBeInstanceOf(THREE.AmbientLight);
+    expect(lighting.directional).toBeInstanceOf(THREE.DirectionalLight);
+    expect(lighting.ambient.color.getHex()).toBe(0xffffff);
+    expect(lighting.directional.color.getHex()).toBe(0xffffff);
+    expect(lighting.ambient.intensity).toBe(
+      STAGE_LIGHTING_AMBIENT_INTENSITY_DEFAULT,
+    );
+    expect(lighting.directional.intensity).toBe(
+      STAGE_LIGHTING_DIRECTIONAL_INTENSITY_DEFAULT,
+    );
+    lighting.dispose();
+  });
+
+  it('positions the DirectionalLight at `direction × STAGE_LIGHTING_DISTANCE_DEFAULT`', () => {
+    const lighting = createStageLighting({ direction: DIR });
+    const expected = DIR.clone().multiplyScalar(STAGE_LIGHTING_DISTANCE_DEFAULT);
+    expect(lighting.directional.position.x).toBeCloseTo(expected.x, 6);
+    expect(lighting.directional.position.y).toBeCloseTo(expected.y, 6);
+    expect(lighting.directional.position.z).toBeCloseTo(expected.z, 6);
+    lighting.dispose();
+  });
+
+  it('does not mutate the caller-owned direction vector', () => {
+    // The caller's LIGHT_DIR also flows into the math-surface shader
+    // as a uniform — mutation here would silently corrupt the shader.
+    // The factory does `.copy(direction).multiplyScalar(d)` on the
+    // light's own position, not on the caller's vector.
+    const caller = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
+    const snapshot = caller.clone();
+    const lighting = createStageLighting({ direction: caller });
+    expect(caller.x).toBe(snapshot.x);
+    expect(caller.y).toBe(snapshot.y);
+    expect(caller.z).toBe(snapshot.z);
+    lighting.dispose();
+  });
+
+  it('respects custom intensities + distance', () => {
+    const lighting = createStageLighting({
+      direction: DIR,
+      ambientIntensity: 0.7,
+      directionalIntensity: 1.2,
+      distance: 10,
+    });
+    expect(lighting.ambient.intensity).toBe(0.7);
+    expect(lighting.directional.intensity).toBe(1.2);
+    const expected = DIR.clone().multiplyScalar(10);
+    expect(lighting.directional.position.x).toBeCloseTo(expected.x, 6);
+    expect(lighting.directional.position.y).toBeCloseTo(expected.y, 6);
+    expect(lighting.directional.position.z).toBeCloseTo(expected.z, 6);
+    lighting.dispose();
+  });
+
+  it('dispose() is idempotent', () => {
+    const lighting = createStageLighting({ direction: DIR });
+    expect(() => {
+      lighting.dispose();
+      lighting.dispose();
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #248

## Summary

All four cluster scenes (`quadrics`, `tangent-planes`, `gradient-levels`, `saddle-extrema`) declared the identical `AmbientLight(0xffffff, 0.4) + DirectionalLight(0xffffff, 0.8)` (dir × 5) block in `mount()` — textbook extract-on-Nth-use (#188 rule, recorded in #248's `_private/plans/224-environment-surround.md` §1/§8 deferral). Lift into a new `scaffold/staging/StageLighting` primitive matching the `StageFloor` / `ContrastPit` / `StageRailing` pattern: immutable-tuple tokens (`STAGE_LIGHTING_COLOR_RGB`, `*_INTENSITY_DEFAULT`, `*_DISTANCE_DEFAULT`) + `createStageLighting(opts)` factory returning `{ group, ambient, directional, dispose }` + idempotent dispose + named-handle ownership at the call site.

Each scene's `LIGHT_DIR` stays **scene-local** because it also flows into the math-surface shader as the `uLightDir` uniform; the scaffold takes `direction` as a required option to keep the directional light and the shaded surface agreeing on a single math-frame illumination vector.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 41 files / 560 tests pass, including 5 new `StageLighting.test.ts` cases (light wiring, default + custom intensities/distance, caller-vector non-mutation, idempotent dispose)
- [x] `npx eslint .` clean
- [x] Cloudflare PR preview smoke: visit all four cluster scenes (`?exhibit=quadrics`, `tangent-planes`, `gradient-levels`, `saddle-extrema`) and confirm the math surfaces + accessory geometry are lit identically to `main` — no perceptual delta is the success criterion (verbatim intensities, dir × 5 placement, direction wired from each scene's existing `LIGHT_DIR`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)