### PR TITLE
feat(scaffold): production-value slider thumb composite (#256)

### DIFF
--- a/src/scaffold/ui/Slider.ts
+++ b/src/scaffold/ui/Slider.ts
@@ -3,13 +3,19 @@ import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
 import { raySphereHit } from '@/scaffold/ui/rayHit';
 import type { Pointer } from '@/shell/Pointer';
 
-// `arrow-{x,y,z}` are bidirectional 3D arrows aligned with their respective
-// world axis. The slider group has no rotation, so slider-local frame =
-// world frame; pick the variant whose axis matches the math-frame axis the
-// slider drives (arrow-x for slider 'a' → math-X, arrow-y for slider 'b' →
-// math-Y, arrow-z for slider 'c' → math-Z). `sphere` is reserved for
-// slider 'd' (the constant term — no spatial direction, so a directionless
-// thumb reads as pedagogically truthful).
+// Per-shape composition (#256). All thumbs are now composite: a
+// `THREE.Group` containing an outer translucent axis-tinted sphere
+// (the grab-affordance envelope) and — for `arrow-*` shapes — an
+// interior opaque bidirectional axis-arrow that reads as the
+// slider's math-axis identity through the translucent body.
+// `sphere` produces an outer translucent sphere only (no interior),
+// reserved for sliders without axis identity (quadrics `d`, the
+// constant term) AND for sliders that are axis-tinted point-
+// selectors where the scene's pedagogy favors the empty-sphere
+// reading (saddle-extrema x/y per the 256 v3 plan §3.4 Q8 deferral).
+// Pick the `arrow-*` variant whose axis matches the math-frame axis
+// the slider drives (arrow-x for slider 'a' → math-X, arrow-y for
+// slider 'b' → math-Y, arrow-z for slider 'c' → math-Z).
 export type ThumbShape = 'sphere' | 'arrow-x' | 'arrow-y' | 'arrow-z';
 
 export interface SliderOptions {
@@ -75,6 +81,36 @@ const HAPTIC_DURATION_MS = 10;
 const THUMB_HOVER_SCALE = 0.4;
 const THUMB_GRAB_SCALE = 0.7;
 
+// Outer translucent sphere opacity (#256). Three values for the
+// `sphere`-shaped sliders' hover-state alpha bump: the translucent
+// material's emissive contribution is attenuated by opacity in
+// standard alpha blending, so bumping opacity on hover/grab keeps
+// the affordance cue visually strong even when the hover target is
+// the translucent outer (the only material on a sphere thumb).
+// `arrow-*` thumbs are unaffected — their hover target is the
+// opaque interior arrow, and their outer opacity stays at the
+// steady-state value regardless of state.
+//
+// First-pass per `feedback_staging_dimensions_first_pass`. Bracket
+// per `feedback_binary_search_visual_constants`:
+//   - If smoke shows the interior arrow gets lost behind the body,
+//     drop SLIDER_THUMB_OUTER_OPACITY to 0.20.
+//   - If the outer sphere reads as a haze with no clear shape,
+//     bump SLIDER_THUMB_OUTER_OPACITY to 0.40.
+//   - If hover cue is too weak on neutral-gray sphere sliders,
+//     bump SLIDER_THUMB_OUTER_OPACITY_HOVERED toward 0.65 / 0.70.
+//   - Same for the grabbed state. One dial per round.
+const SLIDER_THUMB_OUTER_OPACITY = 0.3;
+const SLIDER_THUMB_OUTER_OPACITY_HOVERED = 0.5;
+const SLIDER_THUMB_OUTER_OPACITY_GRABBED = 0.7;
+
+// Outer translucent sphere joins the cluster's transparent-pass
+// surfaces (SlicingPlane, TangentPlane, TaylorOverlay — all
+// `renderOrder = 1` per TranslucentRect convention) so depth-sort
+// among transparent surfaces is by camera distance, stable across
+// scenes.
+const SLIDER_THUMB_OUTER_RENDER_ORDER = 1;
+
 // Denominator floor for the skew-line projection in
 // `pointerAxisProjection`. When the pointer ray is nearly parallel to the
 // slider's local X axis (`aDotR ≈ ±1`), `denom = 1 - aDotR² → 0` and the
@@ -89,7 +125,37 @@ export class Slider {
 
   private readonly opts: Required<SliderOptions>;
   private readonly track: THREE.Mesh;
-  private readonly thumb: THREE.Mesh;
+  // Composite thumb (#256): a `THREE.Group` containing an outer
+  // translucent axis-tinted sphere and, for `arrow-*` shapes, an
+  // interior opaque axis-arrow. Position writes still target
+  // `thumb.position.x` like the pre-#256 Mesh; the group inherits
+  // `position` / `getWorldPosition` from Object3D so the hit-test
+  // and drag math are unchanged.
+  private readonly thumb: THREE.Group;
+  // Material(s) whose `.emissive` flips on hover/grab. For `arrow-*`
+  // this is the interior arrow's material; for `sphere` it's the
+  // outer translucent sphere's material. The single-entry list keeps
+  // the type uniform; future shapes that want multi-material glow are
+  // accommodated without re-plumbing the state machine.
+  private readonly hoverTargets: readonly THREE.MeshStandardMaterial[];
+  // Outer translucent sphere's material, exposed for the §3.5 hover-
+  // state opacity bump. May be `null` for future shapes that don't
+  // compose an outer translucent sphere; the four v3 shapes all do.
+  private readonly outerMaterial: THREE.MeshStandardMaterial | null;
+  // True iff the hover/grab handler should bump the outer material's
+  // opacity (#256 v3 §3.5). Set by `buildThumb` per shape: TRUE for
+  // `sphere` (hover target IS the translucent outer; emissive is
+  // alpha-attenuated, opacity bump compensates), FALSE for `arrow-*`
+  // (hover target is the opaque interior; outer stays at steady-
+  // state). Explicit field rather than a `hoverTargets[0] ===
+  // outerMaterial` identity check — keeps intent contractual.
+  private readonly applyOpacityBump: boolean;
+  // Single GPU-resource disposer for the composite thumb's geometry
+  // + material set. Slider.dispose() calls this; never calls
+  // `.geometry.dispose()` / `.material.dispose()` directly on the
+  // composite's children. The track's geometry/material disposal
+  // is independent and stays explicit in dispose().
+  private readonly disposeThumb: () => void;
   private readonly thumbWorld = new THREE.Vector3();
   // Skew-line projection scratches (allocated once per Slider). Shared
   // between `rayHitsThumb` (ray-sphere hit-test) and
@@ -166,10 +232,16 @@ export class Slider {
     this.hoverEmissive = baseColor.clone().multiplyScalar(THUMB_HOVER_SCALE);
     this.grabEmissive = baseColor.clone().multiplyScalar(THUMB_GRAB_SCALE);
 
-    this.thumb = new THREE.Mesh(
-      buildThumbGeometry(this.opts.thumbShape, this.opts.thumbRadius),
-      new THREE.MeshStandardMaterial({ color: baseColor }),
+    const build = buildThumb(
+      this.opts.thumbShape,
+      this.opts.thumbRadius,
+      baseColor,
     );
+    this.thumb = build.object;
+    this.hoverTargets = build.hoverTargets;
+    this.outerMaterial = build.outerMaterial;
+    this.applyOpacityBump = build.applyOpacityBump;
+    this.disposeThumb = build.dispose;
     this.group.add(this.thumb);
 
     this.syncThumbPosition();
@@ -199,10 +271,13 @@ export class Slider {
   }
 
   dispose(): void {
+    // Track owns its own geometry + material; preserved unchanged from
+    // pre-#256. The composite thumb's geometry/material set is owned by
+    // ThumbBuild — never call .dispose() on the composite's children
+    // directly from here.
     this.track.geometry.dispose();
     (this.track.material as THREE.Material).dispose();
-    this.thumb.geometry.dispose();
-    (this.thumb.material as THREE.Material).dispose();
+    this.disposeThumb();
   }
 
   /**
@@ -362,17 +437,40 @@ export class Slider {
     this.refreshThumbEmissive();
   }
 
-  // Thumb emissive is a deterministic function of {grabbed, hovered, idle}.
-  // Called from each transition point — `tryGrab`, `releaseFromPointer`,
-  // and `updateHover` — so the visual always matches state.
+  // Composite thumb visual is a deterministic function of
+  // {grabbed, hovered, idle}. Called from each transition point —
+  // `tryGrab`, `releaseFromPointer`, and `updateHover` — so the
+  // visual always matches state.
+  //
+  // Two surfaces flip:
+  //   1) Every material in `hoverTargets` gets the emissive copy.
+  //      For `arrow-*` thumbs that's the interior arrow (opaque,
+  //      emissive reads at full strength); for `sphere` thumbs
+  //      that's the outer translucent sphere (emissive attenuated
+  //      by alpha — see (2)).
+  //   2) For `sphere` thumbs (`applyOpacityBump === true`), the
+  //      outer material's `.opacity` bumps to the hover/grab value
+  //      so the alpha-attenuated emissive cue still reads as a
+  //      clear pop. `arrow-*` thumbs leave the outer at the
+  //      steady-state opacity regardless of state.
   private refreshThumbEmissive(): void {
-    const mat = this.thumb.material as THREE.MeshStandardMaterial;
-    if (this.grabbedBy) {
-      mat.emissive.copy(this.grabEmissive);
-    } else if (this.hovered) {
-      mat.emissive.copy(this.hoverEmissive);
-    } else {
-      mat.emissive.setHex(0x000000);
+    for (const mat of this.hoverTargets) {
+      if (this.grabbedBy) {
+        mat.emissive.copy(this.grabEmissive);
+      } else if (this.hovered) {
+        mat.emissive.copy(this.hoverEmissive);
+      } else {
+        mat.emissive.setHex(0x000000);
+      }
+    }
+    if (this.applyOpacityBump && this.outerMaterial !== null) {
+      if (this.grabbedBy) {
+        this.outerMaterial.opacity = SLIDER_THUMB_OUTER_OPACITY_GRABBED;
+      } else if (this.hovered) {
+        this.outerMaterial.opacity = SLIDER_THUMB_OUTER_OPACITY_HOVERED;
+      } else {
+        this.outerMaterial.opacity = SLIDER_THUMB_OUTER_OPACITY;
+      }
     }
   }
 
@@ -459,40 +557,132 @@ export class Slider {
   }
 }
 
-// `sphere` matches the hit-test radius exactly. The arrow variants extend
-// past `thumbRadius` along their axis (~1.475r at the cone tip); a
-// caller-supplied `grabRadiusMultiplier` (commonly 2.75) covers the full
-// visible arrow plus margin so the entire shape stays grabbable.
-function buildThumbGeometry(
-  shape: ThumbShape,
-  thumbRadius: number,
-): THREE.BufferGeometry {
-  if (shape === 'sphere') {
-    return new THREE.SphereGeometry(thumbRadius, 16, 12);
-  }
-  return buildArrowGeometry(thumbRadius, shape);
+// ThumbBuild — composite thumb construction result (#256). The
+// builder returns the assembled Group + handles the Slider class
+// uses to drive emissive / opacity-bump state and to dispose the
+// composite's GPU resources. Module-internal; no scene consumer
+// needs to construct this directly.
+interface ThumbBuild {
+  // The Group attached to `slider.group` as the thumb. Marked with
+  // `userData.role = 'slider-thumb'` for testable discovery.
+  // Children: outer translucent sphere (always), interior axis-
+  // arrow (only for `arrow-*` shapes).
+  readonly object: THREE.Group;
+  // Materials whose `.emissive` flips on hover/grab. For `arrow-*`
+  // this is the interior arrow's material; for `sphere` it's the
+  // outer translucent sphere's material.
+  readonly hoverTargets: readonly THREE.MeshStandardMaterial[];
+  // The outer translucent sphere's material. Always non-null in
+  // v3 (both `sphere` and `arrow-*` compose an outer sphere).
+  // Typed `| null` so future shapes that elide the outer envelope
+  // don't break the interface.
+  readonly outerMaterial: THREE.MeshStandardMaterial | null;
+  // True for `sphere` (alpha-attenuated emissive needs an opacity
+  // bump to read as a clear hover/grab cue), false for `arrow-*`
+  // (opaque interior carries the cue at full strength).
+  readonly applyOpacityBump: boolean;
+  // Single disposer for every GPU resource the composite owns.
+  // Slider.dispose() calls this; the slider track's own
+  // geometry/material disposal stays independent.
+  dispose(): void;
 }
 
-// Bidirectional 3D arrow (`<->`) for the axis-coefficient sliders. Built
-// along +Y as a merged geometry (shaft cylinder + two outward-pointing
-// cones), then rotated to the requested world axis. Single mesh + single
-// material via `mergeGeometries` keeps Slider's hover/grab emissive logic
-// untouched.
+// Compose a thumb. For `arrow-*`: outer translucent axis-tinted
+// sphere + interior opaque axis-arrow that reads through the
+// translucent body. For `sphere`: outer translucent sphere only,
+// tinted by the slider's baseColor (axis-tint or neutral gray or
+// yellow — set by the scene's SLIDER_CONFIG).
+function buildThumb(
+  shape: ThumbShape,
+  thumbRadius: number,
+  baseColor: THREE.Color,
+): ThumbBuild {
+  const group = new THREE.Group();
+  group.userData.role = 'slider-thumb';
+
+  const outerGeometry = new THREE.SphereGeometry(thumbRadius, 16, 12);
+  const outerMaterial = new THREE.MeshStandardMaterial({
+    color: baseColor,
+    transparent: true,
+    opacity: SLIDER_THUMB_OUTER_OPACITY,
+    side: THREE.FrontSide,
+    // `depthWrite: false` prevents the outer sphere from occluding
+    // anything drawn after it in the transparent pass — including
+    // the interior arrow (drawn after the outer in the group's
+    // traversal) and any other transparent surface in the scene.
+    // `depthTest` stays at its default (true) so the outer still
+    // hides correctly behind nearer opaque objects (the plinth,
+    // the track, a controller mesh passing in front).
+    depthWrite: false,
+  });
+  const outerMesh = new THREE.Mesh(outerGeometry, outerMaterial);
+  outerMesh.userData.role = 'slider-thumb-outer';
+  outerMesh.renderOrder = SLIDER_THUMB_OUTER_RENDER_ORDER;
+  group.add(outerMesh);
+
+  if (shape === 'sphere') {
+    return {
+      object: group,
+      hoverTargets: [outerMaterial],
+      outerMaterial,
+      applyOpacityBump: true,
+      dispose(): void {
+        outerGeometry.dispose();
+        outerMaterial.dispose();
+      },
+    };
+  }
+
+  const interiorGeometry = buildArrowGeometry(thumbRadius, shape);
+  const interiorMaterial = new THREE.MeshStandardMaterial({
+    color: baseColor,
+    // Interior is opaque — reads as a saturated axis-arrow
+    // through the translucent outer envelope. Emissive on this
+    // material lands at full strength (no alpha attenuation).
+  });
+  const interiorMesh = new THREE.Mesh(interiorGeometry, interiorMaterial);
+  group.add(interiorMesh);
+
+  return {
+    object: group,
+    hoverTargets: [interiorMaterial],
+    outerMaterial,
+    applyOpacityBump: false,
+    dispose(): void {
+      outerGeometry.dispose();
+      outerMaterial.dispose();
+      interiorGeometry.dispose();
+      interiorMaterial.dispose();
+    },
+  };
+}
+
+// Bidirectional 3D arrow (`<->`) for the axis-coefficient sliders'
+// interior content (#256). Built along +Y as a merged geometry
+// (shaft cylinder + two outward-pointing cones), then rotated to
+// the requested world axis. Single mesh + single material via
+// `mergeGeometries` keeps the per-shape hover/grab emissive logic
+// simple. Proportions shrunk vs the pre-#256 standalone arrow so
+// the tip extent (shaftLength/2 + coneHeight = 0.95r) fits inside
+// the outer translucent sphere of radius `thumbRadius` with a
+// small breathing margin (#256 v3 §3.3).
 function buildArrowGeometry(
   thumbRadius: number,
   axis: 'arrow-x' | 'arrow-y' | 'arrow-z',
 ): THREE.BufferGeometry {
   const r = thumbRadius;
-  // Arrow proportions retuned post-headset (#65 follow-up). Shaft thicker
-  // and longer, cones wider — arrows now read as substantive 3D objects
-  // rather than thin sticks at the ~0.7 m viewing distance from the
-  // user's spawn pose. coneRadius = 0.75r keeps the arrowheads
-  // recognizably pointy (h/r = 0.8) after a brief headset pass at 1.0r
-  // showed the cones reading too disc-like at full thumbRadius.
-  const shaftLength = 1.75 * r;
-  const shaftRadius = 0.35 * r;
-  const coneHeight = 0.7 * r;
-  const coneRadius = 0.5 * r;
+  // Composite-era arrow proportions (#256 v3 §3.3). The interior
+  // arrow lives inside an outer translucent sphere of radius r, so
+  // every vertex must be inside that sphere. Tip extent (0.95r)
+  // stays well inside; lateral 0.28r is also fully inside. Thinner
+  // shaft / cone than the pre-composite arrow reads cleaner behind
+  // the translucent envelope. §4.2 Test 6 asserts per-vertex radial
+  // containment so a future maintainer can't drift past the
+  // envelope by retuning a single dimension.
+  const shaftLength = 1.2 * r;
+  const shaftRadius = 0.18 * r;
+  const coneHeight = 0.35 * r;
+  const coneRadius = 0.28 * r;
   // Cone center sits at half-shaft + half-cone along Y so its base flushes
   // against the shaft's end.
   const coneCenter = shaftLength / 2 + coneHeight / 2;

--- a/src/scaffold/ui/Slider.ts
+++ b/src/scaffold/ui/Slider.ts
@@ -606,13 +606,18 @@ function buildThumb(
     transparent: true,
     opacity: SLIDER_THUMB_OUTER_OPACITY,
     side: THREE.FrontSide,
-    // `depthWrite: false` prevents the outer sphere from occluding
-    // anything drawn after it in the transparent pass — including
-    // the interior arrow (drawn after the outer in the group's
-    // traversal) and any other transparent surface in the scene.
-    // `depthTest` stays at its default (true) so the outer still
-    // hides correctly behind nearer opaque objects (the plinth,
-    // the track, a controller mesh passing in front).
+    // `depthWrite: false` prevents this sphere's depth values from
+    // occluding LATER transparent surfaces drawn in the same pass
+    // (other slider thumbs, TangentPlane, TaylorOverlay — all
+    // share renderOrder = 1). The interior arrow's visibility
+    // through this sphere is INDEPENDENT of this flag: the arrow
+    // is opaque (no transparent flag) and so draws in the opaque
+    // pass, which completes before the transparent pass starts.
+    // Opaque-pass depth writes already populate the depth buffer
+    // before this sphere's fragments are tested.
+    // `depthTest` stays at its default (true) so this sphere
+    // still hides correctly behind nearer opaque objects (the
+    // plinth, the track, a controller mesh passing in front).
     depthWrite: false,
   });
   const outerMesh = new THREE.Mesh(outerGeometry, outerMaterial);

--- a/test/scaffold/ui/Slider.test.ts
+++ b/test/scaffold/ui/Slider.test.ts
@@ -113,10 +113,13 @@ function mockPointer(
   };
 }
 
-// Ray aimed at world origin — the slider's thumb sits at the group
-// origin under makeSlider's [-1.5, 1.5] / initial=1 / snapDetent=0.05
-// config (snapped to 0 at the [0]-detent, syncThumbPosition writes
-// thumb.position.x = 0). Hit-test fires.
+// Ray aimed at world origin. Fires when the caller passes
+// `initial: 0` to makeSlider — that's outside the [0]-detent's
+// half-width (0.05) so currentValue stays at 0 and
+// syncThumbPosition writes thumb.position.x = 0. The default
+// makeSlider config (initial: 1.0) places the thumb at x ≈ +0.1,
+// where this ray would miss; tests using hittingRay() must
+// override initial: 0.
 const hittingRay = (): MockPointer => mockPointer([0, 0, 1], [0, 0, -1]);
 const missingRay = (): MockPointer => mockPointer([10, 0, 1], [0, 0, -1]);
 
@@ -442,9 +445,13 @@ describe('Slider thumb composition (#256)', () => {
       slider.updateHover([hittingRay()]);
       expect(outerMesh.material.opacity).toBeCloseTo(0.5);
 
-      // Grab — `tryGrab` clears the hover bit (updateHover short-
-      // circuits while grabbed) and sets grabbed-emissive; opacity
-      // bumps to the grab value.
+      // Grab — `tryGrab` sets grabbedBy and calls
+      // refreshThumbEmissive; the grabbed-branch fires (it's
+      // checked before the hovered-branch in the if/else), so
+      // emissive flips to grabbed and opacity bumps to the grab
+      // value. The `hovered` field stays true underneath —
+      // updateHover would short-circuit while grabbed, and only
+      // releaseFromPointer explicitly clears it.
       const grabber = hittingRay();
       expect(slider.tryGrab(grabber)).toBe(true);
       expect(outerMesh.material.opacity).toBeCloseTo(0.7);

--- a/test/scaffold/ui/Slider.test.ts
+++ b/test/scaffold/ui/Slider.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest';
-import { Slider } from '@/scaffold/ui/Slider';
+import { describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+import type { Pointer } from '@/shell/Pointer';
+import { Slider, type ThumbShape } from '@/scaffold/ui/Slider';
 
 // Vitest coverage for `Slider.setRange` (#178), the constructor's
 // snap-point validation pass (#200), and `Slider.setSnapPoints` (#200).
@@ -20,6 +22,8 @@ function makeSlider(overrides: Partial<{
   initial: number;
   snapDetent: number;
   snapPoints: readonly number[];
+  thumbShape: ThumbShape;
+  baseColor: number;
 }> = {}) {
   return new Slider({
     label: 'test',
@@ -32,6 +36,89 @@ function makeSlider(overrides: Partial<{
     ...overrides,
   });
 }
+
+// Stable, role-marked discovery for the composite thumb (#256). The
+// `slider-thumb` marker lands on the thumb Group; `slider-thumb-outer`
+// lands on the outer translucent sphere mesh. Tests never index
+// `slider.group.children` by position or sniff geometry types.
+function findThumbGroup(slider: Slider): THREE.Group {
+  let found: THREE.Group | null = null;
+  slider.group.traverse((obj) => {
+    if (obj.userData?.role === 'slider-thumb') {
+      found = obj as THREE.Group;
+    }
+  });
+  if (!found) throw new Error('slider-thumb role not found');
+  return found;
+}
+
+function findThumbOuterMesh(
+  slider: Slider,
+): THREE.Mesh<THREE.SphereGeometry, THREE.MeshStandardMaterial> {
+  let found: THREE.Mesh | null = null;
+  slider.group.traverse((obj) => {
+    if (obj.userData?.role === 'slider-thumb-outer') {
+      found = obj as THREE.Mesh;
+    }
+  });
+  if (!found) throw new Error('slider-thumb-outer role not found');
+  return found as THREE.Mesh<THREE.SphereGeometry, THREE.MeshStandardMaterial>;
+}
+
+// Per-vertex radial check on a BufferGeometry: every vertex must be
+// inside a sphere of `radius + ε` around origin. This is the true
+// envelope-containment check from the v3 plan §4.2 Test 6 — a
+// per-vertex loop rather than a bounding-box-corner over-approximation
+// that would let a diagonal vertex silently violate the sphere if
+// future tuning bumps `coneRadius` without bumping `coneHeight`.
+function assertEveryVertexWithinRadius(
+  geometry: THREE.BufferGeometry,
+  radius: number,
+): void {
+  const positions = geometry.attributes.position;
+  if (!positions) throw new Error('geometry has no position attribute');
+  const epsilon = 1e-6;
+  for (let i = 0; i < positions.count; i++) {
+    const x = positions.getX(i);
+    const y = positions.getY(i);
+    const z = positions.getZ(i);
+    const r = Math.sqrt(x * x + y * y + z * z);
+    expect(r, `vertex ${i} at (${x}, ${y}, ${z})`).toBeLessThanOrEqual(
+      radius + epsilon,
+    );
+  }
+}
+
+interface MockPointer extends Pointer {
+  origin: THREE.Vector3;
+  direction: THREE.Vector3;
+}
+
+function mockPointer(
+  origin: [number, number, number],
+  direction: [number, number, number],
+  id = 'test',
+): MockPointer {
+  return {
+    id,
+    origin: new THREE.Vector3(...origin),
+    direction: new THREE.Vector3(...direction).normalize(),
+    pulse: vi.fn(),
+    getRayOrigin(target) {
+      return target.copy(this.origin);
+    },
+    getRayDirection(target) {
+      return target.copy(this.direction);
+    },
+  };
+}
+
+// Ray aimed at world origin — the slider's thumb sits at the group
+// origin under makeSlider's [-1.5, 1.5] / initial=1 / snapDetent=0.05
+// config (snapped to 0 at the [0]-detent, syncThumbPosition writes
+// thumb.position.x = 0). Hit-test fires.
+const hittingRay = (): MockPointer => mockPointer([0, 0, 1], [0, 0, -1]);
+const missingRay = (): MockPointer => mockPointer([10, 0, 1], [0, 0, -1]);
 
 describe('Slider.setRange', () => {
   it('updates min and max so subsequent setValue clamps to the new bounds', () => {
@@ -190,5 +277,304 @@ describe('Slider.setSnapPoints (#200)', () => {
     expect(() => slider.setSnapPoints([1.02])).toThrow(/outside range/);
     // Exact-max remains valid (inclusive bounds).
     expect(() => slider.setSnapPoints([1])).not.toThrow();
+  });
+});
+
+// Vitest coverage for the composite thumb visual (#256 v3): each
+// shape's group composition, depth/render flags, hover-target
+// wiring, hover-state opacity bump (sphere only), dispose cleanup
+// (including track preservation), and the per-vertex radial
+// envelope assertion that bounds future arrow-proportion retunes.
+
+describe('Slider thumb composition (#256)', () => {
+  const BASE_COLOR = 0xd55e00; // VERMILLION; arbitrary axis tint for test.
+  const THUMB_RADIUS = 0.025; // Slider's DEFAULT_THUMB_RADIUS.
+
+  describe('arrow-x composite', () => {
+    it('produces a Group with outer translucent sphere + interior arrow', () => {
+      const slider = makeSlider({
+        thumbShape: 'arrow-x',
+        baseColor: BASE_COLOR,
+        initial: 0,
+      });
+      const thumbGroup = findThumbGroup(slider);
+      expect(thumbGroup.children.length).toBe(2);
+    });
+
+    it('outer mesh has correct depth + transparency + render flags', () => {
+      const slider = makeSlider({
+        thumbShape: 'arrow-x',
+        baseColor: BASE_COLOR,
+        initial: 0,
+      });
+      const outerMesh = findThumbOuterMesh(slider);
+      expect(outerMesh.geometry.parameters.radius).toBeCloseTo(THUMB_RADIUS);
+      expect(outerMesh.material.transparent).toBe(true);
+      expect(outerMesh.material.opacity).toBeCloseTo(0.3);
+      expect(outerMesh.material.depthWrite).toBe(false);
+      expect(outerMesh.material.side).toBe(THREE.FrontSide);
+      expect(outerMesh.renderOrder).toBe(1);
+      expect(outerMesh.material.color.getHex()).toBe(BASE_COLOR);
+    });
+
+    it('interior arrow is opaque, baseColor-tinted, and per-vertex radially contained', () => {
+      const slider = makeSlider({
+        thumbShape: 'arrow-x',
+        baseColor: BASE_COLOR,
+        initial: 0,
+      });
+      const thumbGroup = findThumbGroup(slider);
+      // Interior is the thumb-group child without the `slider-thumb-outer`
+      // role marker — we never index by position.
+      const interior = thumbGroup.children.find(
+        (c) => c.userData?.role !== 'slider-thumb-outer',
+      ) as THREE.Mesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>;
+      expect(interior).toBeDefined();
+      expect(interior.material.transparent).toBe(false);
+      expect(interior.material.color.getHex()).toBe(BASE_COLOR);
+      // Per-vertex radial containment — every vertex must sit inside a
+      // sphere of radius `thumbRadius + ε` around the group origin.
+      // True envelope check, not box-corner over-approximation.
+      assertEveryVertexWithinRadius(interior.geometry, THUMB_RADIUS);
+    });
+  });
+
+  describe('sphere composite', () => {
+    it('produces a Group with one child (outer translucent sphere only)', () => {
+      const slider = makeSlider({
+        thumbShape: 'sphere',
+        baseColor: BASE_COLOR,
+        initial: 0,
+      });
+      const thumbGroup = findThumbGroup(slider);
+      expect(thumbGroup.children.length).toBe(1);
+      const outerMesh = findThumbOuterMesh(slider);
+      expect(thumbGroup.children[0]).toBe(outerMesh);
+    });
+
+    it('outer mesh carries the same depth + transparency + render flags as arrow-*', () => {
+      const slider = makeSlider({
+        thumbShape: 'sphere',
+        baseColor: BASE_COLOR,
+        initial: 0,
+      });
+      const outerMesh = findThumbOuterMesh(slider);
+      expect(outerMesh.material.transparent).toBe(true);
+      expect(outerMesh.material.opacity).toBeCloseTo(0.3);
+      expect(outerMesh.material.depthWrite).toBe(false);
+      expect(outerMesh.material.side).toBe(THREE.FrontSide);
+      expect(outerMesh.renderOrder).toBe(1);
+      expect(outerMesh.material.color.getHex()).toBe(BASE_COLOR);
+    });
+
+    it('default thumbShape (no override) is sphere', () => {
+      // Slider's DEFAULT_THUMB_SHAPE is 'sphere'; verify the default
+      // branch produces the same single-child composite. Tangent-planes
+      // / gradient-levels / saddle-extrema rely on this default
+      // implicitly via `thumbShape: 'sphere'` (they pass it explicitly,
+      // but the default fallback is the same code path).
+      const slider = makeSlider({ baseColor: BASE_COLOR, initial: 0 });
+      const thumbGroup = findThumbGroup(slider);
+      expect(thumbGroup.children.length).toBe(1);
+    });
+  });
+
+  describe('hover-target wiring per shape (emissive flips on the right material)', () => {
+    it('arrow-x: emissive flips on interior arrow; outer envelope stays at zero', () => {
+      const slider = makeSlider({
+        thumbShape: 'arrow-x',
+        baseColor: BASE_COLOR,
+        initial: 0,
+      });
+      const thumbGroup = findThumbGroup(slider);
+      const outerMesh = findThumbOuterMesh(slider);
+      const interior = thumbGroup.children.find(
+        (c) => c.userData?.role !== 'slider-thumb-outer',
+      ) as THREE.Mesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>;
+
+      // Idle.
+      expect(interior.material.emissive.getHex()).toBe(0x000000);
+      expect(outerMesh.material.emissive.getHex()).toBe(0x000000);
+
+      slider.updateHover([hittingRay()]);
+      expect(slider.isHovered).toBe(true);
+      // Interior lights up.
+      expect(interior.material.emissive.getHex()).not.toBe(0x000000);
+      // Outer envelope stays unlit — the steady-state translucent body
+      // should not flicker on hover.
+      expect(outerMesh.material.emissive.getHex()).toBe(0x000000);
+
+      slider.updateHover([missingRay()]);
+      expect(slider.isHovered).toBe(false);
+      expect(interior.material.emissive.getHex()).toBe(0x000000);
+      expect(outerMesh.material.emissive.getHex()).toBe(0x000000);
+    });
+
+    it('sphere: emissive flips on outer translucent sphere', () => {
+      const slider = makeSlider({
+        thumbShape: 'sphere',
+        baseColor: BASE_COLOR,
+        initial: 0,
+      });
+      const outerMesh = findThumbOuterMesh(slider);
+
+      expect(outerMesh.material.emissive.getHex()).toBe(0x000000);
+      slider.updateHover([hittingRay()]);
+      expect(outerMesh.material.emissive.getHex()).not.toBe(0x000000);
+      slider.updateHover([missingRay()]);
+      expect(outerMesh.material.emissive.getHex()).toBe(0x000000);
+    });
+  });
+
+  describe('hover-state opacity bump fires iff applyOpacityBump is true', () => {
+    it('sphere: outer opacity bumps idle → hover → grab → release', () => {
+      const slider = makeSlider({
+        thumbShape: 'sphere',
+        baseColor: BASE_COLOR,
+        initial: 0,
+      });
+      const outerMesh = findThumbOuterMesh(slider);
+
+      // Idle.
+      expect(outerMesh.material.opacity).toBeCloseTo(0.3);
+
+      // Hover.
+      slider.updateHover([hittingRay()]);
+      expect(outerMesh.material.opacity).toBeCloseTo(0.5);
+
+      // Grab — `tryGrab` clears the hover bit (updateHover short-
+      // circuits while grabbed) and sets grabbed-emissive; opacity
+      // bumps to the grab value.
+      const grabber = hittingRay();
+      expect(slider.tryGrab(grabber)).toBe(true);
+      expect(outerMesh.material.opacity).toBeCloseTo(0.7);
+
+      // Release.
+      slider.releaseFromPointer(grabber);
+      expect(outerMesh.material.opacity).toBeCloseTo(0.3);
+    });
+
+    it('arrow-x (control case): outer opacity stays at idle through hover/grab', () => {
+      // The opacity bump should NOT fire for `arrow-*` thumbs —
+      // their hover target is the opaque interior, so the outer
+      // translucent body stays at its steady-state opacity regardless
+      // of state. Tests the `applyOpacityBump === false` contract.
+      const slider = makeSlider({
+        thumbShape: 'arrow-x',
+        baseColor: BASE_COLOR,
+        initial: 0,
+      });
+      const outerMesh = findThumbOuterMesh(slider);
+
+      expect(outerMesh.material.opacity).toBeCloseTo(0.3);
+
+      slider.updateHover([hittingRay()]);
+      expect(slider.isHovered).toBe(true);
+      expect(outerMesh.material.opacity).toBeCloseTo(0.3);
+
+      const grabber = hittingRay();
+      expect(slider.tryGrab(grabber)).toBe(true);
+      expect(outerMesh.material.opacity).toBeCloseTo(0.3);
+
+      slider.releaseFromPointer(grabber);
+      expect(outerMesh.material.opacity).toBeCloseTo(0.3);
+    });
+  });
+
+  describe('dispose() cleans up thumb composite AND preserves track disposal', () => {
+    it('arrow-x: both children\'s geometries + materials disposed; track also disposed', () => {
+      const slider = makeSlider({
+        thumbShape: 'arrow-x',
+        baseColor: BASE_COLOR,
+        initial: 0,
+      });
+      const thumbGroup = findThumbGroup(slider);
+      const outerMesh = findThumbOuterMesh(slider);
+      const interior = thumbGroup.children.find(
+        (c) => c.userData?.role !== 'slider-thumb-outer',
+      ) as THREE.Mesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>;
+
+      // Spy on every disposable resource — both composite children plus
+      // the track. The §3.6 / §4.1 v3 invariant: dispose() preserves the
+      // track lines unchanged, only the thumb-owned resources move to
+      // `disposeThumb()`. This test catches a regression where an
+      // implementer reads "DROP the old thumb dispose lines" as "replace
+      // the whole dispose() body" and silently leaks the track.
+      const outerGeoSpy = vi.spyOn(outerMesh.geometry, 'dispose');
+      const outerMatSpy = vi.spyOn(outerMesh.material, 'dispose');
+      const interiorGeoSpy = vi.spyOn(interior.geometry, 'dispose');
+      const interiorMatSpy = vi.spyOn(interior.material, 'dispose');
+      // Track sits as a child of slider.group; the slider's own
+      // `track` field is private, so locate via traversal — exclude
+      // the thumb group, exclude the thumb-outer, and what remains is
+      // the track mesh.
+      const track = slider.group.children.find(
+        (c) =>
+          c.userData?.role !== 'slider-thumb' &&
+          c instanceof THREE.Mesh,
+      ) as THREE.Mesh<THREE.BufferGeometry, THREE.Material>;
+      expect(track).toBeDefined();
+      const trackGeoSpy = vi.spyOn(track.geometry, 'dispose');
+      const trackMatSpy = vi.spyOn(track.material, 'dispose');
+
+      slider.dispose();
+
+      expect(outerGeoSpy).toHaveBeenCalledTimes(1);
+      expect(outerMatSpy).toHaveBeenCalledTimes(1);
+      expect(interiorGeoSpy).toHaveBeenCalledTimes(1);
+      expect(interiorMatSpy).toHaveBeenCalledTimes(1);
+      expect(trackGeoSpy).toHaveBeenCalledTimes(1);
+      expect(trackMatSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('sphere: outer mesh disposed; track also disposed', () => {
+      const slider = makeSlider({
+        thumbShape: 'sphere',
+        baseColor: BASE_COLOR,
+        initial: 0,
+      });
+      const outerMesh = findThumbOuterMesh(slider);
+      const outerGeoSpy = vi.spyOn(outerMesh.geometry, 'dispose');
+      const outerMatSpy = vi.spyOn(outerMesh.material, 'dispose');
+      const track = slider.group.children.find(
+        (c) =>
+          c.userData?.role !== 'slider-thumb' &&
+          c instanceof THREE.Mesh,
+      ) as THREE.Mesh<THREE.BufferGeometry, THREE.Material>;
+      const trackGeoSpy = vi.spyOn(track.geometry, 'dispose');
+      const trackMatSpy = vi.spyOn(track.material, 'dispose');
+
+      slider.dispose();
+
+      expect(outerGeoSpy).toHaveBeenCalledTimes(1);
+      expect(outerMatSpy).toHaveBeenCalledTimes(1);
+      expect(trackGeoSpy).toHaveBeenCalledTimes(1);
+      expect(trackMatSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('interior arrow per-vertex radial envelope (per shape)', () => {
+    // For each `arrow-*` shape, the per-vertex check confirms every
+    // vertex of the merged shaft + 2-cones geometry (after the per-
+    // axis rotation) is within `thumbRadius` of the group origin.
+    // This is the regression guard: a future maintainer can't drift
+    // any single arrow-proportion constant past the §3.3 envelope
+    // along any direction (axial or diagonal) without tripping the
+    // assertion.
+    it.each<ThumbShape>(['arrow-x', 'arrow-y', 'arrow-z'])(
+      '%s: every vertex inside thumbRadius',
+      (shape) => {
+        const slider = makeSlider({
+          thumbShape: shape,
+          baseColor: BASE_COLOR,
+          initial: 0,
+        });
+        const thumbGroup = findThumbGroup(slider);
+        const interior = thumbGroup.children.find(
+          (c) => c.userData?.role !== 'slider-thumb-outer',
+        ) as THREE.Mesh<THREE.BufferGeometry, THREE.MeshStandardMaterial>;
+        assertEveryVertexWithinRadius(interior.geometry, THUMB_RADIUS);
+      },
+    );
   });
 });


### PR DESCRIPTION
Closes #256

## Summary

Replace the pre-#256 standalone `arrow-*` / `sphere` thumb meshes with a composite `THREE.Group`: an outer translucent axis-tinted sphere (the grab-affordance envelope) circumscribing an interior opaque bidirectional axis-arrow for the 10 quadrics axis-coefficient sliders. The 8 `sphere`-shaped sliders (quadrics `d`, saddle-extrema x/y, tangent-planes θ/φ, gradient-levels θ/φ/k) get a tinted translucent sphere with no interior. Plan + roundtable lineage: `_private/plans/256-slider-thumb-visual.md` (v3, post-second-Sonnet sanity check; folded 16 roundtable findings + 3 sanity-check residuals).

Mechanics:
- New `buildThumb(shape, r, baseColor)` returns a `ThumbBuild` with `hoverTargets`, `outerMaterial`, `applyOpacityBump`, and a single `dispose()` for all composite GPU resources. Track disposal stays independent in `Slider.dispose()`.
- Outer sphere material: `MeshStandardMaterial`, `transparent: true`, `opacity: 0.30` idle (`0.50` hover, `0.70` grab for `sphere` thumbs via `applyOpacityBump`), `side: THREE.FrontSide`, `depthWrite: false`, `renderOrder = 1` (matching the LOCKED_113 transparent-pass convention from SlicingPlane / TangentPlane / TaylorOverlay).
- Interior arrow proportions shrunk so the tip extent fits inside the outer sphere with breathing room: `shaftLength = 1.20r`, `shaftRadius = 0.18r`, `coneHeight = 0.35r`, `coneRadius = 0.28r` (tip extent `0.95r`).
- `userData.role` markers: `'slider-thumb'` on the Group, `'slider-thumb-outer'` on the outer sphere mesh (stable test discovery; no positional indexing).

No scene consumers change — `ThumbShape` enum and per-scene `SLIDER_CONFIG` blocks untouched. Hit-test radius math (`thumbRadius × grabRadiusMultiplier`) unchanged.

## Test plan

**Automated (already green at push):**
- Vitest: 15 new test cases in `test/scaffold/ui/Slider.test.ts` covering composite structure, depth/render flags, hover-target wiring, opacity bump (sphere fires; arrow control case doesn't), dispose cleanup with track preservation, and per-vertex radial-containment envelope for arrow-{x,y,z}. All 575 project tests pass.
- ESLint + `tsc --noEmit` + Vite production build all clean.

**Headset smoke (Cloudflare PR preview):**

Per-scene visual gates:
- [ ] Quadrics squared / linear / cross-sections: thumbs `a` / `b` / `c` (+ `u` / `v` / `w` + `x₀` / `y₀` / `z₀`) show vermillion / bluish-green / sky-blue translucent spheres each with an interior axis-arrow visible through the body. Thumb `d` shows a yellow translucent sphere with no interior.
- [ ] Tangent-planes θ / φ + gradient-levels θ / φ / k: neutral-gray translucent spheres, no interior.
- [ ] Saddle-extrema x / y: VERMILLION / BLUISH_GREEN translucent spheres, no interior (axis-tinted per `tokens.ts` slider-tint rule).

Depth + transparency gates:
- [ ] Background visible through translucent sphere (transparency working as designed — plinth, track, opaque surfaces behind the thumb show through at 0.30 opacity).
- [ ] No back-face artifacts — `side: THREE.FrontSide` keeps the rear hemisphere undrawn.
- [ ] No occlusion regression — outer sphere correctly hides behind a controller mesh / pointer passing in front of it.
- [ ] No z-fight between outer body and interior arrow, or between outer body and any other transparent surface in the scene (`renderOrder = 1` shared with SlicingPlane / TangentPlane / TaylorOverlay).

Hover/grab cue gates:
- [ ] Hover any axis-coefficient slider: interior arrow lights up; outer envelope unchanged. Grab intensifies.
- [ ] Hover any `sphere`-shaped slider (d / θ / φ / k / saddle x/y): outer sphere lights up AND opacity bumps to 0.50 on hover, 0.70 on grab. Cue clearly visible.

Legibility gates (critical for neutral-gray sphere thumbs):
- [ ] At 1.0 m and 1.5 m viewing distances, the neutral-gray translucent sphere remains clearly distinguishable from the plinth at rest (no hover assistance). If it disappears against the plinth, bump `SLIDER_THUMB_OUTER_OPACITY` per the bracket-doc comment.
- [ ] Hover/grab cue on neutral-gray spheres is visually unambiguous (alpha-attenuated emissive + opacity bump composes strongly enough). If it reads as too weak, bump `_HOVERED` / `_GRABBED` toward 0.65 / 0.85 per the bracket-doc comment.

Performance + regression:
- [ ] Quest 3S 72 Hz hold preserved across all four scenes (net +10 meshes in quadrics, +0 in the three sister scenes).
- [ ] `?fps=1` overlay still works.
- [ ] SceneRack cluster nav, sliders / presets / section-tab interactions unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)