### PR TITLE
feat(scaffold): emblazoned-label slider thumbs (#276)

### DIFF
--- a/src/exhibits/gradient-levels/SPEC.md
+++ b/src/exhibits/gradient-levels/SPEC.md
@@ -197,8 +197,11 @@ reads top→bottom as "where on this surface (θ, φ) ← which surface
 sits underneath.
 
 All three sliders share `SLIDER_BASE_COLOR = 0xaaaaaa` (neutral
-gray) and `thumbShape: 'sphere'`. None of θ/φ/k carries axis
-meaning — distinct from quadrics' axis-tinted coefficient sliders.
+gray) — none of θ/φ/k carries axis meaning, distinct from quadrics'
+axis-tinted coefficient sliders. Each thumb is a solid sphere
+emblazoned with its symbol via `thumbLabel: 'θ'` / `'φ'` / `'k'`
+(#276); the textual emblazon replaced the pre-#276 axis-arrow vs
+sphere visual distinction across the cluster.
 
 ## Gradient arrow (#165)
 

--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -377,7 +377,7 @@ const gradientLevelsExhibit: Exhibit = {
       snapPoints: THETA_SNAP_POINTS,
       grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER_PLINTH,
       baseColor: SLIDER_BASE_COLOR,
-      thumbShape: 'sphere',
+      thumbLabel: 'θ',
     });
 
     phiSlider = new Slider({
@@ -389,7 +389,7 @@ const gradientLevelsExhibit: Exhibit = {
       snapPoints: PHI_SNAP_POINTS,
       grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER_PLINTH,
       baseColor: SLIDER_BASE_COLOR,
-      thumbShape: 'sphere',
+      thumbLabel: 'φ',
     });
 
     // k slider — `initial` matches the extraUniforms.uK seed above so
@@ -404,7 +404,7 @@ const gradientLevelsExhibit: Exhibit = {
       snapPoints: K_SNAP_POINTS,
       grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER_PLINTH,
       baseColor: SLIDER_BASE_COLOR,
-      thumbShape: 'sphere',
+      thumbLabel: 'k',
     });
 
     // Point indicator — math-object affordance at world frame.
@@ -514,6 +514,11 @@ const gradientLevelsExhibit: Exhibit = {
     kSlider.update();
     thetaSlider.update();
     phiSlider.update();
+    if (camera) {
+      kSlider.faceCamera(camera);
+      thetaSlider.faceCamera(camera);
+      phiSlider.faceCamera(camera);
+    }
 
     // 2. Push k into the surface uniform (existing #163 path).
     if (surfaceMaterial) {

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -42,7 +42,7 @@ import {
 } from '@/scaffold/staging/Plinth';
 import { Section } from '@/scaffold/ui/Section';
 import { SectionTab } from '@/scaffold/ui/SectionTab';
-import { Slider, type ThumbShape } from '@/scaffold/ui/Slider';
+import { Slider } from '@/scaffold/ui/Slider';
 import {
   GRAB_RADIUS_MULTIPLIER_PLINTH,
   SLIDER_SNAP_DETENT,
@@ -397,23 +397,25 @@ function easeInOutCubic(t: number): number {
 // Per-slider config: name + base color + thumb shape. Color is the
 // at-a-glance identification; shape additionally maps each axis-coefficient
 // slider's thumb to its spatial direction — bidirectional 3D arrows
-// aligned with the corresponding world axis (slider 'a' = math-X arrow
-// along the track; slider 'b' = math-Y arrow forward/back from the
-// viewer; slider 'c' = math-Z arrow up/down). Slider 'd' is the constant
-// term and has no spatial direction, so a directionless sphere reads
-// pedagogically truthful. Replaces the original sphere/cube/octahedron/
-// cylinder set from #58 (Q4 redundancy cue) — those were visually
-// distinct but didn't carry meaning; the arrows do.
+// each axis-tinted (vermillion / bluish-green / sky-blue for math-X /
+// Y / Z) and emblazoned with the textual symbol the slider drives —
+// `x²` / `y²` / `z²` for the squared-coefficient sliders, `C` for the
+// constant-term `d` (the latter shared across the Squared and Linear
+// lenses via #140's single-instance mounting; see `dSlider` below).
+// The textual emblazon replaces the pre-#276 bidirectional 3D
+// axis-arrow vocabulary, which read as stale next to the plinth-era
+// staging and (in #256) couldn't survive a translucent-bubble
+// alternative either (see memory `feedback_translucent_at_thumb_scale_fails`).
 type CoeffName = 'a' | 'b' | 'c' | 'd';
 const SLIDER_CONFIG: readonly {
   readonly name: CoeffName;
   readonly color: number;
-  readonly shape: ThumbShape;
+  readonly label: string;
 }[] = [
-  { name: 'a', color: VERMILLION,   shape: 'arrow-x' },
-  { name: 'b', color: BLUISH_GREEN, shape: 'arrow-y' },
-  { name: 'c', color: SKY_BLUE,     shape: 'arrow-z' },
-  { name: 'd', color: YELLOW,       shape: 'sphere' },
+  { name: 'a', color: VERMILLION,   label: 'x²' },
+  { name: 'b', color: BLUISH_GREEN, label: 'y²' },
+  { name: 'c', color: SKY_BLUE,     label: 'z²' },
+  { name: 'd', color: YELLOW,       label: 'C'  },
 ];
 
 // Linear-terms section (#88, scoped by #85). Each slider drives the linear
@@ -429,11 +431,11 @@ type LinearName = 'u' | 'v' | 'w';
 const LINEAR_SLIDER_CONFIG: readonly {
   readonly name: LinearName;
   readonly color: number;
-  readonly shape: ThumbShape;
+  readonly label: string;
 }[] = [
-  { name: 'u', color: VERMILLION,   shape: 'arrow-x' },
-  { name: 'v', color: BLUISH_GREEN, shape: 'arrow-y' },
-  { name: 'w', color: SKY_BLUE,     shape: 'arrow-z' },
+  { name: 'u', color: VERMILLION,   label: 'x' },
+  { name: 'v', color: BLUISH_GREEN, label: 'y' },
+  { name: 'w', color: SKY_BLUE,     label: 'z' },
 ];
 
 // Cross-sections section (#84, expanded #112, toggles #134). Three sliders
@@ -487,11 +489,11 @@ type CrossSectionName = 'x₀' | 'y₀' | 'z₀';
 const CROSS_SECTION_SLIDER_CONFIG: readonly {
   readonly name: CrossSectionName;
   readonly color: number;
-  readonly shape: ThumbShape;
+  readonly label: string;
 }[] = [
-  { name: 'x₀', color: VERMILLION,   shape: 'arrow-x' },
-  { name: 'y₀', color: BLUISH_GREEN, shape: 'arrow-y' },
-  { name: 'z₀', color: SKY_BLUE,     shape: 'arrow-z' },
+  { name: 'x₀', color: VERMILLION,   label: 'x₀' },
+  { name: 'y₀', color: BLUISH_GREEN, label: 'y₀' },
+  { name: 'z₀', color: SKY_BLUE,     label: 'z₀' },
 ];
 // Section names are also the labels rendered on each tab. The cross-
 // section name doubles as the active-section identifier driving
@@ -1039,7 +1041,7 @@ const quadricsExhibit: Exhibit = {
         snapPoints: SLIDER_SNAP_POINTS_CANONICAL,
         grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER_PLINTH,
         baseColor: cfg.color,
-        thumbShape: cfg.shape,
+        thumbLabel: cfg.label,
       });
     });
     // `sliders` is the math-routing array [a, b, c, d] and feeds the
@@ -1089,7 +1091,7 @@ const quadricsExhibit: Exhibit = {
         snapPoints: SLIDER_SNAP_POINTS_CANONICAL,
         grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER_PLINTH,
         baseColor: cfg.color,
-        thumbShape: cfg.shape,
+        thumbLabel: cfg.label,
       });
     });
     linearSliders = linearTermSliders;
@@ -1113,7 +1115,7 @@ const quadricsExhibit: Exhibit = {
         snapPoints: SLIDER_SNAP_POINTS_ZERO_ONLY,
         grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER_PLINTH,
         baseColor: cfg.color,
-        thumbShape: cfg.shape,
+        thumbLabel: cfg.label,
       });
     });
     crossSectionSliders = crossSectionTermSliders;
@@ -1419,6 +1421,19 @@ const quadricsExhibit: Exhibit = {
       activeSection.name !== CROSS_SECTION_SECTION_NAME
     ) {
       dSlider.updateHover(pointers);
+    }
+    // Per-frame yaw-billboard the thumb labels (#276). Same
+    // visibility-gating as updateHover: only the active section's
+    // sliders + dSlider (when not Cross-sections) chase the camera,
+    // so hidden controls don't thrash their label transforms.
+    if (camera) {
+      for (const s of activeSection.sliders) s.faceCamera(camera);
+      if (
+        dSlider !== undefined &&
+        activeSection.name !== CROSS_SECTION_SECTION_NAME
+      ) {
+        dSlider.faceCamera(camera);
+      }
     }
     // Cross-section toggles tick / hover only while their section is
     // focused. Their groups inherit visibility from the slider groups

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -350,7 +350,7 @@ const saddleExtremaExhibit: Exhibit = {
       snapPoints: buildAxisSnapPoints(initialPreset.criticalPoints, 0),
       grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER_PLINTH,
       baseColor: VERMILLION,
-      thumbShape: 'sphere',
+      thumbLabel: 'x',
     });
 
     // y slider — bluish-green (math-Y axis tint).
@@ -363,7 +363,7 @@ const saddleExtremaExhibit: Exhibit = {
       snapPoints: buildAxisSnapPoints(initialPreset.criticalPoints, 1),
       grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER_PLINTH,
       baseColor: BLUISH_GREEN,
-      thumbShape: 'sphere',
+      thumbLabel: 'y',
     });
 
     // Per-slider labels — primary = variable name (set once at mount),
@@ -483,6 +483,10 @@ const saddleExtremaExhibit: Exhibit = {
       ySlider.updateHover(pointers);
       xSlider.update();
       ySlider.update();
+      if (camera) {
+        xSlider.faceCamera(camera);
+        ySlider.faceCamera(camera);
+      }
 
       const x = xSlider.value;
       const y = ySlider.value;

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -406,7 +406,7 @@ const tangentPlanesExhibit: Exhibit = {
       snapPoints: THETA_SNAP_POINTS,
       grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER_PLINTH,
       baseColor: SLIDER_BASE_COLOR,
-      thumbShape: 'sphere',
+      thumbLabel: 'θ',
     });
 
     phiSlider = new Slider({
@@ -418,7 +418,7 @@ const tangentPlanesExhibit: Exhibit = {
       snapPoints: PHI_SNAP_POINTS,
       grabRadiusMultiplier: GRAB_RADIUS_MULTIPLIER_PLINTH,
       baseColor: SLIDER_BASE_COLOR,
-      thumbShape: 'sphere',
+      thumbLabel: 'φ',
     });
 
     // Per-slider variable + value labels (#170). Right-anchored so
@@ -529,6 +529,10 @@ const tangentPlanesExhibit: Exhibit = {
     phiSlider.updateHover(pointers);
     thetaSlider.update();
     phiSlider.update();
+    if (camera) {
+      thetaSlider.faceCamera(camera);
+      phiSlider.faceCamera(camera);
+    }
 
     // Controller-aim picking refresh (#197). Re-raycast each frame while
     // the trigger is held so picking reads as a continuous drag rather

--- a/src/scaffold/ui/Slider.ts
+++ b/src/scaffold/ui/Slider.ts
@@ -1,16 +1,7 @@
 import * as THREE from 'three';
-import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { Text } from 'troika-three-text';
 import { raySphereHit } from '@/scaffold/ui/rayHit';
 import type { Pointer } from '@/shell/Pointer';
-
-// `arrow-{x,y,z}` are bidirectional 3D arrows aligned with their respective
-// world axis. The slider group has no rotation, so slider-local frame =
-// world frame; pick the variant whose axis matches the math-frame axis the
-// slider drives (arrow-x for slider 'a' → math-X, arrow-y for slider 'b' →
-// math-Y, arrow-z for slider 'c' → math-Z). `sphere` is reserved for
-// slider 'd' (the constant term — no spatial direction, so a directionless
-// thumb reads as pedagogically truthful).
-export type ThumbShape = 'sphere' | 'arrow-x' | 'arrow-y' | 'arrow-z';
 
 export interface SliderOptions {
   label: string;
@@ -52,17 +43,59 @@ export interface SliderOptions {
   // copies of this (see THUMB_HOVER_SCALE / THUMB_GRAB_SCALE), so a single
   // base color suffices to retune per-slider visuals (#58).
   baseColor?: number;
-  // Geometry of the thumb. Color is the at-a-glance hint; shape is the
-  // unambiguous redundancy cue per #58 / Q4 — readable even with the
-  // colors stripped (e.g. on a colorblind viewer's display).
-  thumbShape?: ThumbShape;
+  // Symbol emblazoned on the front of the thumb sphere via a Troika
+  // `Text` child that yaw-billboards toward the camera (#276). Required:
+  // every cluster slider gets a label per the #276 plan's §2.2 table;
+  // the explicit per-slider field declares the slider's role inline
+  // rather than spreading it across a per-scene mapping. Pass any
+  // Unicode string — the cluster's existing Troika consumers already
+  // render the full symbol set in source today (`x²` / `y²` / `z²` /
+  // `C` / `x` / `y` / `z` / `x₀` / `y₀` / `z₀` / `θ` / `φ` / `k`).
+  // Empty string is the structural opt-out for a future scene that
+  // wants a bare sphere.
+  thumbLabel: string;
 }
 
 const DEFAULT_TRACK_LENGTH = 0.3;
 const DEFAULT_THUMB_RADIUS = 0.025;
 const DEFAULT_DRAG_GAIN = 1.75;
 const DEFAULT_BASE_COLOR = 0xeeaa33;
-const DEFAULT_THUMB_SHAPE: ThumbShape = 'sphere';
+
+// Thumb-label visual constants (#276). First-pass per
+// `feedback_staging_dimensions_first_pass`; bracket + next-step doc
+// comments per `feedback_binary_search_visual_constants`.
+//
+// thumbRadius default = 0.025 m. Cluster readouts use 0.028 m fontSize
+// at ~0.7 m viewing distance. The thumb label sits at ~1.0 m viewing
+// distance (plinth + user spawn arm's-length-forward), so a slightly
+// smaller fontSize reads at the same angular size. Target label width
+// ≈ thumbRadius for the widest single-char symbol (`x²`, ~1.4 em);
+// narrower symbols (`x`, `θ`, `C`) come in at ~0.7 × thumbRadius.
+// Bracket [0.014, 0.024]: if labels read too small at 1.0 m, bump
+// toward 0.022 / 0.024; if a symbol clips outside the sphere
+// silhouette, drop toward 0.014. One dial per round.
+const SLIDER_THUMB_LABEL_FONT_SIZE = 0.018;
+
+// Standoff from the sphere surface. Without lift, the text quad
+// intersects the sphere at the placement point and produces z-fight
+// shimmer on Quest 3S panels (same regression class as
+// `SURFACE_LABEL_STANDOFF_M` in TapButton.ts). 1.5 mm is below the
+// pixel size of a Quest 3S panel at 1.0 m, so the gap isn't visible
+// as a floating glyph. Bracket [0.0005, 0.003]: bump up if z-fight
+// appears at oblique angles; drop down if the label reads as a decal
+// hovering off the surface.
+const SLIDER_THUMB_LABEL_STANDOFF_M = 0.0015;
+
+// Label color + outline. Matches the established TapButton precedent
+// (`LABEL_COLOR = 0xffffff`, `LABEL_OUTLINE_WIDTH = '8%'`,
+// `LABEL_OUTLINE_COLOR = 0x000000`). White-on-tint with a black
+// outline reads cleanly against every cluster body color: vermillion,
+// bluish-green, sky-blue, yellow, neutral gray. The 8% outline is
+// the same constant `READOUT_OUTLINE_WIDTH` uses across cluster
+// readouts.
+const SLIDER_THUMB_LABEL_COLOR = 0xffffff;
+const SLIDER_THUMB_LABEL_OUTLINE_WIDTH = '8%';
+const SLIDER_THUMB_LABEL_OUTLINE_COLOR = 0x000000;
 
 const HAPTIC_AMPLITUDE = 0.5;
 const HAPTIC_DURATION_MS = 10;
@@ -90,6 +123,7 @@ export class Slider {
   private readonly opts: Required<SliderOptions>;
   private readonly track: THREE.Mesh;
   private readonly thumb: THREE.Mesh;
+  private readonly thumbLabelText: Text;
   private readonly thumbWorld = new THREE.Vector3();
   // Skew-line projection scratches (allocated once per Slider). Shared
   // between `rayHitsThumb` (ray-sphere hit-test) and
@@ -101,6 +135,27 @@ export class Slider {
   private readonly sliderOrigin = new THREE.Vector3();
   private readonly axisDir = new THREE.Vector3();
   private readonly v = new THREE.Vector3();
+  // faceCamera scratches (#276 §3.3.1). `thumbCenterWorld` is read
+  // once per faceCamera tick (step 1, thumb's world position) and
+  // not re-used inside the call. The plan's S3 finding warned
+  // against the v1 algorithm's double-aliasing of this field for
+  // two semantically different reads; the v2 algorithm doesn't read
+  // a label-world position at all (the label's world placement is
+  // implied by the local-frame `position = camFacingLocal * offset`
+  // through the parent transform), so a separate `labelWorld`
+  // scratch isn't needed.
+  private readonly thumbCenterWorld = new THREE.Vector3();
+  private readonly camWorld = new THREE.Vector3();
+  private readonly camFacingWorld = new THREE.Vector3();
+  private readonly camFacingLocal = new THREE.Vector3();
+  private readonly thumbWorldQuat = new THREE.Quaternion();
+  private readonly thumbWorldQuatInv = new THREE.Quaternion();
+  private readonly desiredWorldQuat = new THREE.Quaternion();
+  // World-Y unit vector for `setFromAxisAngle`. Per-instance readonly
+  // (not module-scope export) avoids the `feedback_threejs_token_exports_immutable`
+  // hazard; `setFromAxisAngle` is read-only on its axis arg, so this
+  // is never mutated.
+  private readonly worldY = new THREE.Vector3(0, 1, 0);
   private readonly hoverEmissive: THREE.Color;
   private readonly grabEmissive: THREE.Color;
 
@@ -128,7 +183,6 @@ export class Slider {
       thumbRadius: DEFAULT_THUMB_RADIUS,
       dragGain: DEFAULT_DRAG_GAIN,
       baseColor: DEFAULT_BASE_COLOR,
-      thumbShape: DEFAULT_THUMB_SHAPE,
       ...options,
       // Load-bearing: this trailing override swaps the raw
       // `options.snapPoints` (pulled in by the spread above) for the
@@ -167,10 +221,36 @@ export class Slider {
     this.grabEmissive = baseColor.clone().multiplyScalar(THUMB_GRAB_SCALE);
 
     this.thumb = new THREE.Mesh(
-      buildThumbGeometry(this.opts.thumbShape, this.opts.thumbRadius),
+      new THREE.SphereGeometry(this.opts.thumbRadius, 16, 12),
       new THREE.MeshStandardMaterial({ color: baseColor }),
     );
+    this.thumb.userData.role = 'slider-thumb';
     this.group.add(this.thumb);
+
+    // Per-slider thumb label (#276). Troika `Text` child of the thumb
+    // mesh — the label rides with the thumb as the user drags. Position
+    // and rotation are rewritten every frame by `faceCamera`; the
+    // values below are the at-construction defaults so the label sits
+    // outside the sphere envelope even before any faceCamera dispatch
+    // (e.g. on the first render). `userData.role` marker is the test-
+    // discovery hook (Slider.test.ts traverses the scene graph by
+    // role, not by child-index).
+    this.thumbLabelText = new Text();
+    this.thumbLabelText.userData.role = 'slider-thumb-label';
+    this.thumbLabelText.text = options.thumbLabel;
+    this.thumbLabelText.fontSize = SLIDER_THUMB_LABEL_FONT_SIZE;
+    this.thumbLabelText.color = SLIDER_THUMB_LABEL_COLOR;
+    this.thumbLabelText.anchorX = 'center';
+    this.thumbLabelText.anchorY = 'middle';
+    this.thumbLabelText.outlineWidth = SLIDER_THUMB_LABEL_OUTLINE_WIDTH;
+    this.thumbLabelText.outlineColor = SLIDER_THUMB_LABEL_OUTLINE_COLOR;
+    this.thumbLabelText.position.set(
+      0,
+      0,
+      this.opts.thumbRadius + SLIDER_THUMB_LABEL_STANDOFF_M,
+    );
+    this.thumbLabelText.sync();
+    this.thumb.add(this.thumbLabelText);
 
     this.syncThumbPosition();
     // Initial emissive via the centralized state machine, not by relying on
@@ -203,6 +283,81 @@ export class Slider {
     (this.track.material as THREE.Material).dispose();
     this.thumb.geometry.dispose();
     (this.thumb.material as THREE.Material).dispose();
+    this.thumbLabelText.dispose();
+  }
+
+  /**
+   * Yaw-billboard the thumb's emblazon label (#276) to face the camera
+   * in the world-XZ plane. Position uses the same XZ-projected camera
+   * direction as the orientation, so the label rides the sphere
+   * equator regardless of camera elevation — pancake crouched/tall
+   * poses and VR head pitch don't move the label onto the upper or
+   * lower hemisphere where the vertical glyph plane would non-tangent
+   * the sphere.
+   *
+   * Each cluster scene dispatches this on every visible slider per
+   * frame (`for (const s of allSliders) s.faceCamera(camera)`),
+   * matching the established `TapButton.faceCamera(camera)` pattern.
+   *
+   * `getWorldPosition` / `getWorldQuaternion` call `updateWorldMatrix(
+   * true, false)` internally (three.js r152+), so we don't need an
+   * explicit `scene.updateMatrixWorld(true)` here even though
+   * `Slider.update()` writes `thumb.position` earlier in the same
+   * frame. Three.js's auto-update walks the parent chain and
+   * recomputes `matrixWorld` lazily.
+   */
+  faceCamera(camera: THREE.Camera): void {
+    // 1. World vector from thumb to camera, projected onto world-XZ.
+    //    Yaw-only convention (#29): ignore camera elevation so the
+    //    glyph plane stays world-vertical and a head tilt in VR
+    //    doesn't roll the label.
+    this.thumb.getWorldPosition(this.thumbCenterWorld);
+    camera.getWorldPosition(this.camWorld);
+    this.camFacingWorld.subVectors(this.camWorld, this.thumbCenterWorld);
+    this.camFacingWorld.y = 0;
+    // Near-degenerate guard: camera ~directly above / below the
+    // thumb. No defined yaw; fall back to world +Z so the rotation
+    // is well-defined and a pancake camera move past the thumb's
+    // vertical line doesn't NaN out.
+    const xzLen = this.camFacingWorld.length();
+    if (xzLen < 1e-6) {
+      this.camFacingWorld.set(0, 0, 1);
+    } else {
+      this.camFacingWorld.divideScalar(xzLen);
+    }
+
+    // 2. Desired world-space quaternion: yaw about world-Y so the
+    //    label glyph plane (Troika local +Z normal) faces the camera.
+    //    `setFromAxisAngle` is read-only on `worldY`.
+    const yaw = Math.atan2(this.camFacingWorld.x, this.camFacingWorld.z);
+    this.desiredWorldQuat.setFromAxisAngle(this.worldY, yaw);
+
+    // 3. Convert the desired world quaternion to label-local space
+    //    via the parent's (= thumb's) inverse world quaternion. The
+    //    thumb has no rotation in its slider group, but the slider
+    //    group inherits the plinth's ~20° X-tilt — so the thumb's
+    //    world quaternion captures the full parent chain. Writing
+    //    a world yaw directly into local rotation Y would be wrong
+    //    under a tilted parent (the local-Y axis is tilted forward).
+    this.thumb.getWorldQuaternion(this.thumbWorldQuat);
+    this.thumbWorldQuatInv.copy(this.thumbWorldQuat).invert();
+    this.thumbLabelText.quaternion
+      .copy(this.thumbWorldQuatInv)
+      .multiply(this.desiredWorldQuat);
+
+    // 4. Label position: in world frame the label sits at
+    //    `thumbWorld + camFacingWorld * (R + standoff)`. Express
+    //    the offset as a thumb-local position by rotating the
+    //    XZ-projected unit direction through the inverse parent
+    //    quaternion. The world-frame result is then identical to
+    //    the world-space placement.
+    this.camFacingLocal
+      .copy(this.camFacingWorld)
+      .applyQuaternion(this.thumbWorldQuatInv);
+    const offset = this.opts.thumbRadius + SLIDER_THUMB_LABEL_STANDOFF_M;
+    this.thumbLabelText.position
+      .copy(this.camFacingLocal)
+      .multiplyScalar(offset);
   }
 
   /**
@@ -457,86 +612,6 @@ export class Slider {
       (this.currentValue - this.opts.min) / (this.opts.max - this.opts.min);
     this.thumb.position.x = -halfLen + t * this.opts.trackLength;
   }
-}
-
-// `sphere` matches the hit-test radius exactly. The arrow variants extend
-// past `thumbRadius` along their axis (~1.475r at the cone tip); a
-// caller-supplied `grabRadiusMultiplier` (commonly 2.75) covers the full
-// visible arrow plus margin so the entire shape stays grabbable.
-function buildThumbGeometry(
-  shape: ThumbShape,
-  thumbRadius: number,
-): THREE.BufferGeometry {
-  if (shape === 'sphere') {
-    return new THREE.SphereGeometry(thumbRadius, 16, 12);
-  }
-  return buildArrowGeometry(thumbRadius, shape);
-}
-
-// Bidirectional 3D arrow (`<->`) for the axis-coefficient sliders. Built
-// along +Y as a merged geometry (shaft cylinder + two outward-pointing
-// cones), then rotated to the requested world axis. Single mesh + single
-// material via `mergeGeometries` keeps Slider's hover/grab emissive logic
-// untouched.
-function buildArrowGeometry(
-  thumbRadius: number,
-  axis: 'arrow-x' | 'arrow-y' | 'arrow-z',
-): THREE.BufferGeometry {
-  const r = thumbRadius;
-  // Arrow proportions retuned post-headset (#65 follow-up). Shaft thicker
-  // and longer, cones wider — arrows now read as substantive 3D objects
-  // rather than thin sticks at the ~0.7 m viewing distance from the
-  // user's spawn pose. coneRadius = 0.75r keeps the arrowheads
-  // recognizably pointy (h/r = 0.8) after a brief headset pass at 1.0r
-  // showed the cones reading too disc-like at full thumbRadius.
-  const shaftLength = 1.75 * r;
-  const shaftRadius = 0.35 * r;
-  const coneHeight = 0.7 * r;
-  const coneRadius = 0.5 * r;
-  // Cone center sits at half-shaft + half-cone along Y so its base flushes
-  // against the shaft's end.
-  const coneCenter = shaftLength / 2 + coneHeight / 2;
-
-  const shaft = new THREE.CylinderGeometry(
-    shaftRadius,
-    shaftRadius,
-    shaftLength,
-    12,
-  );
-
-  const upperCone = new THREE.ConeGeometry(coneRadius, coneHeight, 16);
-  upperCone.translate(0, coneCenter, 0);
-
-  // Lower cone: flip 180° around Z so apex points -Y, then translate to
-  // mirror the upper cone across the origin.
-  const lowerCone = new THREE.ConeGeometry(coneRadius, coneHeight, 16);
-  lowerCone.rotateZ(Math.PI);
-  lowerCone.translate(0, -coneCenter, 0);
-
-  const merged = mergeGeometries([shaft, upperCone, lowerCone]);
-  // Sources have identical attribute layouts (position/normal/uv) — merge
-  // can't fail in practice, but the type signature requires the check.
-  if (!merged) {
-    throw new Error('Failed to merge arrow thumb geometries');
-  }
-  shaft.dispose();
-  upperCone.dispose();
-  lowerCone.dispose();
-
-  // Rotate from +Y default to the target world axis. Slider local frame =
-  // world frame (the slider group is positioned but not rotated):
-  //   arrow-x → ±world-X (parallel to track; slider 'a' / math-X)
-  //   arrow-y → ±world-Z (toward/away from viewer; slider 'b' / math-Y per #43,
-  //                       which routes math-Y to world-Z; bidirectional, so
-  //                       sign of the rotation doesn't matter pedagogically)
-  //   arrow-z → ±world-Y (up/down; slider 'c' / math-Z, no rotation needed)
-  if (axis === 'arrow-x') {
-    merged.rotateZ(-Math.PI / 2);
-  } else if (axis === 'arrow-y') {
-    merged.rotateX(Math.PI / 2);
-  }
-
-  return merged;
 }
 
 function clamp(v: number, lo: number, hi: number): number {

--- a/test/scaffold/ui/PointerMigration.test.ts
+++ b/test/scaffold/ui/PointerMigration.test.ts
@@ -86,6 +86,7 @@ describe('Slider — Pointer contract', () => {
       snapDetent: 0,
       snapPoints: [],
       grabRadiusMultiplier: 2.75,
+      thumbLabel: 'test',
     });
   }
 

--- a/test/scaffold/ui/Slider.test.ts
+++ b/test/scaffold/ui/Slider.test.ts
@@ -1,5 +1,33 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+
+// `troika-three-text` reaches for `self`, a browser-only global, in
+// its UMD `now$1` helper. The default vitest environment is Node,
+// so any `new Text()` would blow up at construction time. Stub the
+// module with an Object3D-backed surrogate; matches the pattern in
+// `TapButton.test.ts` / `Preset.test.ts` / `PointerMigration.test.ts`.
+// None of this file's assertions touch text rendering — `Object3D`
+// gives the position/rotation/quaternion machinery the faceCamera
+// algorithm needs, plus a `text` string property the label-text
+// assertions read.
+vi.mock('troika-three-text', () => {
+  class StubText extends THREE.Object3D {
+    text = '';
+    fontSize = 0;
+    color = 0xffffff;
+    anchorX: string | undefined;
+    anchorY: string | undefined;
+    outlineWidth: string | undefined;
+    outlineColor: number | undefined;
+    sync() {}
+    dispose() {}
+  }
+  return { Text: StubText };
+});
+
+import { Text } from 'troika-three-text';
 import { Slider } from '@/scaffold/ui/Slider';
+import type { Pointer } from '@/shell/Pointer';
 
 // Vitest coverage for `Slider.setRange` (#178), the constructor's
 // snap-point validation pass (#200), and `Slider.setSnapPoints` (#200).
@@ -20,6 +48,8 @@ function makeSlider(overrides: Partial<{
   initial: number;
   snapDetent: number;
   snapPoints: readonly number[];
+  thumbLabel: string;
+  baseColor: number;
 }> = {}) {
   return new Slider({
     label: 'test',
@@ -29,6 +59,7 @@ function makeSlider(overrides: Partial<{
     snapDetent: 0.05,
     snapPoints: [0],
     grabRadiusMultiplier: 2.75,
+    thumbLabel: 'test',
     ...overrides,
   });
 }
@@ -190,5 +221,242 @@ describe('Slider.setSnapPoints (#200)', () => {
     expect(() => slider.setSnapPoints([1.02])).toThrow(/outside range/);
     // Exact-max remains valid (inclusive bounds).
     expect(() => slider.setSnapPoints([1])).not.toThrow();
+  });
+});
+
+// Thumb-label test scaffolding (#276 plan §4.2). Tests locate scene-
+// graph nodes by `userData.role` traversal, not by positional indexing.
+
+function findThumbMesh(slider: Slider): THREE.Mesh {
+  let found: THREE.Mesh | null = null;
+  slider.group.traverse((obj) => {
+    if (obj.userData?.role === 'slider-thumb') {
+      found = obj as THREE.Mesh;
+    }
+  });
+  if (!found) throw new Error('slider-thumb role not found');
+  return found;
+}
+
+function findThumbLabel(slider: Slider): Text {
+  let found: Text | null = null;
+  slider.group.traverse((obj) => {
+    if (obj.userData?.role === 'slider-thumb-label') {
+      found = obj as Text;
+    }
+  });
+  if (!found) throw new Error('slider-thumb-label role not found');
+  return found;
+}
+
+// Stub Pointer aimed at a given world position along world −Z; thumb
+// at world origin → ray hits the thumb's grab sphere.
+interface StubPointer extends Pointer {
+  origin: THREE.Vector3;
+  direction: THREE.Vector3;
+}
+function stubPointer(
+  origin: [number, number, number],
+  direction: [number, number, number],
+): StubPointer {
+  return {
+    id: 'test',
+    origin: new THREE.Vector3(...origin),
+    direction: new THREE.Vector3(...direction).normalize(),
+    pulse: vi.fn(),
+    getRayOrigin(target) {
+      return target.copy(this.origin);
+    },
+    getRayDirection(target) {
+      return target.copy(this.direction);
+    },
+  };
+}
+const HIT_RAY = (): StubPointer => stubPointer([0, 0, 1], [0, 0, -1]);
+
+describe('Slider thumb label (#276)', () => {
+  it('thumb is a single opaque sphere with a Text label child', () => {
+    const slider = makeSlider({ thumbLabel: 'x²', baseColor: 0xff0000 });
+    const thumb = findThumbMesh(slider);
+    expect(thumb).toBeInstanceOf(THREE.Mesh);
+    expect(thumb.geometry).toBeInstanceOf(THREE.SphereGeometry);
+    expect((thumb.geometry as THREE.SphereGeometry).parameters.radius).toBe(
+      0.025,
+    );
+    const mat = thumb.material as THREE.MeshStandardMaterial;
+    expect(mat.transparent).toBe(false);
+    expect(mat.color.getHex()).toBe(0xff0000);
+    // Exactly one child of the thumb mesh — the Text label.
+    expect(thumb.children).toHaveLength(1);
+    expect(thumb.children[0].userData?.role).toBe('slider-thumb-label');
+  });
+
+  it('label text matches thumbLabel; persists through hover', () => {
+    // `initial: 0` parks the thumb at slider-local origin so HIT_RAY
+    // (aimed at world (0,0,0) along −Z) reliably hits the grab sphere.
+    const slider = makeSlider({ thumbLabel: 'θ', initial: 0 });
+    const thumb = findThumbMesh(slider);
+    const label = findThumbLabel(slider);
+    expect(label.text).toBe('θ');
+
+    slider.updateHover([HIT_RAY()]);
+    expect(slider.isHovered).toBe(true);
+    expect(label.text).toBe('θ');
+    expect(label.parent).toBe(thumb);
+
+    slider.updateHover([]);
+    expect(slider.isHovered).toBe(false);
+    expect(label.text).toBe('θ');
+    expect(label.parent).toBe(thumb);
+  });
+
+  it('label persists through tryGrab / releaseFromPointer', () => {
+    const slider = makeSlider({ thumbLabel: 'C', initial: 0 });
+    const thumb = findThumbMesh(slider);
+    const label = findThumbLabel(slider);
+    const pointer = HIT_RAY();
+
+    expect(slider.tryGrab(pointer)).toBe(true);
+    expect(label.text).toBe('C');
+    expect(label.parent).toBe(thumb);
+
+    slider.releaseFromPointer(pointer);
+    expect(label.text).toBe('C');
+    expect(label.parent).toBe(thumb);
+  });
+
+  it('dispose() cleans up label, track, and thumb resources', () => {
+    const slider = makeSlider({ thumbLabel: 'x' });
+    const thumb = findThumbMesh(slider);
+    const label = findThumbLabel(slider);
+    // The track is the first child of the slider group (constructed
+    // before the thumb in Slider's ctor).
+    const track = slider.group.children.find(
+      (c) => c instanceof THREE.Mesh && c !== thumb,
+    ) as THREE.Mesh;
+    expect(track).toBeDefined();
+
+    const labelSpy = vi.spyOn(label, 'dispose');
+    const thumbGeomSpy = vi.spyOn(thumb.geometry, 'dispose');
+    const thumbMatSpy = vi.spyOn(thumb.material as THREE.Material, 'dispose');
+    const trackGeomSpy = vi.spyOn(track.geometry, 'dispose');
+    const trackMatSpy = vi.spyOn(track.material as THREE.Material, 'dispose');
+
+    slider.dispose();
+
+    expect(labelSpy).toHaveBeenCalledTimes(1);
+    expect(thumbGeomSpy).toHaveBeenCalledTimes(1);
+    expect(thumbMatSpy).toHaveBeenCalledTimes(1);
+    expect(trackGeomSpy).toHaveBeenCalledTimes(1);
+    expect(trackMatSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // Test 5: world-frame billboard correctness under a plinth-tilt
+  // parent. Replaces the v1-plan local-Euler assertion; world-frame
+  // assertions are the only way to detect the v1 algorithmic bug
+  // where local-Y rotation under a tilted parent diverges from
+  // world-Y yaw (#276 roundtable convergent HIGH).
+  it('faceCamera writes correct world-space billboard under plinth tilt', () => {
+    const slider = makeSlider({ thumbLabel: 'x' });
+    const thumb = findThumbMesh(slider);
+    const label = findThumbLabel(slider);
+
+    // Tilt parent: rotate the slider group 20° about world-X to
+    // mimic the plinth's surface tilt.
+    const scene = new THREE.Scene();
+    const tiltParent = new THREE.Object3D();
+    tiltParent.rotation.x = Math.PI / 9; // ≈ 20°
+    scene.add(tiltParent);
+    tiltParent.add(slider.group);
+
+    const camera = new THREE.PerspectiveCamera();
+
+    const labelWorld = new THREE.Vector3();
+    const thumbWorld = new THREE.Vector3();
+    const labelWorldQuat = new THREE.Quaternion();
+    const labelUp = new THREE.Vector3();
+    const labelForward = new THREE.Vector3();
+
+    const assertWorldFrameBillboard = (
+      camPos: [number, number, number],
+      label0: Text,
+    ): void => {
+      camera.position.set(...camPos);
+      scene.updateMatrixWorld(true);
+      slider.faceCamera(camera);
+      // updateMatrixWorld AFTER faceCamera so the label's transform
+      // writes (rotation + position in thumb-local frame) propagate
+      // to label.matrixWorld for the getWorldPosition / world-axis
+      // reads below.
+      scene.updateMatrixWorld(true);
+
+      // Use getWorldPosition for both thumb and label — NOT local
+      // `.position`. The plinth tilt makes the label's local frame
+      // distinct from world frame, and the world-frame equator check
+      // is what proves the algorithm correctly compensates the
+      // parent rotation.
+      label0.getWorldPosition(labelWorld);
+      thumb.getWorldPosition(thumbWorld);
+      label0.getWorldQuaternion(labelWorldQuat);
+
+      // Label world-up = local +Y transformed by world quaternion.
+      labelUp.set(0, 1, 0).applyQuaternion(labelWorldQuat);
+      // Yaw-only convention: label-up stays world-Y within float
+      // tolerance regardless of parent tilt.
+      expect(labelUp.x).toBeCloseTo(0, 5);
+      expect(labelUp.y).toBeCloseTo(1, 5);
+      expect(labelUp.z).toBeCloseTo(0, 5);
+
+      // Label world-forward = local +Z transformed by world
+      // quaternion. Projected onto world-XZ, it should align with
+      // the camera-to-thumb XZ direction.
+      labelForward.set(0, 0, 1).applyQuaternion(labelWorldQuat);
+      labelForward.y = 0;
+      labelForward.normalize();
+      const camFacing = new THREE.Vector3(
+        camPos[0] - thumbWorld.x,
+        0,
+        camPos[2] - thumbWorld.z,
+      ).normalize();
+      expect(labelForward.dot(camFacing)).toBeGreaterThan(0.999);
+
+      // Label rides the sphere equator: world Y-offset from thumb
+      // is near zero. This is the GPT-roundtable position-vs-
+      // orientation conflict gate.
+      expect(labelWorld.y - thumbWorld.y).toBeCloseTo(0, 5);
+
+      // Magnitude of world offset = thumbRadius + standoff.
+      const offsetWorld = new THREE.Vector3().subVectors(labelWorld, thumbWorld);
+      expect(offsetWorld.length()).toBeCloseTo(0.025 + 0.0015, 4);
+    };
+
+    // Standing eye-level pose.
+    assertWorldFrameBillboard([0, 1.5, 1.0], label);
+    // Tall pose — vertical camera move; label still rides the equator.
+    assertWorldFrameBillboard([0, 1.8, 1.0], label);
+    // Crouched pose.
+    assertWorldFrameBillboard([0, 1.3, 1.0], label);
+    // Yaw-change pose — camera rotated in XZ around the thumb.
+    assertWorldFrameBillboard([1.0, 1.5, 1.0], label);
+  });
+
+  it('empty-string label is a structurally valid opt-out', () => {
+    const slider = makeSlider({ thumbLabel: '' });
+    const label = findThumbLabel(slider);
+    expect(label.text).toBe('');
+  });
+
+  it('ctor places label outside sphere envelope before faceCamera', () => {
+    const slider = makeSlider({ thumbLabel: 'x²' });
+    const label = findThumbLabel(slider);
+    // Neutral local +Z placement set in ctor; faceCamera will refine
+    // it once the scene is mounted + a camera available, but the
+    // constructor-time default sits OUTSIDE the sphere envelope so
+    // the first render lands cleanly even without a faceCamera
+    // dispatch.
+    expect(label.position.x).toBe(0);
+    expect(label.position.y).toBe(0);
+    expect(label.position.z).toBeCloseTo(0.025 + 0.0015, 6);
+    expect(label.position.length()).toBeGreaterThan(0.025);
   });
 });


### PR DESCRIPTION
Closes #276.

Direction-pivot successor to #256 (closed won't-do, 2026-05-28) after
PR #275 closed unmerged following negative headset + pancake smoke
on the translucent-bubble approach.

## Summary

- Replaces all four `ThumbShape` values (`'sphere' | 'arrow-x' | 'arrow-y' | 'arrow-z'`) with a single opaque axis-tinted sphere + Troika `Text` label child. Drops the bidirectional 3D axis-arrow geometry; `buildArrowGeometry` + `mergeGeometries` import + `ThumbShape` type all delete.
- New required `thumbLabel: string` option on `SliderOptions`; each cluster slider declares its symbol inline. Empty-string is the structural opt-out for any future scene that wants a bare sphere.
- New `Slider.faceCamera(camera)` method — yaw-billboard the thumb label using the world-XZ-projected camera-facing direction for BOTH orientation and position. Computes the desired world-frame quaternion (about world-Y), then converts to label-local space via the inverse parent quaternion; this is what makes the yaw-only convention correct under the plinth's ~20° X-tilt.
- Each cluster scene's `update()` adds one symmetric `faceCamera` dispatch per visible slider alongside the existing `.update()` / `.updateHover(pointers)` ticks. Quadrics gates the `dSlider` dispatch on `activeSection.name !== CROSS_SECTION_SECTION_NAME`, matching the existing `dSlider.updateHover` guard.
- Per-slider symbol assignments (from #276 issue body):
  - quadrics squared coefficients: `x²` / `y²` / `z²`
  - quadrics constant `d` (shared across Squared + Linear via #140): `C` — propagates to both racks via the existing single-instance mounting wiring, no per-rack code path
  - quadrics linear terms: `x` / `y` / `z`
  - quadrics cross-sections: `x₀` / `y₀` / `z₀`
  - tangent-planes: `θ` / `φ`
  - gradient-levels: `θ` / `φ` / `k`
  - saddle-extrema: `x` / `y`
- 7 new Vitest behavioral cases:
  1. Thumb mesh structure + role markers + Text label child.
  2. Label text matches `thumbLabel` + persists through hover.
  3. Label persists through `tryGrab` / `releaseFromPointer`.
  4. `dispose()` cleans up label + track + thumb resources.
  5. `faceCamera` writes correct world-space billboard under a 20° plinth-tilt parent across standing / tall / crouched / yaw-change poses (label-up stays world-Y; label-forward XZ-projected dotted with cam-facing > 0.999; label rides the sphere equator).
  6. Empty-string `thumbLabel` is a structurally valid opt-out.
  7. Constructor-time label position is `(0, 0, R + standoff)` — outside the sphere envelope even before any `faceCamera` dispatch lands.
- Both `makeSlider` test helpers (`Slider.test.ts` + `PointerMigration.test.ts`) gain `thumbLabel: 'test'` for the required field; Troika is stubbed via the established `vi.mock('troika-three-text', ...)` pattern from `TapButton.test.ts`.
- `src/exhibits/gradient-levels/SPEC.md:200` updated to drop the now-defunct `thumbShape: 'sphere'` reference.

Plan + roundtable (Sonnet + GPT-5.5 + DeepSeek V4 Pro) + second-Sonnet sanity check captured in `_private/plans/276-emblazoned-label-slider-thumbs.md` (maintainer-private). v1 → v2 (13 findings folded) → v3 (4 tightening notes from sanity check).

## Test plan

- [x] `npm test` — 567/567 passing locally (added 7 new cases under `Slider thumb label (#276)`).
- [x] `npx tsc --noEmit` — clean across the diff.
- [x] `pre-commit` (gitleaks + standard fixers) — passing.
- [ ] Quest 3S + pancake smoke on the Cloudflare PR preview (per `CLAUDE.md` "Headset smoke-testing"):
  - [ ] Each cluster slider's thumb shows its symbol clearly at 1.0 m on pancake + Quest.
  - [ ] Label is readable from standing 1.6 m / crouched 1.3 m / tall 1.8 m poses (`#255` plan §3.2).
  - [ ] Hover / grab affordance on the sphere body remains clearly visible; label stays steady through transitions.
  - [ ] d-slider's `C` label appears identically in both Squared and Linear racks; hidden in Cross-sections lens.
  - [ ] No regression in cluster nav, FPS hold (72 Hz on Quest 3S), sister-scene visuals.
  - [ ] No z-fight shimmer at label/sphere interface at any pose.
- [ ] `/spar` (per `feedback_spar_before_merge_on_shell_diffs`) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)