### PR TITLE
feat(scaffold): bake slider thumb emblazon into sphere texture (#278)

### DIFF
--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -514,11 +514,6 @@ const gradientLevelsExhibit: Exhibit = {
     kSlider.update();
     thetaSlider.update();
     phiSlider.update();
-    if (camera) {
-      kSlider.faceCamera(camera);
-      thetaSlider.faceCamera(camera);
-      phiSlider.faceCamera(camera);
-    }
 
     // 2. Push k into the surface uniform (existing #163 path).
     if (surfaceMaterial) {

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -1422,19 +1422,10 @@ const quadricsExhibit: Exhibit = {
     ) {
       dSlider.updateHover(pointers);
     }
-    // Per-frame yaw-billboard the thumb labels (#276). Same
-    // visibility-gating as updateHover: only the active section's
-    // sliders + dSlider (when not Cross-sections) chase the camera,
-    // so hidden controls don't thrash their label transforms.
-    if (camera) {
-      for (const s of activeSection.sliders) s.faceCamera(camera);
-      if (
-        dSlider !== undefined &&
-        activeSection.name !== CROSS_SECTION_SECTION_NAME
-      ) {
-        dSlider.faceCamera(camera);
-      }
-    }
+    // Thumb labels are statically oriented along the plinth's
+    // surface normal (#278) — no per-frame billboard. The glyph
+    // stays fixed on the sphere surface; the user reads it from
+    // the natural lean-over working pose.
     // Cross-section toggles tick / hover only while their section is
     // focused. Their groups inherit visibility from the slider groups
     // (Section.setActive flips slider.group.visible), so a hidden

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -483,10 +483,6 @@ const saddleExtremaExhibit: Exhibit = {
       ySlider.updateHover(pointers);
       xSlider.update();
       ySlider.update();
-      if (camera) {
-        xSlider.faceCamera(camera);
-        ySlider.faceCamera(camera);
-      }
 
       const x = xSlider.value;
       const y = ySlider.value;

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -529,10 +529,6 @@ const tangentPlanesExhibit: Exhibit = {
     phiSlider.updateHover(pointers);
     thetaSlider.update();
     phiSlider.update();
-    if (camera) {
-      thetaSlider.faceCamera(camera);
-      phiSlider.faceCamera(camera);
-    }
 
     // Controller-aim picking refresh (#197). Re-raycast each frame while
     // the trigger is held so picking reads as a continuous drag rather

--- a/src/scaffold/ui/Slider.ts
+++ b/src/scaffold/ui/Slider.ts
@@ -1,5 +1,8 @@
 import * as THREE from 'three';
-import { Text } from 'troika-three-text';
+import {
+  acquireBakedSymbolTexture,
+  releaseBakedSymbolTexture,
+} from '@/scaffold/ui/bakedSymbolTexture';
 import { raySphereHit } from '@/scaffold/ui/rayHit';
 import type { Pointer } from '@/shell/Pointer';
 
@@ -43,14 +46,17 @@ export interface SliderOptions {
   // copies of this (see THUMB_HOVER_SCALE / THUMB_GRAB_SCALE), so a single
   // base color suffices to retune per-slider visuals (#58).
   baseColor?: number;
-  // Symbol emblazoned on the front of the thumb sphere via a Troika
-  // `Text` child that yaw-billboards toward the camera (#276). Required:
-  // every cluster slider gets a label per the #276 plan's §2.2 table;
-  // the explicit per-slider field declares the slider's role inline
-  // rather than spreading it across a per-scene mapping. Pass any
-  // Unicode string — the cluster's existing Troika consumers already
-  // render the full symbol set in source today (`x²` / `y²` / `z²` /
-  // `C` / `x` / `y` / `z` / `x₀` / `y₀` / `z₀` / `θ` / `φ` / `k`).
+  // Symbol emblazoned on the thumb sphere via a baked
+  // `(symbol, baseColor)` canvas texture wired into the sphere
+  // material's `map` slot (#278; #276 was the planar-billboard
+  // predecessor). Required: every cluster slider gets a label per
+  // the #276 plan's §2.2 table; the explicit per-slider field
+  // declares the slider's role inline rather than spreading it
+  // across a per-scene mapping. Pass any Unicode string the
+  // platform's `system-ui` font covers — the cluster's existing
+  // symbol set (`x²` / `y²` / `z²` / `C` / `x` / `y` / `z` /
+  // `x₀` / `y₀` / `z₀` / `θ` / `φ` / `k`) all render correctly on
+  // every targeted browser including Quest 3S.
   // Empty string is the structural opt-out for a future scene that
   // wants a bare sphere.
   thumbLabel: string;
@@ -60,42 +66,6 @@ const DEFAULT_TRACK_LENGTH = 0.3;
 const DEFAULT_THUMB_RADIUS = 0.025;
 const DEFAULT_DRAG_GAIN = 1.75;
 const DEFAULT_BASE_COLOR = 0xeeaa33;
-
-// Thumb-label visual constants (#276). First-pass per
-// `feedback_staging_dimensions_first_pass`; bracket + next-step doc
-// comments per `feedback_binary_search_visual_constants`.
-//
-// thumbRadius default = 0.025 m. Cluster readouts use 0.028 m fontSize
-// at ~0.7 m viewing distance. The thumb label sits at ~1.0 m viewing
-// distance (plinth + user spawn arm's-length-forward), so a slightly
-// smaller fontSize reads at the same angular size. Target label width
-// ≈ thumbRadius for the widest single-char symbol (`x²`, ~1.4 em);
-// narrower symbols (`x`, `θ`, `C`) come in at ~0.7 × thumbRadius.
-// Bracket [0.014, 0.024]: if labels read too small at 1.0 m, bump
-// toward 0.022 / 0.024; if a symbol clips outside the sphere
-// silhouette, drop toward 0.014. One dial per round.
-const SLIDER_THUMB_LABEL_FONT_SIZE = 0.018;
-
-// Standoff from the sphere surface. Without lift, the text quad
-// intersects the sphere at the placement point and produces z-fight
-// shimmer on Quest 3S panels (same regression class as
-// `SURFACE_LABEL_STANDOFF_M` in TapButton.ts). 1.5 mm is below the
-// pixel size of a Quest 3S panel at 1.0 m, so the gap isn't visible
-// as a floating glyph. Bracket [0.0005, 0.003]: bump up if z-fight
-// appears at oblique angles; drop down if the label reads as a decal
-// hovering off the surface.
-const SLIDER_THUMB_LABEL_STANDOFF_M = 0.0015;
-
-// Label color + outline. Matches the established TapButton precedent
-// (`LABEL_COLOR = 0xffffff`, `LABEL_OUTLINE_WIDTH = '8%'`,
-// `LABEL_OUTLINE_COLOR = 0x000000`). White-on-tint with a black
-// outline reads cleanly against every cluster body color: vermillion,
-// bluish-green, sky-blue, yellow, neutral gray. The 8% outline is
-// the same constant `READOUT_OUTLINE_WIDTH` uses across cluster
-// readouts.
-const SLIDER_THUMB_LABEL_COLOR = 0xffffff;
-const SLIDER_THUMB_LABEL_OUTLINE_WIDTH = '8%';
-const SLIDER_THUMB_LABEL_OUTLINE_COLOR = 0x000000;
 
 const HAPTIC_AMPLITUDE = 0.5;
 const HAPTIC_DURATION_MS = 10;
@@ -123,7 +93,6 @@ export class Slider {
   private readonly opts: Required<SliderOptions>;
   private readonly track: THREE.Mesh;
   private readonly thumb: THREE.Mesh;
-  private readonly thumbLabelText: Text;
   private readonly thumbWorld = new THREE.Vector3();
   // Skew-line projection scratches (allocated once per Slider). Shared
   // between `rayHitsThumb` (ray-sphere hit-test) and
@@ -135,21 +104,18 @@ export class Slider {
   private readonly sliderOrigin = new THREE.Vector3();
   private readonly axisDir = new THREE.Vector3();
   private readonly v = new THREE.Vector3();
-  // faceCamera scratches (#276 §3.3.1). `thumbCenterWorld` is read
-  // once per faceCamera tick (step 1, thumb's world position) and
-  // not re-used inside the call. The plan's S3 finding warned
-  // against the v1 algorithm's double-aliasing of this field for
-  // two semantically different reads; the v2 algorithm doesn't read
-  // a label-world position at all (the label's world placement is
-  // implied by the local-frame `position = camFacingLocal * offset`
-  // through the parent transform), so a separate `labelWorld`
-  // scratch isn't needed.
+  // faceCamera scratches (#278). The thumb yaw-billboards the
+  // baked texture toward the camera; the parent-inverse uses the
+  // SLIDER GROUP's world quaternion (not the thumb's own), since
+  // `thumb.quaternion` is interpreted in slider-group-local frame.
+  // The slider group inherits the plinth's ~20° X-tilt; without
+  // the inverse, a naive write to `thumb.rotation.y` would tilt
+  // the texture instead of yawing it.
   private readonly thumbCenterWorld = new THREE.Vector3();
   private readonly camWorld = new THREE.Vector3();
   private readonly camFacingWorld = new THREE.Vector3();
-  private readonly camFacingLocal = new THREE.Vector3();
-  private readonly thumbWorldQuat = new THREE.Quaternion();
-  private readonly thumbWorldQuatInv = new THREE.Quaternion();
+  private readonly sliderGroupWorldQuat = new THREE.Quaternion();
+  private readonly sliderGroupWorldQuatInv = new THREE.Quaternion();
   private readonly desiredWorldQuat = new THREE.Quaternion();
   // World-Y unit vector for `setFromAxisAngle`. Per-instance readonly
   // (not module-scope export) avoids the `feedback_threejs_token_exports_immutable`
@@ -158,6 +124,7 @@ export class Slider {
   private readonly worldY = new THREE.Vector3(0, 1, 0);
   private readonly hoverEmissive: THREE.Color;
   private readonly grabEmissive: THREE.Color;
+  private _disposed = false;
 
   // `rawValue` integrates hand motion every frame, untouched by detents.
   // `currentValue` is the emitted value — snapped to the nearest
@@ -220,37 +187,24 @@ export class Slider {
     this.hoverEmissive = baseColor.clone().multiplyScalar(THUMB_HOVER_SCALE);
     this.grabEmissive = baseColor.clone().multiplyScalar(THUMB_GRAB_SCALE);
 
+    // Per-slider baked emblazon texture (#278). One refcounted
+    // entry per unique `(thumbLabel, baseColor)` pair; the
+    // texture carries body color + centered white glyph, and the
+    // material's `color: 0xffffff` lets the texture supply the
+    // entire diffuse pass. `thumb.userData.thumbLabel` exposes
+    // the symbol assignment for test discovery (Slider tests read
+    // this instead of traversing for a Text child as in #276).
+    const thumbTexture = acquireBakedSymbolTexture(
+      options.thumbLabel,
+      this.opts.baseColor,
+    );
     this.thumb = new THREE.Mesh(
       new THREE.SphereGeometry(this.opts.thumbRadius, 16, 12),
-      new THREE.MeshStandardMaterial({ color: baseColor }),
+      new THREE.MeshStandardMaterial({ color: 0xffffff, map: thumbTexture }),
     );
     this.thumb.userData.role = 'slider-thumb';
+    this.thumb.userData.thumbLabel = options.thumbLabel;
     this.group.add(this.thumb);
-
-    // Per-slider thumb label (#276). Troika `Text` child of the thumb
-    // mesh — the label rides with the thumb as the user drags. Position
-    // and rotation are rewritten every frame by `faceCamera`; the
-    // values below are the at-construction defaults so the label sits
-    // outside the sphere envelope even before any faceCamera dispatch
-    // (e.g. on the first render). `userData.role` marker is the test-
-    // discovery hook (Slider.test.ts traverses the scene graph by
-    // role, not by child-index).
-    this.thumbLabelText = new Text();
-    this.thumbLabelText.userData.role = 'slider-thumb-label';
-    this.thumbLabelText.text = options.thumbLabel;
-    this.thumbLabelText.fontSize = SLIDER_THUMB_LABEL_FONT_SIZE;
-    this.thumbLabelText.color = SLIDER_THUMB_LABEL_COLOR;
-    this.thumbLabelText.anchorX = 'center';
-    this.thumbLabelText.anchorY = 'middle';
-    this.thumbLabelText.outlineWidth = SLIDER_THUMB_LABEL_OUTLINE_WIDTH;
-    this.thumbLabelText.outlineColor = SLIDER_THUMB_LABEL_OUTLINE_COLOR;
-    this.thumbLabelText.position.set(
-      0,
-      0,
-      this.opts.thumbRadius + SLIDER_THUMB_LABEL_STANDOFF_M,
-    );
-    this.thumbLabelText.sync();
-    this.thumb.add(this.thumbLabelText);
 
     this.syncThumbPosition();
     // Initial emissive via the centralized state machine, not by relying on
@@ -279,46 +233,57 @@ export class Slider {
   }
 
   dispose(): void {
+    // Idempotent guard (#278). Calling dispose() twice is a clean
+    // no-op; matches Three.js's own dispose conventions and lets
+    // scene-teardown / HMR / error-recovery paths be sloppy
+    // without surfacing spurious warnings from
+    // `releaseBakedSymbolTexture`.
+    if (this._disposed) return;
+    this._disposed = true;
     this.track.geometry.dispose();
     (this.track.material as THREE.Material).dispose();
     this.thumb.geometry.dispose();
     (this.thumb.material as THREE.Material).dispose();
-    this.thumbLabelText.dispose();
+    releaseBakedSymbolTexture(this.opts.thumbLabel, this.opts.baseColor);
   }
 
   /**
-   * Yaw-billboard the thumb's emblazon label (#276) to face the camera
-   * in the world-XZ plane. Position uses the same XZ-projected camera
-   * direction as the orientation, so the label rides the sphere
-   * equator regardless of camera elevation — pancake crouched/tall
-   * poses and VR head pitch don't move the label onto the upper or
-   * lower hemisphere where the vertical glyph plane would non-tangent
-   * the sphere.
+   * Yaw-billboard the thumb sphere (#278) so the baked emblazon
+   * texture's centered glyph (sphere +Z surface point) faces the
+   * camera in the world-XZ plane. The sphere body is uniform-
+   * colored away from the glyph, so the rotation is visually
+   * invisible apart from the glyph region; the user always sees
+   * the glyph from any camera azimuth.
    *
-   * Each cluster scene dispatches this on every visible slider per
-   * frame (`for (const s of allSliders) s.faceCamera(camera)`),
-   * matching the established `TapButton.faceCamera(camera)` pattern.
+   * Yaw-only convention (#29): camera elevation is ignored so the
+   * texture stays world-upright and a head tilt in VR doesn't
+   * roll the glyph. The parent-inverse uses the SLIDER GROUP's
+   * world quaternion (not the thumb's own) because
+   * `thumb.quaternion` is interpreted in slider-group-local
+   * frame; the slider group inherits the plinth's ~20° X-tilt,
+   * so a naive `thumb.rotation.set(0, yaw, 0)` would tilt the
+   * texture instead of yawing it about world-Y.
    *
-   * `getWorldPosition` / `getWorldQuaternion` call `updateWorldMatrix(
-   * true, false)` internally (three.js r152+), so we don't need an
-   * explicit `scene.updateMatrixWorld(true)` here even though
-   * `Slider.update()` writes `thumb.position` earlier in the same
-   * frame. Three.js's auto-update walks the parent chain and
-   * recomputes `matrixWorld` lazily.
+   * Each cluster scene dispatches this on every visible slider
+   * per frame (`for (const s of allSliders) s.faceCamera(camera)`),
+   * matching the established `TapButton.faceCamera(camera)`
+   * pattern.
+   *
+   * `getWorldPosition` / `getWorldQuaternion` call
+   * `updateWorldMatrix(true, false)` internally (three.js r152+),
+   * so we don't need an explicit `scene.updateMatrixWorld(true)`
+   * here even though `Slider.update()` writes `thumb.position`
+   * earlier in the same frame.
    */
   faceCamera(camera: THREE.Camera): void {
     // 1. World vector from thumb to camera, projected onto world-XZ.
-    //    Yaw-only convention (#29): ignore camera elevation so the
-    //    glyph plane stays world-vertical and a head tilt in VR
-    //    doesn't roll the label.
     this.thumb.getWorldPosition(this.thumbCenterWorld);
     camera.getWorldPosition(this.camWorld);
     this.camFacingWorld.subVectors(this.camWorld, this.thumbCenterWorld);
     this.camFacingWorld.y = 0;
     // Near-degenerate guard: camera ~directly above / below the
     // thumb. No defined yaw; fall back to world +Z so the rotation
-    // is well-defined and a pancake camera move past the thumb's
-    // vertical line doesn't NaN out.
+    // stays well-defined.
     const xzLen = this.camFacingWorld.length();
     if (xzLen < 1e-6) {
       this.camFacingWorld.set(0, 0, 1);
@@ -327,37 +292,26 @@ export class Slider {
     }
 
     // 2. Desired world-space quaternion: yaw about world-Y so the
-    //    label glyph plane (Troika local +Z normal) faces the camera.
-    //    `setFromAxisAngle` is read-only on `worldY`.
+    //    sphere's local +Z surface point (where the glyph centers
+    //    at U=0.5, V=0.5 under SphereGeometry's default
+    //    equirectangular UVs) points at the camera.
     const yaw = Math.atan2(this.camFacingWorld.x, this.camFacingWorld.z);
     this.desiredWorldQuat.setFromAxisAngle(this.worldY, yaw);
 
-    // 3. Convert the desired world quaternion to label-local space
-    //    via the parent's (= thumb's) inverse world quaternion. The
-    //    thumb has no rotation in its slider group, but the slider
-    //    group inherits the plinth's ~20° X-tilt — so the thumb's
-    //    world quaternion captures the full parent chain. Writing
-    //    a world yaw directly into local rotation Y would be wrong
-    //    under a tilted parent (the local-Y axis is tilted forward).
-    this.thumb.getWorldQuaternion(this.thumbWorldQuat);
-    this.thumbWorldQuatInv.copy(this.thumbWorldQuat).invert();
-    this.thumbLabelText.quaternion
-      .copy(this.thumbWorldQuatInv)
+    // 3. Convert the desired world quaternion to slider-group-local
+    //    space via the slider group's inverse world quaternion, then
+    //    write to `thumb.quaternion`.
+    this.group.getWorldQuaternion(this.sliderGroupWorldQuat);
+    this.sliderGroupWorldQuatInv.copy(this.sliderGroupWorldQuat).invert();
+    this.thumb.quaternion
+      .copy(this.sliderGroupWorldQuatInv)
       .multiply(this.desiredWorldQuat);
 
-    // 4. Label position: in world frame the label sits at
-    //    `thumbWorld + camFacingWorld * (R + standoff)`. Express
-    //    the offset as a thumb-local position by rotating the
-    //    XZ-projected unit direction through the inverse parent
-    //    quaternion. The world-frame result is then identical to
-    //    the world-space placement.
-    this.camFacingLocal
-      .copy(this.camFacingWorld)
-      .applyQuaternion(this.thumbWorldQuatInv);
-    const offset = this.opts.thumbRadius + SLIDER_THUMB_LABEL_STANDOFF_M;
-    this.thumbLabelText.position
-      .copy(this.camFacingLocal)
-      .multiplyScalar(offset);
+    // 4. No position write — the glyph is baked into the sphere
+    //    surface; rotating the sphere moves the glyph. The thumb's
+    //    `thumb.position.x` track-tracking write in
+    //    `syncThumbPosition` is the only position write the thumb
+    //    mesh receives.
   }
 
   /**

--- a/src/scaffold/ui/Slider.ts
+++ b/src/scaffold/ui/Slider.ts
@@ -104,24 +104,6 @@ export class Slider {
   private readonly sliderOrigin = new THREE.Vector3();
   private readonly axisDir = new THREE.Vector3();
   private readonly v = new THREE.Vector3();
-  // faceCamera scratches (#278). The thumb yaw-billboards the
-  // baked texture toward the camera; the parent-inverse uses the
-  // SLIDER GROUP's world quaternion (not the thumb's own), since
-  // `thumb.quaternion` is interpreted in slider-group-local frame.
-  // The slider group inherits the plinth's ~20° X-tilt; without
-  // the inverse, a naive write to `thumb.rotation.y` would tilt
-  // the texture instead of yawing it.
-  private readonly thumbCenterWorld = new THREE.Vector3();
-  private readonly camWorld = new THREE.Vector3();
-  private readonly camFacingWorld = new THREE.Vector3();
-  private readonly sliderGroupWorldQuat = new THREE.Quaternion();
-  private readonly sliderGroupWorldQuatInv = new THREE.Quaternion();
-  private readonly desiredWorldQuat = new THREE.Quaternion();
-  // World-Y unit vector for `setFromAxisAngle`. Per-instance readonly
-  // (not module-scope export) avoids the `feedback_threejs_token_exports_immutable`
-  // hazard; `setFromAxisAngle` is read-only on its axis arg, so this
-  // is never mutated.
-  private readonly worldY = new THREE.Vector3(0, 1, 0);
   private readonly hoverEmissive: THREE.Color;
   private readonly grabEmissive: THREE.Color;
   private _disposed = false;
@@ -198,22 +180,35 @@ export class Slider {
       options.thumbLabel,
       this.opts.baseColor,
     );
-    // Rotate the sphere geometry so the texture's centered UV
-    // (U=0.5, V=0.5) maps to thumb-local +Z instead of +X. Three.js
-    // `SphereGeometry`'s default equirectangular UV places (0.5,
-    // 0.5) on the local +X surface point (per the source's
-    // `vertex.x = -radius * cos(phiStart + u * phiLength) * ...`);
-    // without this rotation, faceCamera's yaw math (which writes
-    // local +Z toward the camera) would point the bare +Z side at
-    // the user and the glyph would face world +X. Vertices rotate;
-    // UVs don't, so the glyph effectively moves 90° around the
-    // sphere to land where faceCamera expects it.
+    // Two-step orientation so the glyph centers along the
+    // drafting-board surface normal (#278). The user works the
+    // sliders by leaning over the plinth, so the natural reading
+    // pose is looking down the surface normal — the glyph stays
+    // fixed on the sphere, NOT yaw-tracking the camera.
+    //
+    // Step 1: `SphereGeometry`'s default equirectangular UV places
+    // (U=0.5, V=0.5) on the local +X surface point (per
+    // three/src/geometries/SphereGeometry.js: `vertex.x = -radius
+    // * cos(phiStart + u * phiLength) * sin(...)`); rotate the
+    // VERTICES (UVs don't rotate, only positions) about local +Y
+    // so the glyph effectively moves 90° around the sphere to
+    // mesh-local +Z.
+    //
+    // Step 2: rotate the THUMB MESH itself about local +X by −π/2
+    // so the mesh-local +Z direction (carrying the glyph) maps to
+    // slider-local +Y. Sliders mount on the plinth with
+    // orientation='surface' (slot-frame rotation −tilt about
+    // world +X per `Plinth.computePlinthSlotTransform`), which
+    // makes slider-local +Y = surface normal in world. The glyph
+    // therefore faces along the drafting-board normal regardless
+    // of the cluster the slider lives in.
     const sphereGeom = new THREE.SphereGeometry(this.opts.thumbRadius, 16, 12);
     sphereGeom.rotateY(-Math.PI / 2);
     this.thumb = new THREE.Mesh(
       sphereGeom,
       new THREE.MeshStandardMaterial({ color: 0xffffff, map: thumbTexture }),
     );
+    this.thumb.rotation.x = -Math.PI / 2;
     this.thumb.userData.role = 'slider-thumb';
     this.thumb.userData.thumbLabel = options.thumbLabel;
     this.group.add(this.thumb);
@@ -257,73 +252,6 @@ export class Slider {
     this.thumb.geometry.dispose();
     (this.thumb.material as THREE.Material).dispose();
     releaseBakedSymbolTexture(this.opts.thumbLabel, this.opts.baseColor);
-  }
-
-  /**
-   * Yaw-billboard the thumb sphere (#278) so the baked emblazon
-   * texture's centered glyph (sphere +Z surface point) faces the
-   * camera in the world-XZ plane. The sphere body is uniform-
-   * colored away from the glyph, so the rotation is visually
-   * invisible apart from the glyph region; the user always sees
-   * the glyph from any camera azimuth.
-   *
-   * Yaw-only convention (#29): camera elevation is ignored so the
-   * texture stays world-upright and a head tilt in VR doesn't
-   * roll the glyph. The parent-inverse uses the SLIDER GROUP's
-   * world quaternion (not the thumb's own) because
-   * `thumb.quaternion` is interpreted in slider-group-local
-   * frame; the slider group inherits the plinth's ~20° X-tilt,
-   * so a naive `thumb.rotation.set(0, yaw, 0)` would tilt the
-   * texture instead of yawing it about world-Y.
-   *
-   * Each cluster scene dispatches this on every visible slider
-   * per frame (`for (const s of allSliders) s.faceCamera(camera)`),
-   * matching the established `TapButton.faceCamera(camera)`
-   * pattern.
-   *
-   * `getWorldPosition` / `getWorldQuaternion` call
-   * `updateWorldMatrix(true, false)` internally (three.js r152+),
-   * so we don't need an explicit `scene.updateMatrixWorld(true)`
-   * here even though `Slider.update()` writes `thumb.position`
-   * earlier in the same frame.
-   */
-  faceCamera(camera: THREE.Camera): void {
-    // 1. World vector from thumb to camera, projected onto world-XZ.
-    this.thumb.getWorldPosition(this.thumbCenterWorld);
-    camera.getWorldPosition(this.camWorld);
-    this.camFacingWorld.subVectors(this.camWorld, this.thumbCenterWorld);
-    this.camFacingWorld.y = 0;
-    // Near-degenerate guard: camera ~directly above / below the
-    // thumb. No defined yaw; fall back to world +Z so the rotation
-    // stays well-defined.
-    const xzLen = this.camFacingWorld.length();
-    if (xzLen < 1e-6) {
-      this.camFacingWorld.set(0, 0, 1);
-    } else {
-      this.camFacingWorld.divideScalar(xzLen);
-    }
-
-    // 2. Desired world-space quaternion: yaw about world-Y so the
-    //    sphere's local +Z surface point (where the glyph centers
-    //    at U=0.5, V=0.5 under SphereGeometry's default
-    //    equirectangular UVs) points at the camera.
-    const yaw = Math.atan2(this.camFacingWorld.x, this.camFacingWorld.z);
-    this.desiredWorldQuat.setFromAxisAngle(this.worldY, yaw);
-
-    // 3. Convert the desired world quaternion to slider-group-local
-    //    space via the slider group's inverse world quaternion, then
-    //    write to `thumb.quaternion`.
-    this.group.getWorldQuaternion(this.sliderGroupWorldQuat);
-    this.sliderGroupWorldQuatInv.copy(this.sliderGroupWorldQuat).invert();
-    this.thumb.quaternion
-      .copy(this.sliderGroupWorldQuatInv)
-      .multiply(this.desiredWorldQuat);
-
-    // 4. No position write — the glyph is baked into the sphere
-    //    surface; rotating the sphere moves the glyph. The thumb's
-    //    `thumb.position.x` track-tracking write in
-    //    `syncThumbPosition` is the only position write the thumb
-    //    mesh receives.
   }
 
   /**

--- a/src/scaffold/ui/Slider.ts
+++ b/src/scaffold/ui/Slider.ts
@@ -198,8 +198,20 @@ export class Slider {
       options.thumbLabel,
       this.opts.baseColor,
     );
+    // Rotate the sphere geometry so the texture's centered UV
+    // (U=0.5, V=0.5) maps to thumb-local +Z instead of +X. Three.js
+    // `SphereGeometry`'s default equirectangular UV places (0.5,
+    // 0.5) on the local +X surface point (per the source's
+    // `vertex.x = -radius * cos(phiStart + u * phiLength) * ...`);
+    // without this rotation, faceCamera's yaw math (which writes
+    // local +Z toward the camera) would point the bare +Z side at
+    // the user and the glyph would face world +X. Vertices rotate;
+    // UVs don't, so the glyph effectively moves 90° around the
+    // sphere to land where faceCamera expects it.
+    const sphereGeom = new THREE.SphereGeometry(this.opts.thumbRadius, 16, 12);
+    sphereGeom.rotateY(-Math.PI / 2);
     this.thumb = new THREE.Mesh(
-      new THREE.SphereGeometry(this.opts.thumbRadius, 16, 12),
+      sphereGeom,
       new THREE.MeshStandardMaterial({ color: 0xffffff, map: thumbTexture }),
     );
     this.thumb.userData.role = 'slider-thumb';

--- a/src/scaffold/ui/Slider.ts
+++ b/src/scaffold/ui/Slider.ts
@@ -180,13 +180,13 @@ export class Slider {
       options.thumbLabel,
       this.opts.baseColor,
     );
-    // Two-step orientation so the glyph centers along the
-    // drafting-board surface normal (#278). The user works the
-    // sliders by leaning over the plinth, so the natural reading
-    // pose is looking down the surface normal — the glyph stays
-    // fixed on the sphere, NOT yaw-tracking the camera.
+    // Static glyph orientation along the drafting-board surface
+    // normal (#278). The user works the sliders by leaning over
+    // the plinth, so the natural reading pose looks down the
+    // surface normal — the glyph stays fixed on the sphere, NOT
+    // yaw-tracking the camera.
     //
-    // Step 1: `SphereGeometry`'s default equirectangular UV places
+    // `SphereGeometry`'s default equirectangular UV places
     // (U=0.5, V=0.5) on the local +X surface point (per
     // three/src/geometries/SphereGeometry.js: `vertex.x = -radius
     // * cos(phiStart + u * phiLength) * sin(...)`); rotate the
@@ -194,21 +194,24 @@ export class Slider {
     // so the glyph effectively moves 90° around the sphere to
     // mesh-local +Z.
     //
-    // Step 2: rotate the THUMB MESH itself about local +X by −π/2
-    // so the mesh-local +Z direction (carrying the glyph) maps to
-    // slider-local +Y. Sliders mount on the plinth with
+    // The thumb mesh itself has identity rotation, so mesh-local
+    // +Z = slider-local +Z. Sliders mount on the plinth with
     // orientation='surface' (slot-frame rotation −tilt about
-    // world +X per `Plinth.computePlinthSlotTransform`), which
-    // makes slider-local +Y = surface normal in world. The glyph
-    // therefore faces along the drafting-board normal regardless
-    // of the cluster the slider lives in.
+    // world +X per `Plinth.computePlinthSlotTransform`); the slab
+    // is thin in slot-local Z with the outward face at z=0, so
+    // slot-local +Z IS the slab's surface normal. After the slot
+    // rotation, slider-local +Z maps to world (0, sin(tilt),
+    // cos(tilt)) — "up and toward the user" at the spawn pose.
+    // (Slot-local +Y is "up along the slab" from front edge to
+    // back edge, which under the slot rotation winds up "up and
+    // back" — visually centered there looked like eyes rolled
+    // upward, hence the +Z choice.)
     const sphereGeom = new THREE.SphereGeometry(this.opts.thumbRadius, 16, 12);
     sphereGeom.rotateY(-Math.PI / 2);
     this.thumb = new THREE.Mesh(
       sphereGeom,
       new THREE.MeshStandardMaterial({ color: 0xffffff, map: thumbTexture }),
     );
-    this.thumb.rotation.x = -Math.PI / 2;
     this.thumb.userData.role = 'slider-thumb';
     this.thumb.userData.thumbLabel = options.thumbLabel;
     this.group.add(this.thumb);

--- a/src/scaffold/ui/bakedSymbolTexture.ts
+++ b/src/scaffold/ui/bakedSymbolTexture.ts
@@ -21,16 +21,16 @@ import * as THREE from 'three';
 // `feedback_binary_search_visual_constants`.
 const TEXTURE_SIZE_PX = 256;
 
-// Glyph height in texture pixels. Round 2 of binary search per
-// `feedback_binary_search_visual_constants`: round 1 (160) read
-// in Brad's pancake smoke as "wraps a full hemisphere of the
-// slider" — too distorted on the sphere. Dropping to 112 (=
-// 0.7 × 160) shrinks the glyph footprint so it drifts over less
-// of the sphere surface. Bracket [80, 144]: if 112 still reads
-// as wrapping too much, drop toward 96 / 80; if it's now too
-// small for the narrower glyphs (e.g., `θ`), bump back toward
-// 128 / 144. One dial per round.
-const GLYPH_FONT_SIZE_PX = 112;
+// Glyph height in texture pixels. Round 3 of binary search per
+// `feedback_binary_search_visual_constants`. Round 1 (160) read
+// as a full-hemisphere wrap; round 2 (112) was tighter but still
+// drifting over more of the sphere than wanted. Round 3 = 90 (≈
+// 0.56 × original; Brad asked for "0.5× original" while specifying
+// 90, so the rounded number wins). Tight bracket [78, 108] now
+// that we're converging: drop toward 78 if 90 still feels too
+// wrappy; bump toward 108 if the narrower glyphs (`θ`) read
+// undersized.
+const GLYPH_FONT_SIZE_PX = 90;
 
 // `system-ui` resolves to the OS default UI font: San Francisco on
 // macOS, Segoe UI on Windows, Roboto / Noto Sans on Android (incl.

--- a/src/scaffold/ui/bakedSymbolTexture.ts
+++ b/src/scaffold/ui/bakedSymbolTexture.ts
@@ -21,15 +21,16 @@ import * as THREE from 'three';
 // `feedback_binary_search_visual_constants`.
 const TEXTURE_SIZE_PX = 256;
 
-// Glyph height in texture pixels. The font occupies ~60% of the
-// canvas height; the surrounding 20% top + 20% bottom is body
-// color. On an equirectangular sphere UV the glyph at V=0.5 reads
-// at the equator; horizontal scale ≈ vertical scale at the
-// equator's center, so the glyph stays roughly square. Bracket
-// [120, 200]: drop if smoke shows the glyph overhanging the sphere
-// silhouette; bump if it reads as too small for narrower glyphs
-// like `θ`.
-const GLYPH_FONT_SIZE_PX = 160;
+// Glyph height in texture pixels. Round 2 of binary search per
+// `feedback_binary_search_visual_constants`: round 1 (160) read
+// in Brad's pancake smoke as "wraps a full hemisphere of the
+// slider" — too distorted on the sphere. Dropping to 112 (=
+// 0.7 × 160) shrinks the glyph footprint so it drifts over less
+// of the sphere surface. Bracket [80, 144]: if 112 still reads
+// as wrapping too much, drop toward 96 / 80; if it's now too
+// small for the narrower glyphs (e.g., `θ`), bump back toward
+// 128 / 144. One dial per round.
+const GLYPH_FONT_SIZE_PX = 112;
 
 // `system-ui` resolves to the OS default UI font: San Francisco on
 // macOS, Segoe UI on Windows, Roboto / Noto Sans on Android (incl.

--- a/src/scaffold/ui/bakedSymbolTexture.ts
+++ b/src/scaffold/ui/bakedSymbolTexture.ts
@@ -1,0 +1,286 @@
+import * as THREE from 'three';
+
+// Refcounted cache of `(symbol, color)` → `THREE.CanvasTexture` for
+// the slider-thumb emblazon (#278). Each texture bakes the body
+// color across the full quad PLUS the centered white glyph; the
+// thumb sphere's `MeshStandardMaterial({ color: 0xffffff, map })`
+// then samples the entire surface from the texture, leaving the
+// emissive flip (hover/grab) as the dynamic affordance. Each unique
+// `(symbol, color)` pair lives once in the cache; consumers acquire
+// on construction and release on dispose. At refcount zero the
+// underlying GL state + backing canvas are freed.
+
+// Resolution chosen so the glyph never approaches the per-screen-
+// pixel limit on Quest 3S at the smoke pose (plinth + arm's-length-
+// forward ≈ 1.0 m, thumb 2.5 cm wide → ~32 px across the sphere
+// diameter). Bracket [128, 512]: drop to 128 if smoke shows GL
+// memory pressure (13 × 256² × 4 B = ~3.3 MB across the cluster —
+// well under any realistic Quest 3S budget); bump to 512 only if
+// glyph anti-aliasing reads as too coarse at oblique pancake camera
+// angles. One dial per round per
+// `feedback_binary_search_visual_constants`.
+const TEXTURE_SIZE_PX = 256;
+
+// Glyph height in texture pixels. The font occupies ~60% of the
+// canvas height; the surrounding 20% top + 20% bottom is body
+// color. On an equirectangular sphere UV the glyph at V=0.5 reads
+// at the equator; horizontal scale ≈ vertical scale at the
+// equator's center, so the glyph stays roughly square. Bracket
+// [120, 200]: drop if smoke shows the glyph overhanging the sphere
+// silhouette; bump if it reads as too small for narrower glyphs
+// like `θ`.
+const GLYPH_FONT_SIZE_PX = 160;
+
+// `system-ui` resolves to the OS default UI font: San Francisco on
+// macOS, Segoe UI on Windows, Roboto / Noto Sans on Android (incl.
+// Quest 3S browser, which is Chromium-Meta). All of those ship
+// complete coverage for the cluster symbol set (`x²` / `y²` / `z²`
+// / `C` / `x` / `y` / `z` / `x₀` / `y₀` / `z₀` / `θ` / `φ` / `k`).
+// Fallback to `sans-serif` covers the rare browser that doesn't
+// recognize `system-ui`.
+const GLYPH_FONT_FAMILY = 'system-ui, sans-serif';
+
+// Empirical vertical-centering offset (pixels). `textBaseline:
+// 'middle'` centers the font em box, which for symbols with
+// superscripts (`x²`) sits above the visual ink-bbox centroid (the
+// `²` shifts ink up but the em box stays centered). A small
+// downward offset re-centers the visible ink. Bracket [-12, 12]:
+// positive = shift down; tune in smoke per
+// `feedback_binary_search_visual_constants` if `x²` / `x₀` read
+// noticeably off-center on the sphere face.
+const GLYPH_VERTICAL_OFFSET_PX = 4;
+
+// White-on-tint contrast strategy, matches the established
+// TapButton / Label precedent. Hard-coded; the §6 (c) escape in
+// the #278 plan derives per-baseColor if the yellow d-slider
+// washes out.
+const GLYPH_FILL_STYLE = '#ffffff';
+
+// Black outline width as a fraction of glyph font size, matches
+// the 8% Troika outline convention.
+const GLYPH_STROKE_WIDTH_PX = Math.round(GLYPH_FONT_SIZE_PX * 0.08);
+const GLYPH_STROKE_STYLE = '#000000';
+
+interface CacheEntry {
+  texture: THREE.CanvasTexture;
+  refCount: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+// Test-injectable canvas factory. Default is the browser's
+// `document.createElement('canvas')`. Vitest tests inject a fake
+// that returns a plain object with a stubbed `getContext` — avoids
+// needing jsdom (Vitest in this project runs in Node; jsdom is not
+// installed) and the global-prototype mutation that the original
+// stub strategy would have required.
+//
+// The default factory checks for `document` at call time and
+// throws a readable error if absent (Node / SSR / build-step
+// accidentally triggering a bake from a non-browser environment).
+// When tests inject a factory, the default never runs and no
+// `document` access happens.
+type CanvasFactory = () => HTMLCanvasElement;
+const defaultCanvasFactory: CanvasFactory = () => {
+  if (typeof document === 'undefined') {
+    throw new Error(
+      'bakedSymbolTexture: requires a browser environment ' +
+        '(no `document` available — for tests, inject a factory ' +
+        'via `_setCanvasFactoryForTests`).',
+    );
+  }
+  return document.createElement('canvas');
+};
+let createCanvas: CanvasFactory = defaultCanvasFactory;
+
+/**
+ * Test-only: override the canvas factory. Pass `null` to reset to
+ * the browser default.
+ */
+export function _setCanvasFactoryForTests(factory: CanvasFactory | null): void {
+  createCanvas = factory ?? defaultCanvasFactory;
+}
+
+function cacheKey(symbol: string, color: number): string {
+  // Pad to 6 hex digits for canonical formatting and grep-friendly
+  // log lines. Padding doesn't prevent any genuine collision
+  // (`0xff0000` and `0xff00` wouldn't collide unpadded either since
+  // `"ff0000" !== "ff00"`); it's purely cosmetic / log readability.
+  return `${symbol}|0x${color.toString(16).padStart(6, '0')}`;
+}
+
+function renderTexture(symbol: string, color: number): THREE.CanvasTexture {
+  const canvas = createCanvas();
+  canvas.width = TEXTURE_SIZE_PX;
+  canvas.height = TEXTURE_SIZE_PX;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('bakedSymbolTexture: canvas 2D context unavailable');
+  }
+  // Body color across the whole quad. Resolves to baseColor when
+  // sampled by the sphere material with `mat.color = 0xffffff`.
+  ctx.fillStyle = `#${color.toString(16).padStart(6, '0')}`;
+  ctx.fillRect(0, 0, TEXTURE_SIZE_PX, TEXTURE_SIZE_PX);
+
+  // Centered white glyph with a thin black stroke for contrast
+  // against the yellow d-slider and any other light body color.
+  ctx.font = `${GLYPH_FONT_SIZE_PX}px ${GLYPH_FONT_FAMILY}`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.lineWidth = GLYPH_STROKE_WIDTH_PX;
+  ctx.strokeStyle = GLYPH_STROKE_STYLE;
+  ctx.lineJoin = 'round';
+  const cx = TEXTURE_SIZE_PX / 2;
+  const cy = TEXTURE_SIZE_PX / 2 + GLYPH_VERTICAL_OFFSET_PX;
+  ctx.strokeText(symbol, cx, cy);
+  ctx.fillStyle = GLYPH_FILL_STYLE;
+  ctx.fillText(symbol, cx, cy);
+
+  const texture = new THREE.CanvasTexture(canvas);
+  // The canvas paints in sRGB space; tell Three.js so the shader
+  // converts to linear before lighting and back to sRGB on output.
+  // Without this the glyph + body read slightly off-saturation
+  // against the rest of the cluster.
+  texture.colorSpace = THREE.SRGBColorSpace;
+  // `CanvasTexture` inherits `Texture`'s default `flipY = true`,
+  // which combined with `SphereGeometry`'s V-axis convention (V=0
+  // at north pole, V=1 at south) gives upright glyphs on the +Z
+  // equator (V=0.5). Leaving as default; the #278 plan §4.3 smoke
+  // checklist asserts upright rendering on `x²` and `x₀` where any
+  // orientation regression would be most visible.
+  //
+  // Mipmaps on by default — a 256² high-contrast white-on-tint
+  // glyph minified to ~32 px on Quest 3S during head motion is a
+  // known shimmer pattern without mipmapping. Linear-mipmap-linear
+  // gives smooth scaling between mip levels.
+  texture.generateMipmaps = true;
+  texture.minFilter = THREE.LinearMipmapLinearFilter;
+  texture.magFilter = THREE.LinearFilter;
+  texture.anisotropy = 1;
+  texture.needsUpdate = true;
+  return texture;
+}
+
+/**
+ * Acquire (or first-time create) the baked texture for a
+ * `(symbol, color)` pair. Increments the refcount and returns the
+ * shared texture instance. Consumers MUST call
+ * `releaseBakedSymbolTexture` with the same key on disposal.
+ */
+export function acquireBakedSymbolTexture(
+  symbol: string,
+  color: number,
+): THREE.CanvasTexture {
+  const key = cacheKey(symbol, color);
+  let entry = cache.get(key);
+  if (!entry) {
+    entry = { texture: renderTexture(symbol, color), refCount: 0 };
+    cache.set(key, entry);
+  }
+  entry.refCount += 1;
+  return entry.texture;
+}
+
+/**
+ * Release a previously-acquired baked texture. Decrements the
+ * refcount; at zero, disposes the GPU texture, clears the backing
+ * canvas, and removes the cache entry.
+ *
+ * Soft semantics on missing / over-released keys: warns to console
+ * and returns rather than throwing. The throw alternative
+ * surfaced uncaught errors on legitimate lifecycle paths (HMR mid-
+ * mount, scene-teardown error recovery, tests that accidentally
+ * double-dispose) without giving the caller a meaningful recovery
+ * option. Matches Three.js's own dispose conventions:
+ * idempotent-friendly.
+ */
+export function releaseBakedSymbolTexture(
+  symbol: string,
+  color: number,
+): void {
+  const key = cacheKey(symbol, color);
+  const entry = cache.get(key);
+  if (!entry) {
+    console.warn(
+      `bakedSymbolTexture: release for unknown key ${key} ` +
+        '(double-release or release-without-acquire — no-op).',
+    );
+    return;
+  }
+  entry.refCount -= 1;
+  if (entry.refCount <= 0) {
+    if (entry.refCount < 0) {
+      // Belt-and-suspenders: the previous refcount→0 should have
+      // deleted the entry, so this branch is reached only if
+      // someone mutated the entry externally. Warn but still
+      // dispose cleanly.
+      console.warn(
+        `bakedSymbolTexture: refCount went negative for ${key} ` +
+          '(suggests external mutation — disposing anyway).',
+      );
+    }
+    // Free GPU texture state.
+    entry.texture.dispose();
+    // Clear the backing canvas reference so the next gc pass
+    // collects it. `texture.dispose()` frees the GL upload but
+    // leaves `texture.image` pointing at the canvas; without this
+    // clear, a stale slider material still holding `mat.map`
+    // could pin the canvas in memory.
+    const image = entry.texture.image as HTMLCanvasElement | undefined;
+    if (image && 'width' in image) {
+      image.width = 0;
+      image.height = 0;
+    }
+    (entry.texture as { image: HTMLCanvasElement | null }).image = null;
+    // `cache.delete(key)` intentionally last — the in-between
+    // window (texture disposed but cache entry still present) is
+    // safe in single-threaded JS, but the delete-last ordering
+    // guards a future refactor from accidentally making a
+    // synchronous re-acquire path return a disposed texture.
+    cache.delete(key);
+  }
+}
+
+/**
+ * Test-only: read-only snapshot of cache size, keys, and per-key
+ * refcounts without exposing the internal `Map`.
+ */
+export function _cacheStateForTests(): {
+  size: number;
+  keys: readonly string[];
+  refCounts: Record<string, number>;
+} {
+  const refCounts: Record<string, number> = {};
+  for (const [k, v] of cache.entries()) refCounts[k] = v.refCount;
+  return {
+    size: cache.size,
+    keys: [...cache.keys()],
+    refCounts,
+  };
+}
+
+/**
+ * Test-only: wipe the cache. Disposes every live texture, clears
+ * every backing-store reference, and empties the map. Wired into
+ * the `afterEach` blocks of `Slider.test.ts` +
+ * `PointerMigration.test.ts` so the existing un-disposed
+ * `makeSlider` callsites in those files don't pollute cache state
+ * across tests.
+ *
+ * NOT exported as a production API. Calling this in a production
+ * code path would silently break any Slider still holding a
+ * `material.map` reference (the texture's GL state would be freed
+ * but the material still points at a now-disposed texture).
+ */
+export function _clearCacheForTests(): void {
+  for (const entry of cache.values()) {
+    entry.texture.dispose();
+    const image = entry.texture.image as HTMLCanvasElement | undefined;
+    if (image && 'width' in image) {
+      image.width = 0;
+      image.height = 0;
+    }
+    (entry.texture as { image: HTMLCanvasElement | null }).image = null;
+  }
+  cache.clear();
+}

--- a/test/scaffold/ui/PointerMigration.test.ts
+++ b/test/scaffold/ui/PointerMigration.test.ts
@@ -1,14 +1,20 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as THREE from 'three';
 
 // `troika-three-text` reaches for `self`, a browser-only global, in its
 // UMD `now$1` helper. The default vitest environment is Node, so any
-// `new Text()` blows up at construction time. TapButton creates a
-// `Text` for its label; we stub the dep with a minimal mesh-like
-// surrogate that exposes the same surface (`text`, `fontSize`, …,
-// `sync`, `dispose`, `position`, `rotation`, `getWorldPosition`). The
-// ray-hit math we're validating doesn't touch text rendering, so the
-// stub is faithful enough for this test file.
+// `new Text()` blows up at construction time. TapButton + Preset +
+// SectionTab + SceneTab + AxisToggle each construct a `Text` for their
+// label; we stub the dep with a minimal mesh-like surrogate that
+// exposes the same surface (`text`, `fontSize`, …, `sync`, `dispose`,
+// `position`, `rotation`, `getWorldPosition`). The ray-hit math we're
+// validating doesn't touch text rendering, so the stub is faithful
+// enough for this test file.
+//
+// Slider no longer imports Troika directly post-#278 (it bakes a
+// `(symbol, baseColor)` canvas texture instead), so this mock isn't
+// load-bearing for Slider construction — but the other primitives
+// in this file still rely on it.
 vi.mock('troika-three-text', () => {
   class StubText extends THREE.Object3D {
     text = '';
@@ -24,6 +30,10 @@ vi.mock('troika-three-text', () => {
   return { Text: StubText };
 });
 
+import {
+  _clearCacheForTests,
+  _setCanvasFactoryForTests,
+} from '@/scaffold/ui/bakedSymbolTexture';
 import { Slider } from '@/scaffold/ui/Slider';
 import { TapButton } from '@/scaffold/ui/TapButton';
 import { Preset } from '@/scaffold/ui/Preset';
@@ -31,6 +41,42 @@ import { SectionTab } from '@/scaffold/ui/SectionTab';
 import { SceneTab } from '@/scaffold/ui/SceneTab';
 import { AxisToggle } from '@/exhibits/quadrics/AxisToggle';
 import type { Pointer } from '@/shell/Pointer';
+
+// Slider's #278 emblazon-texture path calls `document.createElement('canvas')`
+// in `bakedSymbolTexture.renderTexture`. The Node Vitest environment
+// has no `document`; inject a stub canvas factory so the rendering
+// path runs end-to-end without crashing. Drain the cache between
+// tests so existing `makeSlider()` callsites (none of which dispose)
+// don't pollute state across tests.
+function makeStubCanvas(): HTMLCanvasElement {
+  const ctx = {
+    fillRect: () => {},
+    fillText: () => {},
+    strokeText: () => {},
+    measureText: () => ({ width: 0 }),
+    set fillStyle(_v: string) {},
+    set strokeStyle(_v: string) {},
+    set font(_v: string) {},
+    set textAlign(_v: string) {},
+    set textBaseline(_v: string) {},
+    set lineWidth(_v: number) {},
+    set lineJoin(_v: string) {},
+  };
+  return {
+    width: 0,
+    height: 0,
+    getContext: () => ctx,
+  } as unknown as HTMLCanvasElement;
+}
+
+beforeEach(() => {
+  _setCanvasFactoryForTests(makeStubCanvas);
+});
+
+afterEach(() => {
+  _clearCacheForTests();
+  _setCanvasFactoryForTests(null);
+});
 
 // Vitest coverage for the #191 bundled migration: every UI primitive that
 // moved from `controller: THREE.Object3D` → `pointer: Pointer` exercises

--- a/test/scaffold/ui/Slider.test.ts
+++ b/test/scaffold/ui/Slider.test.ts
@@ -332,93 +332,86 @@ describe('Slider thumb texture (#278)', () => {
     expect(_cacheStateForTests().size).toBe(0);
   });
 
-  // World-frame billboard correctness under a plinth-tilt parent.
-  // Same algorithm as #276 §3.3.1 but retargeted from
-  // `thumbLabelText.quaternion` to `thumb.quaternion`. The
-  // parent-inverse uses the slider GROUP's world quaternion (not
-  // the thumb's own) since `thumb.quaternion` is interpreted in
-  // slider-group-local frame.
-  it('faceCamera yaws thumb.quaternion correctly under plinth tilt', () => {
+  // Static-orientation invariant: the glyph faces slider-local
+  // +Y, which under the slot-frame rotation a cluster scene
+  // applies (`Plinth.computePlinthSlotTransform` with
+  // orientation='surface' = −tilt about world +X) becomes the
+  // drafting-board surface normal in world. The thumb's own
+  // rotation is constant — no per-frame billboard — so the glyph
+  // stays fixed on the sphere as the camera moves.
+  it('thumb is statically oriented with the glyph at slider-local +Y', () => {
     const slider = makeSlider({ thumbLabel: 'x' });
     const thumb = findThumbMesh(slider);
 
-    // Tilt parent: rotate the slider group 20° about world-X to
-    // mimic the plinth's surface tilt.
-    const scene = new THREE.Scene();
-    const tiltParent = new THREE.Object3D();
-    tiltParent.rotation.x = Math.PI / 9; // ≈ 20°
-    scene.add(tiltParent);
-    tiltParent.add(slider.group);
+    // The thumb's own rotation: about local +X by −π/2.
+    expect(thumb.rotation.x).toBeCloseTo(-Math.PI / 2, 8);
+    expect(thumb.rotation.y).toBeCloseTo(0, 8);
+    expect(thumb.rotation.z).toBeCloseTo(0, 8);
 
-    const camera = new THREE.PerspectiveCamera();
-
-    const thumbWorld = new THREE.Vector3();
-    const thumbWorldQuat = new THREE.Quaternion();
-    const thumbUp = new THREE.Vector3();
-    const thumbForward = new THREE.Vector3();
-
-    const assertThumbBillboard = (camPos: [number, number, number]): void => {
-      camera.position.set(...camPos);
-      scene.updateMatrixWorld(true);
-      slider.faceCamera(camera);
-      scene.updateMatrixWorld(true);
-
-      thumb.getWorldPosition(thumbWorld);
-      thumb.getWorldQuaternion(thumbWorldQuat);
-
-      // Thumb world-up = local +Y transformed by world quaternion.
-      // Yaw-only convention: thumb-up stays world-Y within float
-      // tolerance regardless of parent tilt.
-      thumbUp.set(0, 1, 0).applyQuaternion(thumbWorldQuat);
-      expect(thumbUp.x).toBeCloseTo(0, 5);
-      expect(thumbUp.y).toBeCloseTo(1, 5);
-      expect(thumbUp.z).toBeCloseTo(0, 5);
-
-      // Thumb world-forward = local +Z transformed by world
-      // quaternion. The texture's centered glyph sits at the
-      // sphere's +Z surface point (U=0.5, V=0.5 in equirectangular
-      // UVs); world-forward projected onto world-XZ should align
-      // with the camera-to-thumb XZ direction.
-      thumbForward.set(0, 0, 1).applyQuaternion(thumbWorldQuat);
-      thumbForward.y = 0;
-      thumbForward.normalize();
-      const camFacing = new THREE.Vector3(
-        camPos[0] - thumbWorld.x,
-        0,
-        camPos[2] - thumbWorld.z,
-      ).normalize();
-      expect(thumbForward.dot(camFacing)).toBeGreaterThan(0.999);
-    };
-
-    // Standing eye-level, tall, crouched, yaw-change.
-    assertThumbBillboard([0, 1.5, 1.0]);
-    assertThumbBillboard([0, 1.8, 1.0]);
-    assertThumbBillboard([0, 1.3, 1.0]);
-    assertThumbBillboard([1.0, 1.5, 1.0]);
+    // The geometry rotation (rotateY(−π/2)) moved the texture's
+    // UV (0.5, 0.5) point from sphere-local +X to sphere-local
+    // +Z. Applying the thumb's quaternion to sphere-local +Z
+    // should yield slider-local +Y.
+    const glyphDirSliderLocal = new THREE.Vector3(0, 0, 1).applyQuaternion(
+      thumb.quaternion,
+    );
+    expect(glyphDirSliderLocal.x).toBeCloseTo(0, 5);
+    expect(glyphDirSliderLocal.y).toBeCloseTo(1, 5);
+    expect(glyphDirSliderLocal.z).toBeCloseTo(0, 5);
   });
 
-  it('faceCamera is idempotent for camera-unchanged calls', () => {
+  it('glyph faces the drafting-board surface normal under plinth tilt', () => {
+    // Reproduce the cluster mounting: slider-group rotated by
+    // −tilt about world +X (matches
+    // Plinth.computePlinthSlotTransform with orientation='surface').
+    // The thumb's static orientation, composed with this parent
+    // rotation, should put the glyph direction at world
+    // (0, cos(tilt), −sin(tilt)) — the surface normal direction
+    // the Plinth comment documents.
+    const slider = makeSlider({ thumbLabel: 'θ' });
+    const thumb = findThumbMesh(slider);
+
+    const tilt = (20 * Math.PI) / 180; // PLINTH_TILT_DEFAULT
+    const scene = new THREE.Scene();
+    scene.add(slider.group);
+    slider.group.rotation.x = -tilt;
+    scene.updateMatrixWorld(true);
+
+    // Walk the glyph direction from mesh-local +Z to world.
+    const glyphDirWorld = new THREE.Vector3(0, 0, 1);
+    const thumbWorldQuat = new THREE.Quaternion();
+    thumb.getWorldQuaternion(thumbWorldQuat);
+    glyphDirWorld.applyQuaternion(thumbWorldQuat);
+
+    expect(glyphDirWorld.x).toBeCloseTo(0, 5);
+    expect(glyphDirWorld.y).toBeCloseTo(Math.cos(tilt), 5);
+    expect(glyphDirWorld.z).toBeCloseTo(-Math.sin(tilt), 5);
+  });
+
+  it('thumb orientation does NOT track camera movement', () => {
+    // Static-orientation contract: there is no faceCamera method;
+    // the thumb's quaternion never changes after construction (the
+    // only writes touching the thumb mesh during update() are
+    // syncThumbPosition's position.x writes).
     const slider = makeSlider({ thumbLabel: 'y' });
     const thumb = findThumbMesh(slider);
 
-    const scene = new THREE.Scene();
-    scene.add(slider.group);
-    const camera = new THREE.PerspectiveCamera();
-    camera.position.set(0, 1.5, 1.0);
-    scene.updateMatrixWorld(true);
+    const q0 = thumb.quaternion.clone();
 
-    slider.faceCamera(camera);
-    const q1 = thumb.quaternion.clone();
-    slider.faceCamera(camera);
-    const q2 = thumb.quaternion.clone();
+    // Drive the slider's update path; quaternion must stay put.
+    slider.setValue(1.0);
+    slider.setValue(-1.0);
+    slider.update();
 
-    // No accumulation — second call produces same quaternion as
-    // first. Catches the class of mistake where the algorithm
-    // composes onto the existing quaternion instead of overwriting.
-    expect(q2.x).toBeCloseTo(q1.x, 8);
-    expect(q2.y).toBeCloseTo(q1.y, 8);
-    expect(q2.z).toBeCloseTo(q1.z, 8);
-    expect(q2.w).toBeCloseTo(q1.w, 8);
+    expect(thumb.quaternion.x).toBeCloseTo(q0.x, 8);
+    expect(thumb.quaternion.y).toBeCloseTo(q0.y, 8);
+    expect(thumb.quaternion.z).toBeCloseTo(q0.z, 8);
+    expect(thumb.quaternion.w).toBeCloseTo(q0.w, 8);
+
+    // The Slider class no longer exposes a `faceCamera` method.
+    expect(
+      (slider as unknown as { faceCamera?: unknown }).faceCamera,
+    ).toBeUndefined();
   });
 
   it('empty-string label is a structurally valid opt-out', () => {

--- a/test/scaffold/ui/Slider.test.ts
+++ b/test/scaffold/ui/Slider.test.ts
@@ -1,33 +1,53 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as THREE from 'three';
 
-// `troika-three-text` reaches for `self`, a browser-only global, in
-// its UMD `now$1` helper. The default vitest environment is Node,
-// so any `new Text()` would blow up at construction time. Stub the
-// module with an Object3D-backed surrogate; matches the pattern in
-// `TapButton.test.ts` / `Preset.test.ts` / `PointerMigration.test.ts`.
-// None of this file's assertions touch text rendering — `Object3D`
-// gives the position/rotation/quaternion machinery the faceCamera
-// algorithm needs, plus a `text` string property the label-text
-// assertions read.
-vi.mock('troika-three-text', () => {
-  class StubText extends THREE.Object3D {
-    text = '';
-    fontSize = 0;
-    color = 0xffffff;
-    anchorX: string | undefined;
-    anchorY: string | undefined;
-    outlineWidth: string | undefined;
-    outlineColor: number | undefined;
-    sync() {}
-    dispose() {}
-  }
-  return { Text: StubText };
+import {
+  _cacheStateForTests,
+  _clearCacheForTests,
+  _setCanvasFactoryForTests,
+  acquireBakedSymbolTexture,
+  releaseBakedSymbolTexture,
+} from '@/scaffold/ui/bakedSymbolTexture';
+import { Slider } from '@/scaffold/ui/Slider';
+
+// Slider's #278 emblazon-texture path calls
+// `document.createElement('canvas')` in
+// `bakedSymbolTexture.renderTexture`. The Node Vitest environment
+// has no `document`; inject a stub canvas factory so the
+// rendering path runs end-to-end. Drain the cache between tests
+// so the legacy `makeSlider()` callsites in this file (which
+// don't call `slider.dispose()`) don't pollute cache state
+// across tests — the new #278 tests assert specific size/refCount
+// values from a clean state and would fail without the drain.
+function makeStubCanvas(): HTMLCanvasElement {
+  const ctx = {
+    fillRect: () => {},
+    fillText: () => {},
+    strokeText: () => {},
+    measureText: () => ({ width: 0 }),
+    set fillStyle(_v: string) {},
+    set strokeStyle(_v: string) {},
+    set font(_v: string) {},
+    set textAlign(_v: string) {},
+    set textBaseline(_v: string) {},
+    set lineWidth(_v: number) {},
+    set lineJoin(_v: string) {},
+  };
+  return {
+    width: 0,
+    height: 0,
+    getContext: () => ctx,
+  } as unknown as HTMLCanvasElement;
+}
+
+beforeEach(() => {
+  _setCanvasFactoryForTests(makeStubCanvas);
 });
 
-import { Text } from 'troika-three-text';
-import { Slider } from '@/scaffold/ui/Slider';
-import type { Pointer } from '@/shell/Pointer';
+afterEach(() => {
+  _clearCacheForTests();
+  _setCanvasFactoryForTests(null);
+});
 
 // Vitest coverage for `Slider.setRange` (#178), the constructor's
 // snap-point validation pass (#200), and `Slider.setSnapPoints` (#200).
@@ -224,8 +244,11 @@ describe('Slider.setSnapPoints (#200)', () => {
   });
 });
 
-// Thumb-label test scaffolding (#276 plan §4.2). Tests locate scene-
-// graph nodes by `userData.role` traversal, not by positional indexing.
+// Thumb texture test scaffolding (#278). Tests locate the thumb
+// mesh by `userData.role` traversal; the per-slider symbol is
+// exposed on `thumb.userData.thumbLabel` for inline assertion
+// (replacing the #276-era `slider-thumb-label` role marker that
+// pointed at the deleted Text child).
 
 function findThumbMesh(slider: Slider): THREE.Mesh {
   let found: THREE.Mesh | null = null;
@@ -238,44 +261,8 @@ function findThumbMesh(slider: Slider): THREE.Mesh {
   return found;
 }
 
-function findThumbLabel(slider: Slider): Text {
-  let found: Text | null = null;
-  slider.group.traverse((obj) => {
-    if (obj.userData?.role === 'slider-thumb-label') {
-      found = obj as Text;
-    }
-  });
-  if (!found) throw new Error('slider-thumb-label role not found');
-  return found;
-}
-
-// Stub Pointer aimed at a given world position along world −Z; thumb
-// at world origin → ray hits the thumb's grab sphere.
-interface StubPointer extends Pointer {
-  origin: THREE.Vector3;
-  direction: THREE.Vector3;
-}
-function stubPointer(
-  origin: [number, number, number],
-  direction: [number, number, number],
-): StubPointer {
-  return {
-    id: 'test',
-    origin: new THREE.Vector3(...origin),
-    direction: new THREE.Vector3(...direction).normalize(),
-    pulse: vi.fn(),
-    getRayOrigin(target) {
-      return target.copy(this.origin);
-    },
-    getRayDirection(target) {
-      return target.copy(this.direction);
-    },
-  };
-}
-const HIT_RAY = (): StubPointer => stubPointer([0, 0, 1], [0, 0, -1]);
-
-describe('Slider thumb label (#276)', () => {
-  it('thumb is a single opaque sphere with a Text label child', () => {
+describe('Slider thumb texture (#278)', () => {
+  it('thumb is a single opaque sphere with a baked emblazon texture', () => {
     const slider = makeSlider({ thumbLabel: 'x²', baseColor: 0xff0000 });
     const thumb = findThumbMesh(slider);
     expect(thumb).toBeInstanceOf(THREE.Mesh);
@@ -283,83 +270,77 @@ describe('Slider thumb label (#276)', () => {
     expect((thumb.geometry as THREE.SphereGeometry).parameters.radius).toBe(
       0.025,
     );
+    expect(thumb.userData.thumbLabel).toBe('x²');
+
     const mat = thumb.material as THREE.MeshStandardMaterial;
     expect(mat.transparent).toBe(false);
-    expect(mat.color.getHex()).toBe(0xff0000);
-    // Exactly one child of the thumb mesh — the Text label.
-    expect(thumb.children).toHaveLength(1);
-    expect(thumb.children[0].userData?.role).toBe('slider-thumb-label');
+    // Color is neutral white — the baked texture supplies the
+    // diffuse body color, not mat.color.
+    expect(mat.color.getHex()).toBe(0xffffff);
+    expect(mat.map).not.toBeNull();
+    // The thumb mesh has no children (the #276 Text child is gone).
+    expect(thumb.children).toHaveLength(0);
+
+    // Reference-equality: a fresh acquire of the same key returns
+    // the cached texture instance. Refcount ladders: slider's
+    // acquire = 1, this duplicate acquire = 2; release one and
+    // expect the slider's reference still alive.
+    const duplicate = acquireBakedSymbolTexture('x²', 0xff0000);
+    expect(mat.map).toBe(duplicate);
+    releaseBakedSymbolTexture('x²', 0xff0000);
+    expect(_cacheStateForTests().refCounts['x²|0xff0000']).toBe(1);
   });
 
-  it('label text matches thumbLabel; persists through hover', () => {
-    // `initial: 0` parks the thumb at slider-local origin so HIT_RAY
-    // (aimed at world (0,0,0) along −Z) reliably hits the grab sphere.
-    const slider = makeSlider({ thumbLabel: 'θ', initial: 0 });
+  it('dispose() releases the texture; refcount ladders through cleanup', () => {
+    // Pre-acquire to inflate refcount, so slider.dispose() doesn't
+    // collapse refcount to zero — verifies the per-slider release
+    // doesn't dispose the shared texture while another consumer
+    // still holds it.
+    acquireBakedSymbolTexture('θ', 0xaaaaaa); // refCount = 1
+    const slider = makeSlider({ thumbLabel: 'θ', baseColor: 0xaaaaaa });
+    expect(_cacheStateForTests().refCounts['θ|0xaaaaaa']).toBe(2);
+
     const thumb = findThumbMesh(slider);
-    const label = findThumbLabel(slider);
-    expect(label.text).toBe('θ');
-
-    slider.updateHover([HIT_RAY()]);
-    expect(slider.isHovered).toBe(true);
-    expect(label.text).toBe('θ');
-    expect(label.parent).toBe(thumb);
-
-    slider.updateHover([]);
-    expect(slider.isHovered).toBe(false);
-    expect(label.text).toBe('θ');
-    expect(label.parent).toBe(thumb);
-  });
-
-  it('label persists through tryGrab / releaseFromPointer', () => {
-    const slider = makeSlider({ thumbLabel: 'C', initial: 0 });
-    const thumb = findThumbMesh(slider);
-    const label = findThumbLabel(slider);
-    const pointer = HIT_RAY();
-
-    expect(slider.tryGrab(pointer)).toBe(true);
-    expect(label.text).toBe('C');
-    expect(label.parent).toBe(thumb);
-
-    slider.releaseFromPointer(pointer);
-    expect(label.text).toBe('C');
-    expect(label.parent).toBe(thumb);
-  });
-
-  it('dispose() cleans up label, track, and thumb resources', () => {
-    const slider = makeSlider({ thumbLabel: 'x' });
-    const thumb = findThumbMesh(slider);
-    const label = findThumbLabel(slider);
-    // The track is the first child of the slider group (constructed
-    // before the thumb in Slider's ctor).
-    const track = slider.group.children.find(
-      (c) => c instanceof THREE.Mesh && c !== thumb,
-    ) as THREE.Mesh;
-    expect(track).toBeDefined();
-
-    const labelSpy = vi.spyOn(label, 'dispose');
-    const thumbGeomSpy = vi.spyOn(thumb.geometry, 'dispose');
-    const thumbMatSpy = vi.spyOn(thumb.material as THREE.Material, 'dispose');
-    const trackGeomSpy = vi.spyOn(track.geometry, 'dispose');
-    const trackMatSpy = vi.spyOn(track.material as THREE.Material, 'dispose');
+    const texture = (thumb.material as THREE.MeshStandardMaterial).map!;
+    const textureSpy = vi.spyOn(texture, 'dispose');
 
     slider.dispose();
+    expect(_cacheStateForTests().refCounts['θ|0xaaaaaa']).toBe(1);
+    expect(textureSpy).not.toHaveBeenCalled();
 
-    expect(labelSpy).toHaveBeenCalledTimes(1);
-    expect(thumbGeomSpy).toHaveBeenCalledTimes(1);
-    expect(thumbMatSpy).toHaveBeenCalledTimes(1);
-    expect(trackGeomSpy).toHaveBeenCalledTimes(1);
-    expect(trackMatSpy).toHaveBeenCalledTimes(1);
+    releaseBakedSymbolTexture('θ', 0xaaaaaa);
+    expect(_cacheStateForTests().size).toBe(0);
+    expect(textureSpy).toHaveBeenCalledTimes(1);
   });
 
-  // Test 5: world-frame billboard correctness under a plinth-tilt
-  // parent. Replaces the v1-plan local-Euler assertion; world-frame
-  // assertions are the only way to detect the v1 algorithmic bug
-  // where local-Y rotation under a tilted parent diverges from
-  // world-Y yaw (#276 roundtable convergent HIGH).
-  it('faceCamera writes correct world-space billboard under plinth tilt', () => {
+  it('Slider.dispose() is idempotent — double-dispose is a no-op', () => {
+    // Pre-acquire so the slider's release doesn't go to zero on
+    // the first dispose; we want to assert the SECOND dispose
+    // doesn't decrement again.
+    acquireBakedSymbolTexture('C', 0xeeaa33); // refCount = 1
+    const slider = makeSlider({ thumbLabel: 'C', baseColor: 0xeeaa33 });
+    expect(_cacheStateForTests().refCounts['C|0xeeaa33']).toBe(2);
+
+    slider.dispose();
+    expect(_cacheStateForTests().refCounts['C|0xeeaa33']).toBe(1);
+
+    // Second dispose — the _disposed guard short-circuits.
+    slider.dispose();
+    expect(_cacheStateForTests().refCounts['C|0xeeaa33']).toBe(1);
+
+    releaseBakedSymbolTexture('C', 0xeeaa33);
+    expect(_cacheStateForTests().size).toBe(0);
+  });
+
+  // World-frame billboard correctness under a plinth-tilt parent.
+  // Same algorithm as #276 §3.3.1 but retargeted from
+  // `thumbLabelText.quaternion` to `thumb.quaternion`. The
+  // parent-inverse uses the slider GROUP's world quaternion (not
+  // the thumb's own) since `thumb.quaternion` is interpreted in
+  // slider-group-local frame.
+  it('faceCamera yaws thumb.quaternion correctly under plinth tilt', () => {
     const slider = makeSlider({ thumbLabel: 'x' });
     const thumb = findThumbMesh(slider);
-    const label = findThumbLabel(slider);
 
     // Tilt parent: rotate the slider group 20° about world-X to
     // mimic the plinth's surface tilt.
@@ -371,92 +352,81 @@ describe('Slider thumb label (#276)', () => {
 
     const camera = new THREE.PerspectiveCamera();
 
-    const labelWorld = new THREE.Vector3();
     const thumbWorld = new THREE.Vector3();
-    const labelWorldQuat = new THREE.Quaternion();
-    const labelUp = new THREE.Vector3();
-    const labelForward = new THREE.Vector3();
+    const thumbWorldQuat = new THREE.Quaternion();
+    const thumbUp = new THREE.Vector3();
+    const thumbForward = new THREE.Vector3();
 
-    const assertWorldFrameBillboard = (
-      camPos: [number, number, number],
-      label0: Text,
-    ): void => {
+    const assertThumbBillboard = (camPos: [number, number, number]): void => {
       camera.position.set(...camPos);
       scene.updateMatrixWorld(true);
       slider.faceCamera(camera);
-      // updateMatrixWorld AFTER faceCamera so the label's transform
-      // writes (rotation + position in thumb-local frame) propagate
-      // to label.matrixWorld for the getWorldPosition / world-axis
-      // reads below.
       scene.updateMatrixWorld(true);
 
-      // Use getWorldPosition for both thumb and label — NOT local
-      // `.position`. The plinth tilt makes the label's local frame
-      // distinct from world frame, and the world-frame equator check
-      // is what proves the algorithm correctly compensates the
-      // parent rotation.
-      label0.getWorldPosition(labelWorld);
       thumb.getWorldPosition(thumbWorld);
-      label0.getWorldQuaternion(labelWorldQuat);
+      thumb.getWorldQuaternion(thumbWorldQuat);
 
-      // Label world-up = local +Y transformed by world quaternion.
-      labelUp.set(0, 1, 0).applyQuaternion(labelWorldQuat);
-      // Yaw-only convention: label-up stays world-Y within float
+      // Thumb world-up = local +Y transformed by world quaternion.
+      // Yaw-only convention: thumb-up stays world-Y within float
       // tolerance regardless of parent tilt.
-      expect(labelUp.x).toBeCloseTo(0, 5);
-      expect(labelUp.y).toBeCloseTo(1, 5);
-      expect(labelUp.z).toBeCloseTo(0, 5);
+      thumbUp.set(0, 1, 0).applyQuaternion(thumbWorldQuat);
+      expect(thumbUp.x).toBeCloseTo(0, 5);
+      expect(thumbUp.y).toBeCloseTo(1, 5);
+      expect(thumbUp.z).toBeCloseTo(0, 5);
 
-      // Label world-forward = local +Z transformed by world
-      // quaternion. Projected onto world-XZ, it should align with
-      // the camera-to-thumb XZ direction.
-      labelForward.set(0, 0, 1).applyQuaternion(labelWorldQuat);
-      labelForward.y = 0;
-      labelForward.normalize();
+      // Thumb world-forward = local +Z transformed by world
+      // quaternion. The texture's centered glyph sits at the
+      // sphere's +Z surface point (U=0.5, V=0.5 in equirectangular
+      // UVs); world-forward projected onto world-XZ should align
+      // with the camera-to-thumb XZ direction.
+      thumbForward.set(0, 0, 1).applyQuaternion(thumbWorldQuat);
+      thumbForward.y = 0;
+      thumbForward.normalize();
       const camFacing = new THREE.Vector3(
         camPos[0] - thumbWorld.x,
         0,
         camPos[2] - thumbWorld.z,
       ).normalize();
-      expect(labelForward.dot(camFacing)).toBeGreaterThan(0.999);
-
-      // Label rides the sphere equator: world Y-offset from thumb
-      // is near zero. This is the GPT-roundtable position-vs-
-      // orientation conflict gate.
-      expect(labelWorld.y - thumbWorld.y).toBeCloseTo(0, 5);
-
-      // Magnitude of world offset = thumbRadius + standoff.
-      const offsetWorld = new THREE.Vector3().subVectors(labelWorld, thumbWorld);
-      expect(offsetWorld.length()).toBeCloseTo(0.025 + 0.0015, 4);
+      expect(thumbForward.dot(camFacing)).toBeGreaterThan(0.999);
     };
 
-    // Standing eye-level pose.
-    assertWorldFrameBillboard([0, 1.5, 1.0], label);
-    // Tall pose — vertical camera move; label still rides the equator.
-    assertWorldFrameBillboard([0, 1.8, 1.0], label);
-    // Crouched pose.
-    assertWorldFrameBillboard([0, 1.3, 1.0], label);
-    // Yaw-change pose — camera rotated in XZ around the thumb.
-    assertWorldFrameBillboard([1.0, 1.5, 1.0], label);
+    // Standing eye-level, tall, crouched, yaw-change.
+    assertThumbBillboard([0, 1.5, 1.0]);
+    assertThumbBillboard([0, 1.8, 1.0]);
+    assertThumbBillboard([0, 1.3, 1.0]);
+    assertThumbBillboard([1.0, 1.5, 1.0]);
+  });
+
+  it('faceCamera is idempotent for camera-unchanged calls', () => {
+    const slider = makeSlider({ thumbLabel: 'y' });
+    const thumb = findThumbMesh(slider);
+
+    const scene = new THREE.Scene();
+    scene.add(slider.group);
+    const camera = new THREE.PerspectiveCamera();
+    camera.position.set(0, 1.5, 1.0);
+    scene.updateMatrixWorld(true);
+
+    slider.faceCamera(camera);
+    const q1 = thumb.quaternion.clone();
+    slider.faceCamera(camera);
+    const q2 = thumb.quaternion.clone();
+
+    // No accumulation — second call produces same quaternion as
+    // first. Catches the class of mistake where the algorithm
+    // composes onto the existing quaternion instead of overwriting.
+    expect(q2.x).toBeCloseTo(q1.x, 8);
+    expect(q2.y).toBeCloseTo(q1.y, 8);
+    expect(q2.z).toBeCloseTo(q1.z, 8);
+    expect(q2.w).toBeCloseTo(q1.w, 8);
   });
 
   it('empty-string label is a structurally valid opt-out', () => {
     const slider = makeSlider({ thumbLabel: '' });
-    const label = findThumbLabel(slider);
-    expect(label.text).toBe('');
-  });
-
-  it('ctor places label outside sphere envelope before faceCamera', () => {
-    const slider = makeSlider({ thumbLabel: 'x²' });
-    const label = findThumbLabel(slider);
-    // Neutral local +Z placement set in ctor; faceCamera will refine
-    // it once the scene is mounted + a camera available, but the
-    // constructor-time default sits OUTSIDE the sphere envelope so
-    // the first render lands cleanly even without a faceCamera
-    // dispatch.
-    expect(label.position.x).toBe(0);
-    expect(label.position.y).toBe(0);
-    expect(label.position.z).toBeCloseTo(0.025 + 0.0015, 6);
-    expect(label.position.length()).toBeGreaterThan(0.025);
+    const thumb = findThumbMesh(slider);
+    expect(thumb.userData.thumbLabel).toBe('');
+    expect((thumb.material as THREE.MeshStandardMaterial).map).not.toBeNull();
+    // Cache acquired the empty-string key.
+    expect(_cacheStateForTests().refCounts['|0xeeaa33']).toBe(1);
   });
 });

--- a/test/scaffold/ui/Slider.test.ts
+++ b/test/scaffold/ui/Slider.test.ts
@@ -333,41 +333,43 @@ describe('Slider thumb texture (#278)', () => {
   });
 
   // Static-orientation invariant: the glyph faces slider-local
-  // +Y, which under the slot-frame rotation a cluster scene
+  // +Z, which under the slot-frame rotation a cluster scene
   // applies (`Plinth.computePlinthSlotTransform` with
   // orientation='surface' = −tilt about world +X) becomes the
-  // drafting-board surface normal in world. The thumb's own
-  // rotation is constant — no per-frame billboard — so the glyph
-  // stays fixed on the sphere as the camera moves.
-  it('thumb is statically oriented with the glyph at slider-local +Y', () => {
+  // drafting-board's outward surface normal in world. The slab
+  // is modelled thin in slot-local Z (front face at z=0) so
+  // slot-local +Z is perpendicular to the slab's flat face. The
+  // thumb's own rotation is identity — no per-frame billboard —
+  // so the glyph stays fixed on the sphere as the camera moves.
+  it('thumb is statically oriented with the glyph at slider-local +Z', () => {
     const slider = makeSlider({ thumbLabel: 'x' });
     const thumb = findThumbMesh(slider);
 
-    // The thumb's own rotation: about local +X by −π/2.
-    expect(thumb.rotation.x).toBeCloseTo(-Math.PI / 2, 8);
+    // No additional thumb rotation; the geometry's rotateY(−π/2)
+    // pre-orients the texture so mesh-local +Z carries the glyph.
+    expect(thumb.rotation.x).toBeCloseTo(0, 8);
     expect(thumb.rotation.y).toBeCloseTo(0, 8);
     expect(thumb.rotation.z).toBeCloseTo(0, 8);
 
-    // The geometry rotation (rotateY(−π/2)) moved the texture's
-    // UV (0.5, 0.5) point from sphere-local +X to sphere-local
-    // +Z. Applying the thumb's quaternion to sphere-local +Z
-    // should yield slider-local +Y.
+    // Applying the thumb's quaternion (identity) to mesh-local
+    // +Z yields slider-local +Z.
     const glyphDirSliderLocal = new THREE.Vector3(0, 0, 1).applyQuaternion(
       thumb.quaternion,
     );
     expect(glyphDirSliderLocal.x).toBeCloseTo(0, 5);
-    expect(glyphDirSliderLocal.y).toBeCloseTo(1, 5);
-    expect(glyphDirSliderLocal.z).toBeCloseTo(0, 5);
+    expect(glyphDirSliderLocal.y).toBeCloseTo(0, 5);
+    expect(glyphDirSliderLocal.z).toBeCloseTo(1, 5);
   });
 
   it('glyph faces the drafting-board surface normal under plinth tilt', () => {
     // Reproduce the cluster mounting: slider-group rotated by
     // −tilt about world +X (matches
     // Plinth.computePlinthSlotTransform with orientation='surface').
-    // The thumb's static orientation, composed with this parent
-    // rotation, should put the glyph direction at world
-    // (0, cos(tilt), −sin(tilt)) — the surface normal direction
-    // the Plinth comment documents.
+    // The slab is thin in slot-local Z with the outward face at
+    // z=0, so slot-local +Z is the surface normal. After the slot
+    // rotation, slider-local +Z maps to world (0, sin(tilt),
+    // cos(tilt)) — "up and toward the user" — the direction a
+    // user leaning over the drafting board would read along.
     const slider = makeSlider({ thumbLabel: 'θ' });
     const thumb = findThumbMesh(slider);
 
@@ -384,8 +386,8 @@ describe('Slider thumb texture (#278)', () => {
     glyphDirWorld.applyQuaternion(thumbWorldQuat);
 
     expect(glyphDirWorld.x).toBeCloseTo(0, 5);
-    expect(glyphDirWorld.y).toBeCloseTo(Math.cos(tilt), 5);
-    expect(glyphDirWorld.z).toBeCloseTo(-Math.sin(tilt), 5);
+    expect(glyphDirWorld.y).toBeCloseTo(Math.sin(tilt), 5);
+    expect(glyphDirWorld.z).toBeCloseTo(Math.cos(tilt), 5);
   });
 
   it('thumb orientation does NOT track camera movement', () => {

--- a/test/scaffold/ui/bakedSymbolTexture.test.ts
+++ b/test/scaffold/ui/bakedSymbolTexture.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
+
+import {
+  _cacheStateForTests,
+  _clearCacheForTests,
+  _setCanvasFactoryForTests,
+  acquireBakedSymbolTexture,
+  releaseBakedSymbolTexture,
+} from '@/scaffold/ui/bakedSymbolTexture';
+
+// Vitest unit coverage for `bakedSymbolTexture` (#278). Cache
+// mechanics + refcount lifecycle + soft release semantics. Pixel-
+// level rendering correctness is a Cloudflare-PR-preview smoke
+// concern; this file covers what jsdom-less Vitest can prove.
+//
+// The module's production path calls `document.createElement('canvas')`.
+// Node's Vitest environment has no `document`; inject a stub canvas
+// factory that returns a plain object with a stubbed 2D context.
+
+function makeStubCanvas(): HTMLCanvasElement {
+  const ctx = {
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    strokeText: vi.fn(),
+    measureText: vi.fn(() => ({ width: 0 })),
+    set fillStyle(_v: string) {},
+    set strokeStyle(_v: string) {},
+    set font(_v: string) {},
+    set textAlign(_v: string) {},
+    set textBaseline(_v: string) {},
+    set lineWidth(_v: number) {},
+    set lineJoin(_v: string) {},
+  };
+  return {
+    width: 0,
+    height: 0,
+    getContext: vi.fn(() => ctx),
+  } as unknown as HTMLCanvasElement;
+}
+
+beforeEach(() => {
+  _setCanvasFactoryForTests(makeStubCanvas);
+});
+
+afterEach(() => {
+  // Assert cleanup BEFORE draining, so a leaking test surfaces as
+  // a Vitest failure. Then drain via `_clearCacheForTests` so the
+  // next test starts from a clean state — without this, one
+  // leaking test's pollution cascades into all subsequent test
+  // failures, which obscures the root cause.
+  const state = _cacheStateForTests();
+  _clearCacheForTests();
+  _setCanvasFactoryForTests(null);
+  expect(state.size).toBe(0);
+});
+
+describe('bakedSymbolTexture cache', () => {
+  it('acquire creates a new entry; matching release disposes it', () => {
+    acquireBakedSymbolTexture('θ', 0xaaaaaa);
+    expect(_cacheStateForTests().size).toBe(1);
+    expect(_cacheStateForTests().refCounts['θ|0xaaaaaa']).toBe(1);
+    expect(_cacheStateForTests().keys).toEqual(['θ|0xaaaaaa']);
+
+    releaseBakedSymbolTexture('θ', 0xaaaaaa);
+    expect(_cacheStateForTests().size).toBe(0);
+  });
+
+  it('repeated acquire reuses the same texture instance; refcount ladders', () => {
+    const t1 = acquireBakedSymbolTexture('θ', 0xaaaaaa);
+    const t2 = acquireBakedSymbolTexture('θ', 0xaaaaaa);
+    const t3 = acquireBakedSymbolTexture('θ', 0xaaaaaa);
+
+    expect(t1).toBe(t2);
+    expect(t2).toBe(t3);
+    expect(_cacheStateForTests().refCounts['θ|0xaaaaaa']).toBe(3);
+    expect(_cacheStateForTests().size).toBe(1);
+
+    releaseBakedSymbolTexture('θ', 0xaaaaaa);
+    expect(_cacheStateForTests().size).toBe(1);
+    releaseBakedSymbolTexture('θ', 0xaaaaaa);
+    expect(_cacheStateForTests().size).toBe(1);
+    releaseBakedSymbolTexture('θ', 0xaaaaaa);
+    expect(_cacheStateForTests().size).toBe(0);
+  });
+
+  it('different (symbol, color) pairs key separately', () => {
+    const a = acquireBakedSymbolTexture('θ', 0xaaaaaa);
+    const b = acquireBakedSymbolTexture('φ', 0xaaaaaa);
+    const c = acquireBakedSymbolTexture('θ', 0xff0000);
+
+    expect(_cacheStateForTests().size).toBe(3);
+    expect(a).not.toBe(b);
+    expect(a).not.toBe(c);
+    expect(b).not.toBe(c);
+
+    releaseBakedSymbolTexture('θ', 0xaaaaaa);
+    releaseBakedSymbolTexture('φ', 0xaaaaaa);
+    releaseBakedSymbolTexture('θ', 0xff0000);
+    expect(_cacheStateForTests().size).toBe(0);
+  });
+
+  it('cache keys are zero-padded to 6 hex digits for canonical formatting', () => {
+    acquireBakedSymbolTexture('θ', 0xaa); // color < 0x010000
+    expect(_cacheStateForTests().keys).toEqual(['θ|0x0000aa']);
+    releaseBakedSymbolTexture('θ', 0xaa);
+  });
+
+  it('soft release: missing-key release warns + no-ops (does not throw)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Release without a prior acquire.
+    expect(() => releaseBakedSymbolTexture('θ', 0xaaaaaa)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/θ\|0xaaaaaa/);
+    expect(_cacheStateForTests().size).toBe(0);
+
+    // Acquire once, release twice. Second release is the over-
+    // release case; should also warn + no-op rather than throw.
+    acquireBakedSymbolTexture('θ', 0xaaaaaa);
+    releaseBakedSymbolTexture('θ', 0xaaaaaa); // brings refcount to 0, entry deleted
+    warnSpy.mockClear();
+    expect(() => releaseBakedSymbolTexture('θ', 0xaaaaaa)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+
+  it('texture.dispose is called once at refcount→0; backing canvas is cleared', () => {
+    const texture = acquireBakedSymbolTexture('k', 0xaaaaaa);
+    const disposeSpy = vi.spyOn(texture, 'dispose');
+
+    // Second acquire — refcount goes to 2.
+    acquireBakedSymbolTexture('k', 0xaaaaaa);
+    releaseBakedSymbolTexture('k', 0xaaaaaa); // refcount → 1
+    expect(disposeSpy).not.toHaveBeenCalled();
+
+    releaseBakedSymbolTexture('k', 0xaaaaaa); // refcount → 0
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
+    expect(texture.image).toBeNull();
+  });
+
+  it('texture defaults: sRGB color space + mipmapped minification', () => {
+    const texture = acquireBakedSymbolTexture('θ', 0xaaaaaa);
+    expect(texture.colorSpace).toBe(THREE.SRGBColorSpace);
+    expect(texture.generateMipmaps).toBe(true);
+    expect(texture.minFilter).toBe(THREE.LinearMipmapLinearFilter);
+    expect(texture.magFilter).toBe(THREE.LinearFilter);
+    releaseBakedSymbolTexture('θ', 0xaaaaaa);
+  });
+});


### PR DESCRIPTION
Closes #278

## Summary

Replaces the #276 / #277 planar Troika-`Text`-child billboard with a baked `(symbol, color)` canvas texture wired into the thumb sphere's `material.map`. The sphere itself yaw-billboards via `thumb.quaternion`, so the glyph rides the surface instead of reading as a decal floating in front. New scaffold module `bakedSymbolTexture.ts` exposes a refcounted `(symbol, color)` cache — 13 unique pairs across the 17 cluster sliders. Soft release semantics + idempotent `Slider.dispose()` prevent uncaught throws on lifecycle paths.

## Plan + review trail

Plan: `_private/plans/278-emblazoned-thumb-texture.md` (v3, post second-Sonnet sanity).

- v1 `/roundtable-plan-review` ran across Sonnet (oppositional-reviewer with filesystem access) + GPT-5.5 + DeepSeek V4 Pro. Verdicts: Sonnet REVISE, GPT REVISE, DeepSeek PROCEED.
- Three convergent findings closed in v2: canvas-factory injection (was: broken prototype mutation under Node Vitest); soft release semantics + idempotent dispose (was: throws on legitimate lifecycle paths); explicit refcount-ladder test arithmetic.
- Accepted singletons folded in v2: `system-ui` canvas font (was: hard-coded Apple-first stack with no Quest fallback story); mipmapped minification (was: shimmer hazard in VR); `flipY` doc + smoke item; empirical glyph y-offset; backing-store clear at refcount→0; one stale `Text` import deletion Sonnet caught.
- Second-Sonnet sanity HOLD on v2 → v3 fix: existing un-disposed `makeSlider()` callsites under the v2 factory injection would have polluted cache state across tests. v3 adds `_clearCacheForTests()` helper wired into `afterEach` blocks in both `Slider.test.ts` and `PointerMigration.test.ts`.

## Test plan

- [x] Vitest green locally: `npm test` — 573 passing across 42 files (+6 net new behavioral cases: 7 in `bakedSymbolTexture.test.ts`, 6 new in `Slider.test.ts`, −7 deleted #276 label cases).
- [x] `npm run build` clean (tsc --noEmit + vite build).
- [ ] **Cloudflare PR preview smoke (Quest 3S + pancake)** — the primary verification surface, per project headset-smoke convention:
  - [ ] Quadrics squared (slider `a` → label `x²`, slider `b` → `y²`, slider `c` → `z²`) — glyphs read as **baked into the sphere surface**, not as a decal floating in front.
  - [ ] Quadrics linear (`u`/`v`/`w` → `x`/`y`/`z`) + cross-sections (`x₀`/`y₀`/`z₀`) — subscript `₀` glyph renders cleanly via `system-ui`.
  - [ ] d-slider `C` (YELLOW) appears identically in both Squared and Linear racks; cache hit, not duplicate render.
  - [ ] Tangent-planes (`θ`/`φ` neutral gray), gradient-levels (`θ`/`φ`/`k` neutral gray), saddle-extrema (`x`/`y` VERMILLION/BLUISH_GREEN).
  - [ ] **Glyphs render upright, not flipped or mirrored** (especially `x²` and `x₀` where orientation regressions would be most visible).
  - [ ] **Glyph visual centering on target** — `x²`/`x₀` not visibly shifted up/down on the sphere face. Tune `GLYPH_VERTICAL_OFFSET_PX` per its bracket if off.
  - [ ] Hover/grab affordance still reads (sphere brightens via emissive flip; glyph subtly tints — acceptable per plan §3.4).
  - [ ] No glyph roll on VR head-tilt (yaw-only convention preserved from #276).
  - [ ] `renderer.info.memory.textures` returns to pre-cluster-nav value after a full cluster cycle (refcount cleanup).
  - [ ] FPS overlay 72 Hz hold preserved.

## Escapes (recorded in plan §6 if any fire post-smoke)

- (a) tune `GLYPH_FONT_SIZE_PX` if glyph wraps too tightly on the sphere
- (b) switch to SDF render-target bake if `system-ui` font coverage misses
- (c) per-body-deeper-tint glyph color if white-on-yellow d-slider washes out
- (d) non-emissive rim-ring affordance if glyph hover-tint reads as distracting
- (e) revert to #277 planar billboard if the texture-bake fails the "emblazoned, not decal" gate on both form factors

🤖 Generated with [Claude Code](https://claude.com/claude-code)