### PR TITLE
feat(staging): surface-lock per-slider value labels on the plinth (#280)

### DIFF
--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -475,9 +475,12 @@ const gradientLevelsExhibit: Exhibit = {
       { id: 'slider-theta', target: thetaSlider.group, localXYZ: [0, PLINTH_THETA_Y, 0] },
       { id: 'slider-phi', target: phiSlider.group, localXYZ: [0, PLINTH_PHI_Y, 0] },
       { id: 'slider-k', target: kSlider.group, localXYZ: [0, PLINTH_K_Y, 0] },
-      { id: 'label-theta', target: thetaLabel.group, localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_THETA_Y, 0] },
-      { id: 'label-phi', target: phiLabel.group, localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_PHI_Y, 0] },
-      { id: 'label-k', target: kLabel.group, localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_K_Y, 0] },
+      // Per-slider value labels: 1 mm slot-Z standoff resolves coplanar
+      // z-fighting against the slab top face. Mirrors `SectionTab`'s
+      // `SURFACE_LABEL_STANDOFF_M` (`TapButton.ts:104–118`).
+      { id: 'label-theta', target: thetaLabel.group, localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_THETA_Y, 0.001] },
+      { id: 'label-phi', target: phiLabel.group, localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_PHI_Y, 0.001] },
+      { id: 'label-k', target: kLabel.group, localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_K_Y, 0.001] },
       { id: 'readout', target: gradientLevelsReadout.group, localXYZ: [0, PLINTH_READOUT_Y, 0] },
       {
         id: 'world-axes',
@@ -526,22 +529,21 @@ const gradientLevelsExhibit: Exhibit = {
     //     "π/4" glyph. `formatLinearDecimal` is the local helper above;
     //     extract-on-third-use deferred (only call site).
     //     `k` is preserved here for the raycast closure in step 4.
+    //     Labels surface-locked via plinth slot's default `'surface'`
+    //     orientation (#280) — no per-frame `faceCamera`.
     const k = kSlider.value;
-    if (thetaLabel && camera) {
+    if (thetaLabel) {
       thetaLabel.setSecondary(
         formatAnglePiFraction(thetaSlider.value, THETA_SNAP_POINTS),
       );
-      thetaLabel.faceCamera(camera);
     }
-    if (phiLabel && camera) {
+    if (phiLabel) {
       phiLabel.setSecondary(
         formatAnglePiFraction(phiSlider.value, PHI_SNAP_POINTS),
       );
-      phiLabel.faceCamera(camera);
     }
-    if (kLabel && camera) {
+    if (kLabel) {
       kLabel.setSecondary(formatLinearDecimal(k));
-      kLabel.faceCamera(camera);
     }
 
     // 3. Math-frame direction from θ/φ — mutates `dirMath` in place;

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -441,8 +441,11 @@ const saddleExtremaExhibit: Exhibit = {
     const slots: PlinthSlot[] = [
       { id: 'slider-x', target: xSlider.group, localXYZ: [0, PLINTH_X_SLIDER_Y, 0] },
       { id: 'slider-y', target: ySlider.group, localXYZ: [0, PLINTH_Y_SLIDER_Y, 0] },
-      { id: 'label-x', target: xLabel.group, localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_X_SLIDER_Y, 0] },
-      { id: 'label-y', target: yLabel.group, localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_Y_SLIDER_Y, 0] },
+      // Per-slider value labels: 1 mm slot-Z standoff resolves coplanar
+      // z-fighting against the slab top face. Mirrors `SectionTab`'s
+      // `SURFACE_LABEL_STANDOFF_M` (`TapButton.ts:104–118`).
+      { id: 'label-x', target: xLabel.group, localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_X_SLIDER_Y, 0.001] },
+      { id: 'label-y', target: yLabel.group, localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_Y_SLIDER_Y, 0.001] },
     ];
     presetButtons.forEach((btn, i) => {
       slots.push({
@@ -505,14 +508,14 @@ const saddleExtremaExhibit: Exhibit = {
       }
 
       // 3. Per-slider value labels — linear-decimal format (Cartesian
-      //    coords, not angles).
-      if (xLabel && camera) {
+      //    coords, not angles). Surface-locked via plinth slot's
+      //    default `'surface'` orientation (#280) — no per-frame
+      //    `faceCamera`.
+      if (xLabel) {
         xLabel.setSecondary(formatLinearDecimal(x));
-        xLabel.faceCamera(camera);
       }
-      if (yLabel && camera) {
+      if (yLabel) {
         yLabel.setSecondary(formatLinearDecimal(y));
-        yLabel.faceCamera(camera);
       }
 
       // 4. Classification readout (#181). Hessian evaluated at the

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -490,15 +490,18 @@ const tangentPlanesExhibit: Exhibit = {
         target: phiSlider.group,
         localXYZ: [0, PLINTH_SLIDER_TOP_Y - SLIDER_ROW_PITCH, 0],
       },
+      // Per-slider value labels: 1 mm slot-Z standoff resolves
+      // coplanar z-fighting against the slab top face. Mirrors
+      // `SectionTab`'s `SURFACE_LABEL_STANDOFF_M` (`TapButton.ts:104–118`).
       {
         id: 'label-theta',
         target: thetaLabel.group,
-        localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_SLIDER_TOP_Y, 0],
+        localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_SLIDER_TOP_Y, 0.001],
       },
       {
         id: 'label-phi',
         target: phiLabel.group,
-        localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_SLIDER_TOP_Y - SLIDER_ROW_PITCH, 0],
+        localXYZ: [SLIDER_LABEL_X_OFFSET, PLINTH_SLIDER_TOP_Y - SLIDER_ROW_PITCH, 0.001],
       },
       {
         id: 'readout',
@@ -544,19 +547,21 @@ const tangentPlanesExhibit: Exhibit = {
     // Per-slider value labels (#170). `formatAnglePiFraction` is
     // snap-aware: with PHI_INITIAL = π/4 and PHI_SNAP_POINTS not
     // including π/4, the boot pose renders as "0.25π" not the false-snap
-    // "π/4" glyph. faceCamera runs unconditionally so the label stays
-    // billboarded even on frames where the slider value didn't change.
-    if (thetaLabel && camera) {
+    // "π/4" glyph. Labels are surface-locked via the plinth slot's
+    // default `'surface'` orientation (#280) — no per-frame
+    // `faceCamera`; the slot's `R_x(−tilt)` rotation written at
+    // construction holds, and slot z-standoff resolves coplanar
+    // z-fighting against the slab (mirrors `SectionTab`'s
+    // `SURFACE_LABEL_STANDOFF_M`, `TapButton.ts:104–118`).
+    if (thetaLabel) {
       thetaLabel.setSecondary(
         formatAnglePiFraction(thetaSlider.value, THETA_SNAP_POINTS),
       );
-      thetaLabel.faceCamera(camera);
     }
-    if (phiLabel && camera) {
+    if (phiLabel) {
       phiLabel.setSecondary(
         formatAnglePiFraction(phiSlider.value, PHI_SNAP_POINTS),
       );
-      phiLabel.faceCamera(camera);
     }
 
     // Math-frame direction from θ/φ — mutates `dirMath` in place; no

--- a/src/scaffold/staging/Plinth.ts
+++ b/src/scaffold/staging/Plinth.ts
@@ -51,14 +51,23 @@ import * as THREE from 'three';
 //     `localRotation` in slot-local frame; composed onto the surface
 //     base).
 //
-// Billboarded-primitive carve-out: Label and the four readout classes
-// overwrite `group.rotation` every frame via `faceCamera`. For their
-// slots, `orientation` is documentation-only — they yaw-billboard
-// regardless. The slot position still binds them to the plinth
-// surface; the rotation just gets overwritten next frame. At normal
-// headset / pancake distances this reads as "the surface is tilted
-// but the text on it stays facing you," which is desired behavior
-// for legibility, not a compromise.
+// Slot orientation is mechanically applied at construction; callers
+// that later write `group.rotation` / `group.quaternion` override it.
+// The four readout classes do this every frame via `faceCamera`,
+// which yaw-billboards them toward the camera. Per-slider value
+// `Label`s in the cluster scenes intentionally do NOT call
+// `Label.faceCamera` as of #280 — they remain surface-locked through
+// the slot's default `'surface'` orientation, matching the
+// `SectionTab` vocabulary landed in #255. `rackLabel` in quadrics is
+// the one remaining `Label.faceCamera` in-tree caller; consolidating
+// its rendering is deferred to #270 (which should be scoped to
+// include it alongside the readout family).
+//
+// Plinth-mounted per-slider value labels also receive a 1 mm
+// `slot.localXYZ[2]` standoff applied at the consumer site to
+// resolve coplanar z-fighting against the slab top face. This
+// mirrors `SectionTab`'s `SURFACE_LABEL_STANDOFF_M`
+// (`TapButton.ts:104–118`).
 //
 // Surface-tilted tap-affordance opt-out (#255 PR2). TapButton-based
 // primitives (Preset / SectionTab / SceneTab) also use `faceCamera`
@@ -155,11 +164,15 @@ const PLINTH_SLAB_THICKNESS = 0.025;
  * - `'custom'` — caller supplies `localRotation` (in slot-local
  *   frame); composed onto the surface-tilt base.
  *
- * Note: Label and the four readout classes overwrite
- * `group.rotation` every frame via `faceCamera`. For their slots,
- * `orientation` is documentation-only — they yaw-billboard
- * regardless of the slot rotation contract. See file-top
- * "Billboarded-primitive carve-out" comment.
+ * Note: slot orientation is mechanically applied at construction;
+ * callers that later write `group.rotation` / `group.quaternion`
+ * override it. The four readout classes do this every frame via
+ * `faceCamera`. Per-slider value `Label`s in the cluster scenes
+ * intentionally do NOT call `Label.faceCamera` as of #280 and remain
+ * surface-locked through this slot orientation. `rackLabel` in
+ * quadrics is the one remaining `Label.faceCamera` in-tree caller
+ * (deferred to #270). See file-top comment for the consumer-side
+ * z-standoff convention applied to surface-locked labels.
  *
  * Note: TapButton-based primitives (Preset / SectionTab / SceneTab)
  * inherit the slot rotation on their button bodies cleanly, but

--- a/src/scaffold/ui/Label.ts
+++ b/src/scaffold/ui/Label.ts
@@ -29,9 +29,18 @@ const OUTLINE_WIDTH = '6%';
 const OUTLINE_COLOR = 0x000000;
 
 /**
- * Two-line billboarded text label. Primary line on top (large), secondary
- * line below (small). Owns a single `THREE.Group` you can position on the
- * scene; call `faceCamera(camera)` per-frame to billboard.
+ * Two-line text label. Primary line on top (large), secondary line below
+ * (small). Owns a single `THREE.Group` you can position on the scene.
+ *
+ * Orientation: callers choose. `faceCamera(camera)` per-frame yaw-
+ * billboards the group toward the camera (used by mid-air, non-plinth
+ * consumers and by `rackLabel` in quadrics). Plinth-slotted callers in
+ * the cluster scenes' per-slider value labels (#170, surface-locked per
+ * #280) do NOT call `faceCamera` — they rely on the plinth slot's default
+ * `'surface'` orientation to inherit `R_x(−tilt)` at construction, and
+ * apply a 1 mm `slot.localXYZ[2]` standoff to resolve coplanar
+ * z-fighting against the slab. See `src/scaffold/staging/Plinth.ts`
+ * file-top comment.
  *
  * Reuse target: this primitive is shared with the per-slider labels in #22 —
  * keep the surface narrow and orientation-agnostic.


### PR DESCRIPTION
Closes #280

## Summary

Consolidates the per-slider value labels in `tangent-planes`, `gradient-levels`, and `saddle-extrema` onto the static surface-locked vocabulary that section tabs adopted in #255 — matching Brad's pancake-smoke note from PR #279 that the section-rack text reads "really nice" on the plinth while the sister-scene value labels are still yawing. Removes the 7 per-frame `Label.faceCamera(camera)` calls in those scenes; the plinth slot's default `'surface'` orientation now holds the label tilt co-planar with the slab. Adds a 1 mm `slot.localXYZ[2]` standoff per label slot to resolve coplanar z-fighting against the slab, mirroring the existing `SectionTab` `SURFACE_LABEL_STANDOFF_M` precedent (`TapButton.ts:104–118`).

Narrows the `Plinth.ts` billboarded-primitive carve-out comment: post-#280 only the four readout classes and `rackLabel` in quadrics still write `group.rotation` per frame. `rackLabel` consolidation is deferred to #270 (which should be scoped to include it alongside the readouts).

Drafted, three-vendor `/roundtable-plan-review`'d (REVISE → v2 → second-Sonnet REVISE → v3), then implemented against v3. Maintainer-only plan doc at `_private/plans/280-per-slider-value-label-surface-lock.md`.

## Test plan

- [x] Pancake, default camera: value labels in tangent-planes / gradient-levels / saddle-extrema sit static-tilted on the slab; no yaw motion under camera orbit. Side-by-side comparison with quadrics' section-tab vocabulary confirms the vocabulary matches.
- [x] Pancake, value sweep: drag each slider through its full range. Worst-case strings (`−0.80π`, `−0.99`) render fully on the slab; ~47 mm visible separation between adjacent label rows in gradient-levels' 3-row rack; no z-fight shimmer against the slab under camera yaw 0–180°.
- [x] Pancake, crouched-close pose (~1.3 m height, ~1.2 m from plinth front edge): worst-case foreshortening — labels remain legible (same ~8% predicted as the #255 v3 section-tab analysis).
- [x] VR, Quest 3S: same checks. Labels stay static under head yaw. 1 mm standoff doesn't read as "label floating off the slab" at headset IPD.
- [x] Regression — `rackLabel` in quadrics still yaw-billboards (out-of-scope, deferred to #270).
- [x] Regression — readouts (TangentPlaneReadout, GradientLevelsReadout, SaddleExtremaReadout, EquationReadout) still face camera per frame.
- [x] Regression — `WorldAxes` letter labels still yaw-billboard across all four scenes.
- [x] Regression — quadrics section-tab vocabulary unchanged.

Automated:
- [x] Vitest: 574/574 pass on this branch.
- [x] `tsc --noEmit` clean.
- [x] `eslint .` clean.

Follow-up: thin issue comment on #270 widening its scope to include `rackLabel` alongside the readout family.