### PR TITLE
feat(staging): per-scene plinth + spawn derivation from cutout (#263)

### DIFF
--- a/src/exhibits/gradient-levels/SPEC.md
+++ b/src/exhibits/gradient-levels/SPEC.md
@@ -442,10 +442,17 @@ shared `createPlinth` primitive from `src/scaffold/staging/Plinth.ts`,
 matching quadrics' PR1 ship and the master plan
 (`_private/plans/225-control-plinth.md` §4.2 PR2 / `251-cluster-on-
 plinth.md` §3.2). Drafting-table-console silhouette anchored at world
-`(0, 0, 0.05)` — cluster-uniform anchor. Working-surface depth =
+`(0, 0, -0.625)` as of #263 — derived per-scene by
+`composeClusterStagePose(cutoutDescriptor)`. Gradient-levels' mid
+math envelope (BOUND = 3.0, no CUTOUT_VISUAL_MARGIN) puts the
+railing-front edge at z = -1.0, ~0.68 m closer to the user than
+quadrics'; the plinth slides forward to keep the body-back /
+railing-tube clearance at 0.045 m. Working-surface depth =
 `Plinth.ts` default 0.5 m: the 3-slider rack at `SLIDER_ROW_PITCH =
 0.14 m` fits in slot-Y ∈ [0.135, 0.415] with breathing room above
-and below.
+and below. The per-scene pancake spawn `(0, 1.6, 3.025)` and VR
+offset `(0, 0, 0.825)` ride on the registered `Exhibit.stage`
+metadata.
 
 Every UI primitive's `group` is reparented under `plinth.group` via
 the slot manifest in `mount()`; positions are slot-local. Slot

--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -312,6 +312,7 @@ const gradientLevelsExhibit: Exhibit = {
   stage: {
     pancakeSpawnWorldXYZ: STAGE_POSE.pancakeSpawnWorldXYZ,
     vrSpawnOffsetWorldXYZ: STAGE_POSE.vrSpawnOffsetWorldXYZ,
+    rackAnchorWorldXYZ: STAGE_POSE.plinthAnchorWorldXYZ,
   },
 
   mount({ group, camera: cam, pointers: shellPointers }: ExhibitContext) {

--- a/src/exhibits/gradient-levels/index.ts
+++ b/src/exhibits/gradient-levels/index.ts
@@ -31,6 +31,7 @@ import {
   createStageFloor,
   type StageFloorHandles,
 } from '@/scaffold/staging/StageFloor';
+import { composeClusterStagePose } from '@/scaffold/staging/clusterStagePose';
 import {
   createContrastPit,
   type ContrastPitHandles,
@@ -83,11 +84,22 @@ import { BOUND, fJsRaw, gradJs } from './surfaceModel';
 // relocate the surface across sibling scenes.
 const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
 
-// Plinth (#225 / E1.4 PR2). Cluster-uniform anchor matches quadrics'
-// PR1 ship — railing/floor geometry is shared. Working-surface depth
-// default 0.5 m fits the 3-row slider rack at SLIDER_ROW_PITCH = 0.14 m
-// (slot-Y ∈ [0.135, 0.415]) with breathing room above and below.
-const PLINTH_ANCHOR_WORLD_XYZ = [0, 0, 0.05] as const;
+// Plinth (#225 / E1.4 PR2). Working-surface depth default 0.5 m fits
+// the 3-row slider rack at SLIDER_ROW_PITCH = 0.14 m (slot-Y ∈
+// [0.135, 0.415]) with breathing room above and below. Anchor is
+// derived per-scene from `composeClusterStagePose` (#263); see
+// `STAGE_POSE` declaration below. Gradient-levels' mid envelope
+// (BOUND = 3.0, no CUTOUT_VISUAL_MARGIN) means the derived anchor is
+// `[0, 0, -0.625]` — ~0.68 m closer to the math object than the pre-
+// #263 cluster-uniform `0.05`.
+const CUTOUT_DESCRIPTOR = {
+  kind: 'rect' as const,
+  centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z] as const,
+  halfExtentX: BOUND,
+  halfExtentZ: BOUND,
+};
+const STAGE_POSE = composeClusterStagePose({ cutout: CUTOUT_DESCRIPTOR });
+const PLINTH_ANCHOR_WORLD_XYZ = STAGE_POSE.plinthAnchorWorldXYZ;
 
 // Slot-local layout (slot-local +X right, +Y up the tilted face toward
 // the back, +Z out from the surface normal). Three-row rack centered
@@ -297,6 +309,10 @@ const gradientLevelsExhibit: Exhibit = {
   id: 'gradient-levels',
   title: 'Level surfaces',
   cluster: CLUSTER_CALCULUS3,
+  stage: {
+    pancakeSpawnWorldXYZ: STAGE_POSE.pancakeSpawnWorldXYZ,
+    vrSpawnOffsetWorldXYZ: STAGE_POSE.vrSpawnOffsetWorldXYZ,
+  },
 
   mount({ group, camera: cam, pointers: shellPointers }: ExhibitContext) {
     pointers = shellPointers;
@@ -315,12 +331,9 @@ const gradientLevelsExhibit: Exhibit = {
     // tongues reach world Z = -7 at extreme k; cluster-uniform back-
     // extension pushes the floor + railing back edge to Z = -8 with
     // 1 m clearance. See `_private/plans/223-illusory-railing.md` §3.5.
-    const cutoutDescriptor = {
-      kind: 'rect' as const,
-      centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z] as const,
-      halfExtentX: BOUND,
-      halfExtentZ: BOUND,
-    };
+    // Module-scope `CUTOUT_DESCRIPTOR` (#263) — same value drives
+    // both staging mounts and `STAGE_POSE` derivation.
+    const cutoutDescriptor = CUTOUT_DESCRIPTOR;
     stageFloor = createStageFloor({
       cutout: cutoutDescriptor,
       backExtension: 3,

--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -447,7 +447,11 @@ pancake spawn at boot; `applyPancakeSpawnForExhibit` refreshes on
 each scene-hop; `shell.onXrSessionStart` applies the VR offset
 once per VR session. Foreground floor at the pancake pose is
 ~2.2 m (was ~1.5 m pre-#225 PR1). The SceneRack
-(`shell/SceneRack.ts`) sets `SCENE_RACK_Z = 0.05` to match the
+(`shell/SceneRack.ts`) is positioned per-scene via the shell's
+`rack.group.position` write from each exhibit's `rackAnchorWorldXYZ`
+(= plinth anchor for cluster scenes; cluster-uniform fallback
+`(0, 0, 0.05)` for non-cluster exhibits). For quadrics this lands
+the rack at world `(0, ~1.73, 0.05)` to match the
 plinth anchor so the navigation bulbs sit directly above the
 plinth front edge instead of being stranded over the math-object
 rendering box at the cluster's pre-plinth z = -0.7. The 0.75 m

--- a/src/exhibits/quadrics/SPEC.md
+++ b/src/exhibits/quadrics/SPEC.md
@@ -421,20 +421,32 @@ Quadrics' free-floating UI (sliders, presets, section tabs, equation
 shared `createPlinth` primitive from `src/scaffold/staging/Plinth.ts`
 as the densest cluster member — the API stress test for the slot
 model. Drafting-table-console silhouette anchored at world `(0, 0,
-0.05)` (#225 PR1 v2 smoke). v1 of PR1 anchored at z = 0 so the
-plinth body (z ∈ [-0.3, 0]) sat 0.025 m clear of the inner railing
-front edge at z = -0.325; v2 nudged the anchor 0.05 m further in
-+world-Z so the body back lands at z = -0.25, 0.045 m clear of the
-railing tube's +Z visual edge at z = -0.295 (tube radius 0.03 m).
+0.05)`. As of #263 the anchor is derived per-scene by
+`composeClusterStagePose(cutoutDescriptor)` from
+`scaffold/staging/clusterStagePose.ts`; quadrics is the helper's
+**calibration case** so the derived value matches the pre-#263
+literal to within ±0.5 mm under `roundToMm`. The derivation:
+railing-front-Z (`SURFACE_CENTER.z + halfExtentZ = -4 + 3.675 =
+-0.325`) + tube radius (`0.03`) + body-back clearance (`0.045`) +
+body depth (`0.3`) = `0.05`. v1 of #225 PR1 anchored at z = 0 so
+the body sat 0.025 m clear of the railing-front edge; v2 nudged
+the anchor 0.05 m further in +world-Z so the body back lands at
+z = -0.25, 0.045 m clear of the tube's +Z visual edge at z =
+-0.295 — those values are now the helper's defaults.
+
 `~20°` working-surface tilt, 0.9 m wide × `PLINTH_WORKING_HEIGHT_
 QUADRICS = 0.55` m deep working surface — slightly deeper than the
 Plinth default so the 4-slider rack fits at the cluster's standard
 0.14 m pitch without needing a per-scene pitch override.
 
-The pancake spawn camera is paired-shifted to `(0, 1.6, 3.7)`
-(`shell/cameraControls.ts`) so the user spawns on the same side of
-the inner railing as the plinth's interactables. Foreground floor
-at this pose is ~2.2 m (was ~1.5 m pre-#225 PR1). The SceneRack
+The pancake spawn pose `(0, 1.6, 3.7)` and VR offset `(0, 0, 1.5)`
+both come from the same `composeClusterStagePose(...)` call and
+ride on the registered `Exhibit.stage` metadata (per #263 §3.2).
+Shell wiring: `cameraControls.createCameraControls` consumes the
+pancake spawn at boot; `applyPancakeSpawnForExhibit` refreshes on
+each scene-hop; `shell.onXrSessionStart` applies the VR offset
+once per VR session. Foreground floor at the pancake pose is
+~2.2 m (was ~1.5 m pre-#225 PR1). The SceneRack
 (`shell/SceneRack.ts`) sets `SCENE_RACK_Z = 0.05` to match the
 plinth anchor so the navigation bulbs sit directly above the
 plinth front edge instead of being stranded over the math-object

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -19,6 +19,7 @@ import { PresetTween } from '@/scaffold/anim/PresetTween';
 import { createImplicitSurface } from '@/scaffold/render/ImplicitSurface';
 import { RendererInfoProbe } from '@/scaffold/perf/RendererInfoProbe';
 import { createStageFloor, type StageFloorHandles } from '@/scaffold/staging/StageFloor';
+import { composeClusterStagePose } from '@/scaffold/staging/clusterStagePose';
 import {
   createContrastPit,
   type ContrastPitHandles,
@@ -76,19 +77,12 @@ const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
 // slot-local coordinates and how they relate to the previous world-
 // frame layout (#110 / #93 follow-up).
 //
-// Anchor: floor-footprint center at world (0, 0, 0.05). v1 of #225
-// PR1 placed the anchor at (0, 0, 0) so the plinth body (z ∈ [-0.3,
-// 0]) sat 0.025 m clear of the inner railing front edge at world
-// z = SURFACE_CENTER.z + BOUND * CUTOUT_VISUAL_MARGIN = -4 + 3.675 =
-// -0.325 (tube radius 0.03 gives a tube +Z edge at z = -0.295). v1
-// smoke (Brad, 2026-05-22) found the body back at z = -0.3 still
-// visually penetrating the railing tube's volumetric envelope. v2
-// nudges the anchor 0.05 m further in +world-Z (= -math-Y, toward
-// the user) so the body back lands at z = -0.25 — 0.045 m clear of
-// the tube +Z edge at z = -0.295, an order of magnitude more visual
-// margin than v1 had. First-pass smoke-tunable; PR4 (E1.4e) is the
-// pancake-vs-VR calibration sweep.
-const PLINTH_ANCHOR_WORLD_XYZ = [0, 0, 0.05] as const;
+// Anchor is now derived per-scene from the cutout descriptor via
+// `composeClusterStagePose` (#263); see `STAGE_POSE` declaration
+// below (after `BOUND`) for the actual computation. Quadrics'
+// derived anchor is `[0, 0, 0.05]` — bit-identical (within ±0.5 mm)
+// to the pre-#263 cluster-uniform literal because the helper's
+// defaults match quadrics' #225-PR1-v2 smoke calibration.
 
 // Slightly deeper than the Plinth default (0.5) to fit the 4-slider
 // rack at 0.14 m pitch with breathing room above and below. Back-
@@ -332,6 +326,28 @@ const CANONICAL_FORMS_LABEL_EXPANDED = 'Canonical forms ▾';
 // queued as knob 3 if more headroom is needed).
 const BOUND = 3.5;
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
+
+// CUTOUT_VISUAL_MARGIN: 1.05× outward expansion of the cutout (and
+// inner-railing perimeter) so the rendered surface doesn't kiss the
+// cutout edge at extreme parameters — PR #244 follow-up smoke. Hoisted
+// to module scope (#263) so the same descriptor drives both the
+// floor + railing + contrast-pit mounts AND the per-scene
+// `composeClusterStagePose` derivation.
+const CUTOUT_VISUAL_MARGIN = 1.05;
+const CUTOUT_DESCRIPTOR = {
+  kind: 'rect' as const,
+  centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z] as const,
+  halfExtentX: BOUND * CUTOUT_VISUAL_MARGIN,
+  halfExtentZ: BOUND * CUTOUT_VISUAL_MARGIN,
+};
+// Per-scene stage pose (#263). Plinth anchor, pancake spawn, VR
+// spawn offset all derive from the cutout descriptor via the cluster
+// staging helper. Quadrics calibrates the helper's defaults:
+//   anchor      = [0, 0, 0.05]
+//   pancake     = [0, 1.6, 3.7]  (= [0, 1.6, 3.7] pre-#263 literal)
+//   VR offset   = [0, 0, 1.5]    (= +1.5 m pre-#263 #262 stopgap)
+const STAGE_POSE = composeClusterStagePose({ cutout: CUTOUT_DESCRIPTOR });
+const PLINTH_ANCHOR_WORLD_XYZ = STAGE_POSE.plinthAnchorWorldXYZ;
 
 // Slider detent half-width, per SPEC.md "Slider model". Lets the user
 // park exactly on a snap point (degeneracy boundary or canonical-form
@@ -901,6 +917,10 @@ const quadricsExhibit: Exhibit = {
   id: 'quadrics',
   title: 'Quadric surfaces',
   cluster: CLUSTER_CALCULUS3,
+  stage: {
+    pancakeSpawnWorldXYZ: STAGE_POSE.pancakeSpawnWorldXYZ,
+    vrSpawnOffsetWorldXYZ: STAGE_POSE.vrSpawnOffsetWorldXYZ,
+  },
 
   mount({ group, renderer, camera: cam, pointers: shellPointers }: ExhibitContext) {
     camera = cam;
@@ -922,19 +942,10 @@ const quadricsExhibit: Exhibit = {
     // reaches world Z = -7.5; cluster-uniform back-extension pushes
     // the floor + railing back edge to Z = -8. See plan §3.5.
     //
-    // CUTOUT_VISUAL_MARGIN: 1.05× outward expansion of the cutout
-    // (and consequently the inner railing) so the rendered surface
-    // doesn't kiss the cutout/railing edge at extreme parameters —
-    // PR #244 follow-up smoke. The 1.05× scaling preserves the
-    // "math envelope projected onto floor" framing while adding a
-    // small annular breathing margin.
-    const CUTOUT_VISUAL_MARGIN = 1.05;
-    const cutoutDescriptor = {
-      kind: 'rect' as const,
-      centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z] as const,
-      halfExtentX: BOUND * CUTOUT_VISUAL_MARGIN,
-      halfExtentZ: BOUND * CUTOUT_VISUAL_MARGIN,
-    };
+    // Cutout descriptor is module-scope `CUTOUT_DESCRIPTOR` (#263)
+    // so the same value drives both the staging mounts (here) and
+    // the per-scene `STAGE_POSE` derivation above.
+    const cutoutDescriptor = CUTOUT_DESCRIPTOR;
     stageFloor = createStageFloor({
       cutout: cutoutDescriptor,
       backExtension: 3,

--- a/src/exhibits/quadrics/index.ts
+++ b/src/exhibits/quadrics/index.ts
@@ -920,6 +920,7 @@ const quadricsExhibit: Exhibit = {
   stage: {
     pancakeSpawnWorldXYZ: STAGE_POSE.pancakeSpawnWorldXYZ,
     vrSpawnOffsetWorldXYZ: STAGE_POSE.vrSpawnOffsetWorldXYZ,
+    rackAnchorWorldXYZ: STAGE_POSE.plinthAnchorWorldXYZ,
   },
 
   mount({ group, renderer, camera: cam, pointers: shellPointers }: ExhibitContext) {

--- a/src/exhibits/saddle-extrema/SPEC.md
+++ b/src/exhibits/saddle-extrema/SPEC.md
@@ -770,11 +770,18 @@ cluster-shared `createPlinth` primitive from
 `src/scaffold/staging/Plinth.ts`, matching quadrics' PR1 ship and
 the master plan (`_private/plans/225-control-plinth.md` §4.2 PR2 /
 `251-cluster-on-plinth.md` §3.3). Drafting-table-console silhouette
-anchored at world `(0, 0, 0.05)` — cluster-uniform anchor.
-Working-surface depth = `Plinth.ts` default 0.5 m: the 2-slider rack
-fits comfortably in slot-Y ∈ [0.205, 0.345]; the 5-preset row and
+anchored at world `(0, 0, -2.05)` as of #263 — derived per-scene
+by `composeClusterStagePose(cutoutDescriptor)`. Saddle-extrema's
+preset-driven envelope (`STAGE_CUTOUT_HALF ≈ 1.5 × CUTOUT_VISUAL_
+MARGIN = 1.575`) puts the railing-front edge at z ≈ -2.425, ~2.1 m
+closer to the user than quadrics'; the plinth slides forward to
+keep the body-back / railing-tube clearance at 0.045 m. Working-
+surface depth = `Plinth.ts` default 0.5 m: the 2-slider rack fits
+comfortably in slot-Y ∈ [0.205, 0.345]; the 5-preset row and
 3-line readout deliberately float above the back edge at slot-Y >
-0.5, mirroring quadrics' preset-grid + classifier pattern.
+0.5, mirroring quadrics' preset-grid + classifier pattern. The
+per-scene pancake spawn `(0, 1.6, 1.6)` and VR offset `(0, 0,
+-0.6)` ride on the registered `Exhibit.stage` metadata.
 
 Every UI primitive's `group` is reparented under `plinth.group` via
 the slot manifest in `mount()`; positions are slot-local (11 slots

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -257,6 +257,7 @@ const saddleExtremaExhibit: Exhibit = {
   stage: {
     pancakeSpawnWorldXYZ: STAGE_POSE.pancakeSpawnWorldXYZ,
     vrSpawnOffsetWorldXYZ: STAGE_POSE.vrSpawnOffsetWorldXYZ,
+    rackAnchorWorldXYZ: STAGE_POSE.plinthAnchorWorldXYZ,
   },
 
   mount({ group, camera: cam, pointers: shellPointers }: ExhibitContext) {

--- a/src/exhibits/saddle-extrema/index.ts
+++ b/src/exhibits/saddle-extrema/index.ts
@@ -25,6 +25,7 @@ import {
   createStageFloor,
   type StageFloorHandles,
 } from '@/scaffold/staging/StageFloor';
+import { composeClusterStagePose } from '@/scaffold/staging/clusterStagePose';
 import {
   createContrastPit,
   type ContrastPitHandles,
@@ -89,13 +90,16 @@ const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
 const BASE_COLOR = new THREE.Color(0.4, 0.7, 0.95);
 
-// Plinth (#225 / E1.4 PR2). Cluster-uniform anchor matches quadrics'
-// PR1 ship — railing/floor geometry is shared. Working-surface depth
-// default 0.5 m fits the 2-row slider rack with breathing room; the
-// 5-preset row and 3-line readout deliberately float above the back
-// edge (slot-Y > 0.5), mirroring quadrics' preset-grid + classifier
-// pattern.
-const PLINTH_ANCHOR_WORLD_XYZ = [0, 0, 0.05] as const;
+// Plinth (#225 / E1.4 PR2). Working-surface depth default 0.5 m fits
+// the 2-row slider rack with breathing room; the 5-preset row and
+// 3-line readout deliberately float above the back edge (slot-Y >
+// 0.5), mirroring quadrics' preset-grid + classifier pattern.
+// Anchor is derived per-scene from `composeClusterStagePose` (#263);
+// see `STAGE_POSE` declaration below (after `STAGE_CUTOUT_HALF`).
+// Saddle-extrema's preset-driven envelope (`STAGE_CUTOUT_HALF ×
+// CUTOUT_VISUAL_MARGIN ≈ 1.575`) makes the derived anchor `[0, 0,
+// -2.05]` — ~2.1 m closer to the math object than the pre-#263
+// cluster-uniform `0.05`.
 
 // Slot-local layout. Two-row slider rack centered on slot-Y = 0.275:
 // x at 0.345, y at 0.205 — inter-slider distance 0.14 m, matching the
@@ -133,6 +137,22 @@ const STAGE_CUTOUT_HALF = Math.max(
     ),
   ),
 );
+
+// CUTOUT_VISUAL_MARGIN: 1.05× outward expansion of the cutout (and
+// inner railing) so the rendered surface — especially the `saddle`
+// preset which reaches the full ±STAGE_CUTOUT_HALF domain — has a
+// small annular breathing margin between math and railing. PR #244
+// follow-up smoke. Hoisted to module scope (#263) so the same
+// descriptor drives both staging mounts AND `STAGE_POSE` derivation.
+const CUTOUT_VISUAL_MARGIN = 1.05;
+const CUTOUT_DESCRIPTOR = {
+  kind: 'rect' as const,
+  centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z] as const,
+  halfExtentX: STAGE_CUTOUT_HALF * CUTOUT_VISUAL_MARGIN,
+  halfExtentZ: STAGE_CUTOUT_HALF * CUTOUT_VISUAL_MARGIN,
+};
+const STAGE_POSE = composeClusterStagePose({ cutout: CUTOUT_DESCRIPTOR });
+const PLINTH_ANCHOR_WORLD_XYZ = STAGE_POSE.plinthAnchorWorldXYZ;
 
 // Slider rack — two-row symmetric straddle. Slot-Y values applied via
 // the slot manifest in mount(); per-slider plinth-Y derivations above
@@ -234,6 +254,10 @@ const saddleExtremaExhibit: Exhibit = {
   id: 'saddle-extrema',
   title: 'Critical points',
   cluster: CLUSTER_CALCULUS3,
+  stage: {
+    pancakeSpawnWorldXYZ: STAGE_POSE.pancakeSpawnWorldXYZ,
+    vrSpawnOffsetWorldXYZ: STAGE_POSE.vrSpawnOffsetWorldXYZ,
+  },
 
   mount({ group, camera: cam, pointers: shellPointers }: ExhibitContext) {
     exhibitGroup = group;
@@ -261,18 +285,9 @@ const saddleExtremaExhibit: Exhibit = {
     // (`saddle` at ±1.5) reaches z = -5.5, so 2.5 m margin to the
     // extended back at z = -8. See plan §3.5.
     //
-    // CUTOUT_VISUAL_MARGIN: 1.05× outward expansion of the cutout
-    // (and inner railing) so the rendered surface — especially the
-    // `saddle` preset which reaches the full ±STAGE_CUTOUT_HALF
-    // domain — has a small annular breathing margin between math
-    // and railing. PR #244 follow-up smoke.
-    const CUTOUT_VISUAL_MARGIN = 1.05;
-    const cutoutDescriptor = {
-      kind: 'rect' as const,
-      centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z] as const,
-      halfExtentX: STAGE_CUTOUT_HALF * CUTOUT_VISUAL_MARGIN,
-      halfExtentZ: STAGE_CUTOUT_HALF * CUTOUT_VISUAL_MARGIN,
-    };
+    // Module-scope `CUTOUT_DESCRIPTOR` (#263) — same value drives
+    // both staging mounts and `STAGE_POSE` derivation.
+    const cutoutDescriptor = CUTOUT_DESCRIPTOR;
     stageFloor = createStageFloor({
       cutout: cutoutDescriptor,
       backExtension: 3,

--- a/src/exhibits/tangent-planes/SPEC.md
+++ b/src/exhibits/tangent-planes/SPEC.md
@@ -327,11 +327,18 @@ readout + math-frame axis indicator) lifts onto the cluster-shared
 matching quadrics' PR1 ship and the master plan
 (`_private/plans/225-control-plinth.md` §4.2 PR2 / `251-cluster-on-
 plinth.md` §3.1). Drafting-table-console silhouette anchored at world
-`(0, 0, 0.05)` — cluster-uniform anchor; the railing/floor clearance
-checked for quadrics' v2 smoke applies here too (shared backExtension
-+ inner-railing geometry). Working-surface depth = `Plinth.ts`
-default 0.5 m: the 2-slider rack at `SLIDER_ROW_PITCH = 0.14 m` fits
-comfortably in slot-Y ∈ [0.205, 0.345], well inside [0, 0.5].
+`(0, 0, -2.125)` as of #263 — derived per-scene by
+`composeClusterStagePose(cutoutDescriptor)`. Tangent-planes' smaller
+math envelope (BOUND = 1.5, circle cutout) puts the railing-front
+edge ~2.18 m closer to the user than quadrics' (railing-front =
+-2.5 vs -0.325), so the plinth slides forward by the same amount
+to keep the body-back / railing-tube clearance at the cluster-uniform
+0.045 m. Working-surface depth = `Plinth.ts` default 0.5 m: the 2-
+slider rack at `SLIDER_ROW_PITCH = 0.14 m` fits comfortably in
+slot-Y ∈ [0.205, 0.345], well inside [0, 0.5]. The per-scene
+pancake spawn `(0, 1.6, 1.525)` and VR offset `(0, 0, -0.675)` ride
+on the registered `Exhibit.stage` metadata; shell consumes via
+`shell/stagePose.ts`'s `resolveStagePose`.
 
 Every UI primitive's `group` is reparented under `plinth.group` via
 the slot manifest in `mount()`; positions are slot-local (origin at

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -28,6 +28,9 @@ import { anglesFromDirection } from '@/scaffold/math/anglesFromDirection';
 import { directionFromAngles } from '@/scaffold/math/directionFromAngles';
 import { raycastImplicit } from '@/scaffold/render/raycastImplicit';
 import {
+  composeClusterStagePose,
+} from '@/scaffold/staging/clusterStagePose';
+import {
   createStageFloor,
   type StageFloorHandles,
 } from '@/scaffold/staging/StageFloor';
@@ -79,14 +82,13 @@ import { TangentPlaneReadout } from './TangentPlaneReadout';
 // relocate the surface across sibling scenes.
 const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
 
-// Plinth (#225 / E1.4 PR2). Anchor + working-surface depth match
-// quadrics' PR1 ship — the railing/floor geometry is cluster-uniform
-// (backExtension: 3, inner-railing perimeter at the cutout) so the
-// anchor that cleared quadrics' inner railing tube clears the same
-// geometry here. Working-surface depth default 0.5 m fits the 2-row
-// slider rack at SLIDER_ROW_PITCH = 0.14 m with breathing room above
-// and below.
-const PLINTH_ANCHOR_WORLD_XYZ = [0, 0, 0.05] as const;
+// Plinth (#225 / E1.4 PR2). Working-surface depth default 0.5 m fits
+// the 2-row slider rack at SLIDER_ROW_PITCH = 0.14 m with breathing
+// room above and below. Anchor is now derived per-scene from
+// `composeClusterStagePose` (#263); see `STAGE_POSE` declaration
+// below (after `BOUND`). Tangent-planes' smaller envelope means the
+// derived anchor is `[0, 0, -2.125]` — ~2.2 m closer to the math
+// object than quadrics' cluster-uniform `0.05` placement.
 
 // Slot-local layout (slot-local +X right, +Y up the tilted face toward
 // the back, +Z out from the surface normal). Two-row rack centered on
@@ -108,6 +110,23 @@ const PLINTH_AXIS_INDICATOR_Y = 0.275;
 // Tighter than quadrics' BOUND=3.5: the unit sphere fits in [-1, 1]³ with
 // room to spare; no coefficient-driven expansion to budget for.
 const BOUND = 1.5;
+
+// Cutout descriptor hoisted to module scope (#263) so the same
+// descriptor drives both the staging mounts AND the per-scene
+// `composeClusterStagePose` derivation. Tangent-planes is the only
+// cluster scene with a circle cutout (#238 Path A1).
+const CUTOUT_DESCRIPTOR = {
+  kind: 'circle' as const,
+  centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z] as const,
+  radius: BOUND,
+};
+// Per-scene stage pose (#263). With railing front at world Z =
+// SURFACE_CENTER.z + BOUND = -2.5, the derived anchor is
+// `[0, 0, -2.125]` — the plinth slides ~2.18 m toward the math
+// object vs the cluster-uniform `0.05`. Pancake spawn `[0, 1.6,
+// 1.525]`; VR spawn offset `[0, 0, -0.675]`.
+const STAGE_POSE = composeClusterStagePose({ cutout: CUTOUT_DESCRIPTOR });
+const PLINTH_ANCHOR_WORLD_XYZ = STAGE_POSE.plinthAnchorWorldXYZ;
 
 // Same lighting + base color as quadrics so the surface reads as a sibling.
 const LIGHT_DIR = new THREE.Vector3(0.4, 0.8, 0.5).normalize();
@@ -328,6 +347,10 @@ const tangentPlanesExhibit: Exhibit = {
   id: 'tangent-planes',
   title: 'Tangent planes',
   cluster: CLUSTER_CALCULUS3,
+  stage: {
+    pancakeSpawnWorldXYZ: STAGE_POSE.pancakeSpawnWorldXYZ,
+    vrSpawnOffsetWorldXYZ: STAGE_POSE.vrSpawnOffsetWorldXYZ,
+  },
 
   mount({ group, camera: cam, pointers: shellPointers }: ExhibitContext) {
     pointers = shellPointers;
@@ -346,11 +369,9 @@ const tangentPlanesExhibit: Exhibit = {
     // sphere envelope is strictly inside the railing perimeter already
     // (plan §3.5). The per-scene `outerHalfExtent: 6` (vs cluster
     // default 5) remains the per-scene variation under Path A1.
-    const cutoutDescriptor = {
-      kind: 'circle' as const,
-      centerXZ: [SURFACE_CENTER.x, SURFACE_CENTER.z] as const,
-      radius: BOUND,
-    };
+    // Module-scope `CUTOUT_DESCRIPTOR` (#263) — same value drives
+    // both staging mounts and `STAGE_POSE` derivation.
+    const cutoutDescriptor = CUTOUT_DESCRIPTOR;
     stageFloor = createStageFloor({
       cutout: cutoutDescriptor,
       outerHalfExtent: 6,

--- a/src/exhibits/tangent-planes/index.ts
+++ b/src/exhibits/tangent-planes/index.ts
@@ -350,6 +350,7 @@ const tangentPlanesExhibit: Exhibit = {
   stage: {
     pancakeSpawnWorldXYZ: STAGE_POSE.pancakeSpawnWorldXYZ,
     vrSpawnOffsetWorldXYZ: STAGE_POSE.vrSpawnOffsetWorldXYZ,
+    rackAnchorWorldXYZ: STAGE_POSE.plinthAnchorWorldXYZ,
   },
 
   mount({ group, camera: cam, pointers: shellPointers }: ExhibitContext) {

--- a/src/scaffold/staging/Plinth.ts
+++ b/src/scaffold/staging/Plinth.ts
@@ -142,9 +142,9 @@ export const PLINTH_WORKING_HEIGHT_FROM_FLOOR_DEFAULT = 0.95;
  *  z = 0; the body extends back to z = −PLINTH_BODY_DEPTH). Body is
  *  centered on the working-surface horizontal projection (about
  *  workingSurfaceHeight * sin(tilt) ≈ 0.17 m at defaults) plus visual
- *  breathing room. Kept as a module-local constant (not exported)
- *  because no consumer currently parameterizes it. */
-const PLINTH_BODY_DEPTH = 0.3;
+ *  breathing room. Exported as of #263 so `clusterStagePose` can derive
+ *  each scene's plinth-anchor Z from the cutout's railing-front face. */
+export const PLINTH_BODY_DEPTH = 0.3;
 
 /** Working-surface slab thickness in slot-local +Z (slab extends
  *  from z = 0 down to z = −PLINTH_SLAB_THICKNESS in slot-local).

--- a/src/scaffold/staging/StageInnerRailing.ts
+++ b/src/scaffold/staging/StageInnerRailing.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import {
   STAGE_RAILING_COLOR_RGB,
+  STAGE_RAILING_TUBE_RADIUS,
   type StageRailingHandles,
 } from '@/scaffold/staging/StageRailing';
 import type { StageCutoutDescriptor } from '@/scaffold/staging/StageFloor';
@@ -25,8 +26,8 @@ import type { StageCutoutDescriptor } from '@/scaffold/staging/StageFloor';
 //   geometry / dispose surface for no visual gain.
 //
 // Cluster-uniform visual vocabulary with the outer railing: same color,
-// same POST_HEIGHT, same POST_RADIUS, same TUBE_RADIUS. The inner is
-// recognized by *where it is* (around the cutout, not the perimeter),
+// same POST_HEIGHT, same POST_RADIUS, same STAGE_RAILING_TUBE_RADIUS.
+// The inner is recognized by *where it is* (around the cutout, not the perimeter),
 // not by being a different visual material. Color and palette tokens
 // are shared with `StageRailing` via import.
 //
@@ -41,7 +42,6 @@ import type { StageCutoutDescriptor } from '@/scaffold/staging/StageFloor';
 
 const POST_HEIGHT = 0.9;
 const POST_RADIUS = 0.04;
-const TUBE_RADIUS = 0.03;
 const CIRCLE_POST_COUNT = 8;
 const TORUS_RADIAL_SEGMENTS = 8;
 const TORUS_TUBULAR_SEGMENTS = 32;
@@ -123,8 +123,8 @@ function buildRectInner(
   // Two CylinderGeometry instances — same X-spanning vs Z-spanning
   // split as the outer railing.
   const tubeGeomXSpan = new THREE.CylinderGeometry(
-    TUBE_RADIUS,
-    TUBE_RADIUS,
+    STAGE_RAILING_TUBE_RADIUS,
+    STAGE_RAILING_TUBE_RADIUS,
     halfExtentX * 2,
     8,
     1,
@@ -132,8 +132,8 @@ function buildRectInner(
   );
   geometries.push(tubeGeomXSpan);
   const tubeGeomZSpan = new THREE.CylinderGeometry(
-    TUBE_RADIUS,
-    TUBE_RADIUS,
+    STAGE_RAILING_TUBE_RADIUS,
+    STAGE_RAILING_TUBE_RADIUS,
     halfExtentZ * 2,
     8,
     1,
@@ -192,7 +192,7 @@ function buildCircleInner(
   // orientation the cutout occupies.
   const torusGeom = new THREE.TorusGeometry(
     radius,
-    TUBE_RADIUS,
+    STAGE_RAILING_TUBE_RADIUS,
     TORUS_RADIAL_SEGMENTS,
     TORUS_TUBULAR_SEGMENTS,
   );

--- a/src/scaffold/staging/StageRailing.ts
+++ b/src/scaffold/staging/StageRailing.ts
@@ -55,7 +55,11 @@ export const STAGE_RAILING_COLOR_RGB = [
 
 const POST_HEIGHT = 0.9;
 const POST_RADIUS = 0.04;
-const TUBE_RADIUS = 0.03;
+/** Top-rail tube radius. Consumed by `StageInnerRailing` so its rail
+ *  matches the outer railing's cross-section, and by
+ *  `scaffold/staging/clusterStagePose.ts` for the plinth-back / railing-
+ *  tube visual-margin derivation (#263). */
+export const STAGE_RAILING_TUBE_RADIUS = 0.03;
 
 export interface StageRailingOptions {
   /** Required. Same value the scene passed to `createStageFloor`. */
@@ -126,8 +130,8 @@ export function createStageRailing(
   // at post-cap height. Local +Y is the cylinder's long axis; the
   // quaternion orients it along the side.
   const tubeGeomXSpan = new THREE.CylinderGeometry(
-    TUBE_RADIUS,
-    TUBE_RADIUS,
+    STAGE_RAILING_TUBE_RADIUS,
+    STAGE_RAILING_TUBE_RADIUS,
     outer * 2,
     8,
     1,
@@ -135,8 +139,8 @@ export function createStageRailing(
   );
   geometries.push(tubeGeomXSpan);
   const tubeGeomZSpan = new THREE.CylinderGeometry(
-    TUBE_RADIUS,
-    TUBE_RADIUS,
+    STAGE_RAILING_TUBE_RADIUS,
+    STAGE_RAILING_TUBE_RADIUS,
     outer * 2 + back,
     8,
     1,

--- a/src/scaffold/staging/clusterStagePose.ts
+++ b/src/scaffold/staging/clusterStagePose.ts
@@ -1,0 +1,125 @@
+import {
+  PLINTH_BODY_DEPTH,
+} from '@/scaffold/staging/Plinth';
+import { STAGE_RAILING_TUBE_RADIUS } from '@/scaffold/staging/StageRailing';
+import type { StageCutoutDescriptor } from '@/scaffold/staging/StageFloor';
+
+// Cluster-uniform staging pose composition for the v1.0 staged-exhibit
+// vocabulary (#263). Replaces the cluster-uniform
+// `PLINTH_ANCHOR_WORLD_XYZ = [0, 0, 0.05]` literal duplicated in every
+// cluster scene + the cluster-uniform pancake spawn `(0, 1.6, 3.7)` and
+// VR offset `+1.5 m` with per-scene-derived values:
+//
+//   - Plinth anchor: derived from the cutout's `centerXZ[1] + halfZ` so
+//     the plinth body's back face sits at uniform clearance from the
+//     inner railing's user-facing tube edge regardless of math envelope.
+//   - Pancake + VR spawn poses: derived from the anchor + per-mode
+//     arm's-length padding (3.65 m pancake, 1.45 m VR) so user-to-plinth
+//     distance is invariant across scenes within each mode.
+//
+// The math object (`SURFACE_CENTER = (0, 1.5, -4)`) stays put. The floor
+// outer extent stays put. The back railing stays put. Quadrics is the
+// calibration case: anchor `[0, 0, 0.05]`, pancake spawn `[0, 1.6, 3.7]`,
+// VR offset `[0, 0, 1.5]` are bit-identical to today's cluster-uniform
+// values to within ±0.5 mm (`roundToMm` ensures strict equality).
+//
+// See `_private/plans/263-per-scene-plinth-and-spawn.md` §3.1 for the
+// derivation rule + per-scene results table.
+
+/** Plinth body back ↔ railing tube +Z edge clearance, meters. Bracket
+ *  [0.03, 0.06]; smoke-tunable. Calibrated by Brad 2026-05-22 smoke
+ *  during #225 PR1: 45 mm "an order of magnitude more visual margin
+ *  than v1 had" (quadrics/index.ts:84–88). */
+export const PLINTH_BODY_BACK_CLEARANCE_DEFAULT = 0.045;
+
+/** Arm's-length padding from plinth front face to pancake spawn,
+ *  meters. Bracket [3.0, 4.0]; matches #240's post-smoke calibration
+ *  of 3.65 m (anchor 0.05 + 3.65 = 3.70 — the current cluster-uniform
+ *  pancake spawn-Z for quadrics, post-#225-PR1 smoke nudge from 3.0
+ *  to 3.7). Pancake's larger padding vs VR reflects that pancake
+ *  spawn is "where the math object best frames against the cutout
+ *  foreground," not "where the user stands at HMD-takeover." */
+export const PANCAKE_SPAWN_PADDING_Z_M_DEFAULT = 3.65;
+
+/** Arm's-length padding from plinth front face to VR spawn, meters.
+ *  Bracket [1.2, 1.7]; matches today's #262 cluster-uniform 1.45 m
+ *  (= 1.5 cluster-uniform offset − 0.05 cluster-uniform anchor.z).
+ *  Validated by Brad in #262 smoke as "clear of the plinth volume
+ *  with arm's-length reach." Memory: [feedback_vr_spawn_arm_length_
+ *  from_interactable] — leave a deliberate ~1–1.5 m gap so the user
+ *  is cued to step forward to engage. */
+export const VR_SPAWN_PADDING_Z_M_DEFAULT = 1.45;
+
+export interface ClusterStagePose {
+  /** Plinth ctor input. Floor-footprint center; body extends back
+   *  from this Z by `PLINTH_BODY_DEPTH` (0.3). */
+  readonly plinthAnchorWorldXYZ: readonly [number, number, number];
+  /** Pancake camera initial position. Y = 1.6 (WebXR eye-height
+   *  convention). */
+  readonly pancakeSpawnWorldXYZ: readonly [number, number, number];
+  /** VR `local-floor` reference-space offset: applied as
+   *  `XRRigidTransform({-x, -y, -z}, identity)` in `shell.ts`'s
+   *  session-start handler. Y = 0 (HMD pose drives user Y). */
+  readonly vrSpawnOffsetWorldXYZ: readonly [number, number, number];
+}
+
+export interface ClusterStagePoseOptions {
+  /** Same descriptor the scene passes to `createStageFloor` /
+   *  `createStageInnerRailing` / `createContrastPit`. The
+   *  `centerXZ[1]` + `halfExtentZ` (or `radius`) drives anchor Z. */
+  readonly cutout: StageCutoutDescriptor;
+  /** Default `PLINTH_BODY_BACK_CLEARANCE_DEFAULT`. Smoke-tunable. */
+  readonly plinthBodyBackClearance?: number;
+  /** Default `PANCAKE_SPAWN_PADDING_Z_M_DEFAULT`. */
+  readonly pancakeSpawnPaddingZ?: number;
+  /** Default `VR_SPAWN_PADDING_Z_M_DEFAULT`. */
+  readonly vrSpawnPaddingZ?: number;
+}
+
+/**
+ * Compose the cluster's per-scene plinth anchor + pancake spawn + VR
+ * spawn offset from a stage-floor cutout descriptor. Pure function;
+ * call once per scene at module-load time.
+ *
+ * Derivation (anchor Z):
+ *   anchorZ = cutout.centerXZ[1]               // railing-center-Z
+ *           + halfExtentZ_or_radius            // railing front face
+ *           + STAGE_RAILING_TUBE_RADIUS        // tube +Z edge
+ *           + plinthBodyBackClearance          // visual margin
+ *           + PLINTH_BODY_DEPTH                // body front face = anchor
+ *
+ * Derivation (spawn Z): anchorZ + per-mode padding.
+ *
+ * Output rounded to mm so the helper's quadrics calibration case
+ * (cutout halfExtentZ 3.675 at centerXZ.y = -4) returns
+ * `[0, 0, 0.05]` under strict equality, not `[0, 0, 0.04999...]`.
+ * Sub-mm is below smoke-tunable resolution; rounding makes tests
+ * + back-compat literals work without `toBeCloseTo` everywhere.
+ */
+export function composeClusterStagePose(
+  opts: ClusterStagePoseOptions,
+): ClusterStagePose {
+  const [cx, cz] = opts.cutout.centerXZ;
+  const halfZ =
+    opts.cutout.kind === 'rect' ? opts.cutout.halfExtentZ : opts.cutout.radius;
+  const clearance =
+    opts.plinthBodyBackClearance ?? PLINTH_BODY_BACK_CLEARANCE_DEFAULT;
+  const pancakePad =
+    opts.pancakeSpawnPaddingZ ?? PANCAKE_SPAWN_PADDING_Z_M_DEFAULT;
+  const vrPad = opts.vrSpawnPaddingZ ?? VR_SPAWN_PADDING_Z_M_DEFAULT;
+
+  const anchorZ = roundToMm(
+    cz + halfZ + STAGE_RAILING_TUBE_RADIUS + clearance + PLINTH_BODY_DEPTH,
+  );
+  const anchorX = roundToMm(cx);
+
+  return {
+    plinthAnchorWorldXYZ: [anchorX, 0, anchorZ] as const,
+    pancakeSpawnWorldXYZ: [anchorX, 1.6, roundToMm(anchorZ + pancakePad)] as const,
+    vrSpawnOffsetWorldXYZ: [anchorX, 0, roundToMm(anchorZ + vrPad)] as const,
+  };
+}
+
+function roundToMm(x: number): number {
+  return Math.round(x * 1000) / 1000;
+}

--- a/src/shell/Exhibit.ts
+++ b/src/shell/Exhibit.ts
@@ -27,6 +27,20 @@ export interface ExhibitStageMetadata {
    * hops in VR keep the prior offset. Follow-up: §7 of the #263 plan.
    */
   readonly vrSpawnOffsetWorldXYZ: readonly [number, number, number];
+  /**
+   * World-space anchor the shell-owned `SceneRack` should track per
+   * scene (#263 follow-up). Cluster scenes pass their plinth anchor
+   * so the rack bulbs sit directly above the plinth front face
+   * regardless of math-envelope size; non-cluster exhibits get the
+   * cluster-uniform fallback `(0, 0, 0.05)` so direct dev imports
+   * render the rack where it sat pre-#263.
+   *
+   * The shell writes `rack.group.position` to this value on boot +
+   * on every mount swap; the rack's tab-local Z (formerly baked at
+   * 0.05) is now 0 so the world Z of each tab equals
+   * `rackAnchorWorldXYZ[2]` directly.
+   */
+  readonly rackAnchorWorldXYZ: readonly [number, number, number];
 }
 
 export interface ExhibitContext {

--- a/src/shell/Exhibit.ts
+++ b/src/shell/Exhibit.ts
@@ -2,6 +2,33 @@ import * as THREE from 'three';
 import type { ClusterId } from './clusters';
 import type { Pointer } from './Pointer';
 
+/**
+ * Per-scene staging metadata for the shell-driven spawn pose (#263).
+ *
+ * Shell consumes only spawn poses; the scene composes them at module
+ * load via `scaffold/staging/clusterStagePose.ts`. The plinth anchor
+ * itself stays scene-local (consumed by the per-scene `createPlinth`
+ * call) and intentionally is NOT exposed here — keeping the shell's
+ * seam to spawn data only.
+ */
+export interface ExhibitStageMetadata {
+  /**
+   * Pancake camera initial position in world coords. Shell sets
+   * `camera.position` to this on boot AND on every pancake mount
+   * swap, then calls `controls.saveState()` to refresh the reset
+   * baseline.
+   */
+  readonly pancakeSpawnWorldXYZ: readonly [number, number, number];
+  /**
+   * VR `local-floor` reference-space offset in world coords. Shell
+   * applies as `XRRigidTransform({-x, -y, -z}, identity)` on
+   * session start; the HMD then reports pose in the offset space.
+   * PR1 (#263) applies on `sessionstart` only; in-session scene-rack
+   * hops in VR keep the prior offset. Follow-up: §7 of the #263 plan.
+   */
+  readonly vrSpawnOffsetWorldXYZ: readonly [number, number, number];
+}
+
 export interface ExhibitContext {
   // Per-exhibit root group (#150). The shell creates this on mount and
   // removes it on unmount — exhibits add their content to `group`, not
@@ -30,6 +57,13 @@ export interface Exhibit {
   // `hello` leaves it unset — it's a toolchain smoke test, not a cluster
   // member.
   cluster?: ClusterId;
+  /**
+   * Per-scene staging metadata for the shell's spawn pose (#263).
+   * Absent → cluster-uniform fallback (`shell/stagePose.ts` constants:
+   * pancake `(0, 1.6, 3.7)`, VR offset `(0, 0, 1.5)`). Non-cluster
+   * exhibits (today: `hello`) leave this unset.
+   */
+  stage?: ExhibitStageMetadata;
   mount(ctx: ExhibitContext): void;
   update(frame: ExhibitFrame): void;
   // `unmount` is required as of #150 step 4: exhibits dispose owned GPU

--- a/src/shell/SceneRack.ts
+++ b/src/shell/SceneRack.ts
@@ -23,15 +23,15 @@ import type { Pointer } from './Pointer';
 //     `SECTION_TAB_RACK_X` (also lines up with the post-plinth
 //     `PLINTH_SECTION_TAB_X = -0.42` within ~2 cm so the two racks
 //     read as one vertical column).
-//   * `SCENE_RACK_Z = 0.05` — tracks
-//     `quadrics PLINTH_ANCHOR_WORLD_XYZ.z` so the SceneRack bulbs
-//     sit directly above the plinth front edge instead of being
-//     stranded over the cutout (#225 PR1 v2 smoke: pre-PR1 z = -0.7
-//     left the bulbs floating over the math-object rendering box
-//     after the plinth shifted forward). The 0.75 m offset from the
-//     other three cluster scenes' still-pre-plinth UI at z = -0.7
-//     is a temporary mismatch that PR2 (#251) closes when those
-//     scenes port onto the same primitive.
+//   * Tab-local Z = 0 (#263 follow-up). Pre-#263 this was baked at
+//     0.05 to track quadrics' cluster-uniform plinth anchor; the
+//     per-scene wire-up moved that knob to `rack.group.position.z`,
+//     which the shell sets to each scene's `rackAnchorWorldXYZ`
+//     (= the plinth anchor) on boot + every mount swap. So the
+//     world Z of each tab equals the per-scene plinth anchor Z
+//     directly, and the rack tracks the plinth across SceneRack
+//     hops instead of floating ahead of it in smaller-envelope
+//     scenes.
 //   * `SCENE_TAB_PITCH = 0.20` — horizontal spacing between tabs.
 // These constants live here (rather than in SceneTab) because they
 // are layout concerns for the rack as a whole; per-tab visuals
@@ -39,7 +39,6 @@ import type { Pointer } from './Pointer';
 
 const SCENE_RACK_Y = 1.73;
 const SCENE_RACK_CENTER_X = -0.44;
-const SCENE_RACK_Z = 0.05;
 const SCENE_TAB_PITCH = 0.20;
 
 export interface SceneRackOptions {
@@ -87,7 +86,7 @@ export class SceneRack {
       // straddling the column; odd N reads as one tab on-axis with
       // the SectionTab column beneath, which is the visual we want.
       const x = SCENE_RACK_CENTER_X + (i - (n - 1) / 2) * SCENE_TAB_PITCH;
-      tab.group.position.set(x, SCENE_RACK_Y, SCENE_RACK_Z);
+      tab.group.position.set(x, SCENE_RACK_Y, 0);
       this.group.add(tab.group);
       tabs.push(tab);
     }

--- a/src/shell/cameraControls.ts
+++ b/src/shell/cameraControls.ts
@@ -21,19 +21,20 @@ const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
  * `OrbitControls` wrapper configured for the cluster's spatial
  * envelope (pancake plan v3 §3.3, parent #105, this issue #192).
  *
- * Leaf module — not yet consumed. #193 wires this into `bootShell()`
- * behind the desktop boot path. Until then, this module is
- * purely additive.
+ * Per-scene spawn pose as of #263. `spawnWorldXYZ` is the initial
+ * camera position — derived per-scene from the cluster stage-pose
+ * helper (`scaffold/staging/clusterStagePose.ts`), or the cluster-
+ * uniform fallback `(0, 1.6, 3.7)` for non-cluster exhibits.
  *
  * Mutations applied at construction time:
  *
  * 1. `controls.target` set to `SURFACE_CENTER` so user-driven orbit
- *    rotates around the cluster anchor.
- * 2. `camera.position` overrides the unused-in-XR pre-session
- *    `(0, 1.6, 3)` set at `shell.ts:94`. Desktop mode is the first
- *    time the `PerspectiveCamera`'s position matters at render time
- *    — XR renders via an `ArrayCamera` driven by HMD pose, not this
- *    `PerspectiveCamera` (pancake plan v3 §3.3, S5 / G10).
+ *    rotates around the cluster anchor (cluster-uniform; the math
+ *    object stays put across scene-hops per #263 §1).
+ * 2. `camera.position` set to the boot exhibit's `spawnWorldXYZ`.
+ *    XR renders via an `ArrayCamera` driven by HMD pose, not this
+ *    `PerspectiveCamera` (pancake plan v3 §3.3, S5 / G10) — the
+ *    `spawnWorldXYZ` parameter is pancake-mode only.
  * 3. `camera.lookAt(SURFACE_CENTER)` runs **after** the OrbitControls
  *    constructor (which itself calls `update()` against the default
  *    `target = (0,0,0)` and would re-orient + reposition the camera).
@@ -53,7 +54,8 @@ const SURFACE_CENTER = new THREE.Vector3(0, 1.5, -4);
  */
 export function createCameraControls(
   camera: THREE.PerspectiveCamera,
-  domElement: HTMLElement | null = null,
+  domElement: HTMLElement | null,
+  spawnWorldXYZ: readonly [number, number, number],
 ): OrbitControls {
   const controls = new OrbitControls(camera, domElement);
 
@@ -70,21 +72,7 @@ export function createCameraControls(
   // configuration, not whatever spherical the constructor derived
   // against the default `target = (0, 0, 0)`.
   controls.target.copy(SURFACE_CENTER);
-  // Pancake spawn pose (#240; v2 #225 PR1). Z = 3.7 places the
-  // camera ~7.7 m from `SURFACE_CENTER`, leaving ~2.2 m of foreground
-  // floor visible between the user and quadrics' cutout near-edge
-  // (the tightest of the four cluster scenes' StageFloor cutouts at
-  // z = -0.5). Original #240 pose was Z = 3 (~1.5 m foreground);
-  // shifted +0.7 m in +world-Z alongside the plinth lift (#225 PR1
-  // first-smoke maintainer feedback) so the user spawns on the same
-  // side of the inner railing as the plinth's interactables rather
-  // than orbiting in from "behind" the controls. Earlier #240 pose
-  // `(0, 1.6, 0)` placed the camera right at the front of every
-  // cutout — no foreground floor on first paint. Z values that
-  // expose foreground depend on the shell's vertical FOV = 75°
-  // (`shell.ts:86`); the math derivation is in
-  // `_private/plans/240-pancake-default-camera.md` §3.
-  camera.position.set(0, 1.6, 3.7);
+  camera.position.set(spawnWorldXYZ[0], spawnWorldXYZ[1], spawnWorldXYZ[2]);
   camera.lookAt(SURFACE_CENTER);
 
   // Re-seed OrbitControls' internal `_lastPosition` from the corrected
@@ -100,9 +88,34 @@ export function createCameraControls(
   // this, `position0` / `target0` carry the constructor-time pre-
   // overwrite values (default target = origin, pre-init camera
   // position) and `controls.reset()` would teleport to the wrong pose.
+  // `applyPancakeSpawnForExhibit` re-snapshots after every scene-hop
+  // so reset goes back to the current scene's pose, not the boot pose.
   controls.saveState();
 
   return controls;
+}
+
+/**
+ * Reposition the pancake camera + refresh OrbitControls reset
+ * baseline for a newly-mounted exhibit (#263 §3.3). Called from
+ * `switchExhibitNow` in `shell.ts` after `target.mount(ctx)` when
+ * `cameraControls !== null` (pancake-mode guard).
+ *
+ * Keeps `target` at `SURFACE_CENTER` defensively — the math object
+ * stays put across scene-hops, so the orbit pivot is invariant.
+ * `controls.saveState()` snapshots the new pose so `reset()` goes
+ * back to the current scene's spawn, not the boot scene's.
+ */
+export function applyPancakeSpawnForExhibit(
+  camera: THREE.PerspectiveCamera,
+  controls: OrbitControls,
+  spawnWorldXYZ: readonly [number, number, number],
+): void {
+  camera.position.set(spawnWorldXYZ[0], spawnWorldXYZ[1], spawnWorldXYZ[2]);
+  camera.lookAt(SURFACE_CENTER);
+  controls.target.copy(SURFACE_CENTER);
+  controls.update();
+  controls.saveState();
 }
 
 export { SURFACE_CENTER };

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -581,6 +581,17 @@ async function bootShellAsync(): Promise<void> {
     grabRadiusMultiplier: 2.75,
     onSelect: (id) => scheduler.requestSwitch(id, 'push'),
   });
+  // Position the rack at the boot exhibit's per-scene anchor (#263
+  // follow-up). Refreshed in `switchExhibitNow` on every mount swap
+  // so the rack tracks the per-scene plinth across SceneRack hops.
+  // SceneRack's tab-local Z is 0 (zeroed-out in `SceneRack.ts` as
+  // part of the same follow-up), so writing `rack.group.position`
+  // here drives the tabs' world Z directly.
+  {
+    const rackAnchor =
+      resolveStagePose(initialBootExhibit).rackAnchorWorldXYZ;
+    rack.group.position.set(rackAnchor[0], rackAnchor[1], rackAnchor[2]);
+  }
   scene.add(rack.group);
   // scene.fog material audit (#224 plan §3.5, amended at impl). The
   // fogNear≥14 linear-fog invariant provably un-fogs all near-field
@@ -666,13 +677,26 @@ async function bootShellAsync(): Promise<void> {
     // mount may have hopped between scenes, but the VR offset stays
     // at the prior `sessionstart` value per the #263 §3.4 PR1
     // decision; in-session re-offset is the §7 follow-up.
+    const targetStage = resolveStagePose(target);
     if (cameraControls !== null) {
       applyPancakeSpawnForExhibit(
         camera,
         cameraControls,
-        resolveStagePose(target).pancakeSpawnWorldXYZ,
+        targetStage.pancakeSpawnWorldXYZ,
       );
     }
+    // Per-scene rack position (#263 follow-up — fixes the plan §1
+    // gap that the v3 sanity check missed). The rack follows the
+    // per-scene plinth anchor so the bulbs sit above the plinth
+    // front face in every cluster scene, not floating ahead of it
+    // in the smaller-envelope scenes. Mode-agnostic — VR also needs
+    // the rack at the new scene's anchor since the rack is shell-
+    // owned, not plinth-owned.
+    rack.group.position.set(
+      targetStage.rackAnchorWorldXYZ[0],
+      targetStage.rackAnchorWorldXYZ[1],
+      targetStage.rackAnchorWorldXYZ[2],
+    );
   }
 
   const scheduler = createSwitchScheduler({ commit: switchExhibitNow });

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -16,7 +16,8 @@ import {
 import type { Pointer } from './Pointer';
 import { VRPointer } from './VRPointer';
 import { DesktopPointer } from './DesktopPointer';
-import { createCameraControls } from './cameraControls';
+import { applyPancakeSpawnForExhibit, createCameraControls } from './cameraControls';
+import { resolveStagePose } from './stagePose';
 import { createEnvironment } from '@/scaffold/staging/Environment';
 import { FpsOverlay } from '@/scaffold/perf/FpsOverlay';
 
@@ -49,23 +50,6 @@ import { FpsOverlay } from '@/scaffold/perf/FpsOverlay';
 let booted = false;
 let bootGeneration = 0;
 const disposers: Array<() => void> = [];
-
-/**
- * VR-spawn forward distance, world meters. The XR session-start
- * handler in `bootShellAsync` translates the reference space so the
- * user spawns at world `(0, ~head-height, +VR_SPAWN_FORWARD_Z_M)`.
- *
- * Chosen against the plinth front face at world `z = 0.05` (anchor =
- * `PLINTH_ANCHOR_WORLD_XYZ.z = 0.05`, depth extends back to
- * `-PLINTH_BODY_DEPTH = -0.25` per `scaffold/staging/Plinth.ts`).
- * `1.5` puts the user ~1.45 m forward of the plinth's user-facing
- * face — clear of the plinth volume with arm's-length reach to the
- * working surface.
- *
- * Cluster-uniform stopgap for #262. Per-scene-adaptive offset
- * (deriving from each scene's inner-railing geometry) is #263.
- */
-const VR_SPAWN_FORWARD_Z_M = 1.5;
 
 /**
  * World-frame anchor for the `?fps=1`-gated dev FPS overlay (#261).
@@ -134,12 +118,14 @@ async function bootShellAsync(): Promise<void> {
     0.1,
     100,
   );
-  // Pre-mode camera position; overwritten by `createCameraControls` in
-  // desktop mode and unused-in-XR (HMD pose drives an `ArrayCamera`)
-  // in VR mode. Z = 3.7 (was 3 pre-#225 PR1 smoke) — shifted +0.7 m
-  // in +world-Z alongside the plinth so the user spawns on the same
-  // side of the inner railing as the plinth's interactables.
-  camera.position.set(0, 1.6, 3.7);
+  // Pre-mode camera position is left at the `PerspectiveCamera`
+  // constructor default `(0, 0, 0)`. Pancake mode overwrites via
+  // `createCameraControls(..., spawnWorldXYZ)` below; VR mode renders
+  // through an `ArrayCamera` driven by HMD pose, so the
+  // `PerspectiveCamera`'s pre-mode position never matters there.
+  // Pre-#263 this line was `camera.position.set(0, 1.6, 3.7)` — the
+  // cluster-uniform spawn — but per-scene spawn lives in the boot
+  // exhibit's stage metadata now.
 
   const renderer = new THREE.WebGLRenderer({ antialias: true });
   renderer.setSize(window.innerWidth, window.innerHeight);
@@ -206,6 +192,31 @@ async function bootShellAsync(): Promise<void> {
   }
   const defaultId = clusterExhibits[0].id;
 
+  // Boot-exhibit resolution hoisted before mode branch (#263). The
+  // pancake `createCameraControls` call needs the boot exhibit's
+  // `pancakeSpawnWorldXYZ` for its initial pose, and the VR
+  // `applyVRSpawnOffsetForExhibit` closure needs an initial fallback
+  // for sessionstart before `currentExhibit` is assigned. The same
+  // `bootRequestedParam` rides through to `scheduler.requestSwitch` below
+  // so the initial mount path stays unchanged.
+  const bootRequestedParam = new URLSearchParams(window.location.search).get(
+    'exhibit',
+  );
+  const { id: bootInitialId } = resolveExhibitId(
+    bootRequestedParam,
+    clusterExhibits,
+  );
+  const initialBootExhibit = clusterExhibits.find((e) => e.id === bootInitialId)!;
+
+  // VR base reference-space snapshot (#263 §3.3). Stored on
+  // `sessionstart`, cleared on `sessionend`. The base is the
+  // UNOFFSET `local-floor` space; offsets ALWAYS derive from this
+  // snapshot rather than from `renderer.xr.getReferenceSpace()`,
+  // which returns the currently-offset space after the first call
+  // and would stack on re-application. VR branch only writes; VR
+  // closures + (deferred) follow-up reads.
+  let baseXRReferenceSpace: XRReferenceSpace | null = null;
+
   // Mode resolution (#189 + #193, pancake plan v3 §3.2). Explicit
   // `?mode=` always wins; otherwise the async `isSessionSupported`
   // probe distinguishes a real headset from a desktop browser that
@@ -252,42 +263,64 @@ async function bootShellAsync(): Promise<void> {
     // in motion at the Quest 3S panel's pixel density. SPEC.md `## Frame-pacing
     // knobs` named this as the next deferred knob; this is its first land.
     renderer.xr.setFramebufferScaleFactor(0.85);
-    // VR spawn offset (#262). The default `local-floor` reference space
-    // origin sits at world (0, 0, 0), which after #225 PR1 + PR2 is
-    // *inside* the plinth body (world x ∈ ±0.45, y ∈ [0, 0.95],
-    // z ∈ [-0.25, +0.05] for `PLINTH_ANCHOR_WORLD_XYZ = [0, 0, 0.05]`
-    // and `PLINTH_BODY_DEPTH = 0.3`). On session start, translate the
-    // reference space so the user spawns at world (0, ~1.6, +1.5) —
-    // ~1.45 m forward of the plinth's user-facing front face at
-    // z = 0.05, with clear sightlines onto the math object beyond the
-    // inner railing.
+    // VR spawn offset (#262 → #263). The default `local-floor`
+    // reference space origin sits at world (0, 0, 0), which is
+    // *inside* every cluster scene's plinth body (anchor at
+    // floor-footprint center, body Z range
+    // `[anchor.z - PLINTH_BODY_DEPTH, anchor.z]`). On session start,
+    // snapshot the unoffset reference space and translate by the
+    // currently-mounted exhibit's per-scene `vrSpawnOffsetWorldXYZ`
+    // so the user spawns ~1.45 m forward of that scene's plinth
+    // front face.
     //
     // Sign convention: `XRReferenceSpace.getOffsetReferenceSpace(origin)`
     // returns a new space whose origin, *expressed in the base space*,
     // sits at `origin.position`. HMD pose is then reported in the new
-    // space's coordinates, so to make the HMD report `+1.5` in z we
-    // place the new space's origin at `-1.5` in the base. The HMD's
-    // y component stays floor-relative (head height) regardless of
-    // this offset.
+    // space's coordinates — to make the HMD report `+offsetZ`, place
+    // the new space's origin at `-offsetZ` in the base. The HMD's y
+    // component stays floor-relative (head height) regardless.
     //
-    // Cluster-uniform stopgap. Per-scene-adaptive spawn is #263; this
-    // bare offset just gets the user out of the plinth volume for the
-    // current four-scene cluster.
-    const onXrSessionStart = (): void => {
-      const baseReferenceSpace = renderer.xr.getReferenceSpace();
-      if (!baseReferenceSpace) return;
+    // PR1 applies the offset on `sessionstart` only; in-session
+    // scene-rack hops in VR keep the prior offset. The receding-
+    // plinth UX on cross-envelope hops is the accepted PR1 trade-off
+    // (#263 §3.4 + §7 follow-up: the helper is wire-up-ready, the
+    // §6 smoke verdict on quadrics→tangent-planes hops decides
+    // priority).
+    const applyVRSpawnOffsetForExhibit = (exhibit: Exhibit | null): void => {
+      if (!renderer.xr.isPresenting) return;
+      if (!baseXRReferenceSpace) return;
+      const { vrSpawnOffsetWorldXYZ } = resolveStagePose(
+        exhibit ?? initialBootExhibit,
+      );
       const originOffset = new XRRigidTransform(
-        { x: 0, y: 0, z: -VR_SPAWN_FORWARD_Z_M },
+        {
+          x: -vrSpawnOffsetWorldXYZ[0],
+          y: -vrSpawnOffsetWorldXYZ[1],
+          z: -vrSpawnOffsetWorldXYZ[2],
+        },
         { x: 0, y: 0, z: 0, w: 1 },
       );
+      // ALWAYS derive from the stored base, never from
+      // `renderer.xr.getReferenceSpace()` (which returns the
+      // currently-offset space after the first call → stacking).
       const offsetSpace =
-        baseReferenceSpace.getOffsetReferenceSpace(originOffset);
+        baseXRReferenceSpace.getOffsetReferenceSpace(originOffset);
       renderer.xr.setReferenceSpace(offsetSpace);
     };
+    const onXrSessionStart = (): void => {
+      baseXRReferenceSpace = renderer.xr.getReferenceSpace();
+      if (!baseXRReferenceSpace) return;
+      applyVRSpawnOffsetForExhibit(currentExhibit);
+    };
+    const onXrSessionEnd = (): void => {
+      baseXRReferenceSpace = null;
+    };
     renderer.xr.addEventListener('sessionstart', onXrSessionStart);
-    disposers.push(() =>
-      renderer.xr.removeEventListener('sessionstart', onXrSessionStart),
-    );
+    renderer.xr.addEventListener('sessionend', onXrSessionEnd);
+    disposers.push(() => {
+      renderer.xr.removeEventListener('sessionstart', onXrSessionStart);
+      renderer.xr.removeEventListener('sessionend', onXrSessionEnd);
+    });
     const vrButton = VRButton.createButton(renderer);
     document.body.appendChild(vrButton);
     disposers.push(() => vrButton.remove());
@@ -365,7 +398,11 @@ async function bootShellAsync(): Promise<void> {
     // pointer's diagnostic `id`; plan v3 §3.4's "Pointer abstraction
     // tolerates the divergence" cashes out as a single shell branch
     // here.
-    cameraControls = createCameraControls(camera, renderer.domElement);
+    cameraControls = createCameraControls(
+      camera,
+      renderer.domElement,
+      resolveStagePose(initialBootExhibit).pancakeSpawnWorldXYZ,
+    );
     const cameraControlsRef = cameraControls;
     disposers.push(() => cameraControlsRef.dispose());
     // `DesktopPointer` is the camera-NDC `Pointer` adapter; the `id`
@@ -621,6 +658,21 @@ async function bootShellAsync(): Promise<void> {
     target.mount(ctx);
     currentExhibit = target;
     currentCtx = ctx;
+
+    // Per-scene pancake spawn (#263 §3.3 + §4.1 step 5). Reposition
+    // the camera + refresh OrbitControls reset baseline for the
+    // newly-mounted exhibit. Pancake-mode guard via `cameraControls !==
+    // null` (VR mode leaves `cameraControls` null). For VR mode this
+    // mount may have hopped between scenes, but the VR offset stays
+    // at the prior `sessionstart` value per the #263 §3.4 PR1
+    // decision; in-session re-offset is the §7 follow-up.
+    if (cameraControls !== null) {
+      applyPancakeSpawnForExhibit(
+        camera,
+        cameraControls,
+        resolveStagePose(target).pancakeSpawnWorldXYZ,
+      );
+    }
   }
 
   const scheduler = createSwitchScheduler({ commit: switchExhibitNow });
@@ -652,12 +704,11 @@ async function bootShellAsync(): Promise<void> {
   // small (handful of allocations at boot); efficacy is measured
   // in headset smoke (§7) and we file a follow-up if first-switch
   // visibly stalls.
-  const requestedParam = new URLSearchParams(window.location.search).get(
-    'exhibit',
-  );
-  const { id: initialId } = resolveExhibitId(requestedParam, clusterExhibits);
+  // `bootRequestedParam` + `bootInitialId` were resolved up-front
+  // (above the mode branch) for the per-scene boot spawn; reuse them
+  // here for the warm-up filter.
   for (const e of clusterExhibits) {
-    if (e.id === initialId) continue;
+    if (e.id === bootInitialId) continue;
     const warmGroup = new THREE.Group();
     warmGroup.name = `warm:${e.id}`;
     scene.add(warmGroup);
@@ -676,10 +727,10 @@ async function bootShellAsync(): Promise<void> {
   // Initial-boot mount: route through the same scheduler so the
   // `'replace'` history mode normalizes a bogus / non-cluster /
   // empty `?exhibit=` without leaving a forward history entry the
-  // user has to back through. The raw `requestedParam` (which may
+  // user has to back through. The raw `bootRequestedParam` (which may
   // be null for a bare URL) rides through unchanged so the
   // resolver can keep the bare-URL boot silent.
-  scheduler.requestSwitch(requestedParam, 'replace');
+  scheduler.requestSwitch(bootRequestedParam, 'replace');
 
   const timer = new THREE.Timer();
   // Page Visibility integration: prevents huge delta spikes after the tab

--- a/src/shell/stagePose.ts
+++ b/src/shell/stagePose.ts
@@ -31,9 +31,23 @@ export const CLUSTER_FALLBACK_VR_SPAWN_OFFSET_WORLD_XYZ = [
   0, 0, 1.5,
 ] as const;
 
+/**
+ * Cluster-uniform fallback for the SceneRack world-space anchor.
+ * Matches the pre-#263 quadrics plinth anchor `(0, 0, 0.05)` —
+ * `SceneRack` originally baked `SCENE_RACK_Z = 0.05` into tab-local
+ * positions; the per-scene wire-up moved that knob to the
+ * `rack.group.position` so the rack tracks the per-scene plinth
+ * anchor. Non-cluster exhibits land here so direct dev imports of
+ * e.g. `hello` render the rack at the original world Z.
+ */
+export const CLUSTER_FALLBACK_RACK_ANCHOR_WORLD_XYZ = [
+  0, 0, 0.05,
+] as const;
+
 export interface ResolvedStagePose {
   readonly pancakeSpawnWorldXYZ: readonly [number, number, number];
   readonly vrSpawnOffsetWorldXYZ: readonly [number, number, number];
+  readonly rackAnchorWorldXYZ: readonly [number, number, number];
 }
 
 export function resolveStagePose(exhibit: Exhibit): ResolvedStagePose {
@@ -44,5 +58,8 @@ export function resolveStagePose(exhibit: Exhibit): ResolvedStagePose {
     vrSpawnOffsetWorldXYZ:
       exhibit.stage?.vrSpawnOffsetWorldXYZ
       ?? CLUSTER_FALLBACK_VR_SPAWN_OFFSET_WORLD_XYZ,
+    rackAnchorWorldXYZ:
+      exhibit.stage?.rackAnchorWorldXYZ
+      ?? CLUSTER_FALLBACK_RACK_ANCHOR_WORLD_XYZ,
   };
 }

--- a/src/shell/stagePose.ts
+++ b/src/shell/stagePose.ts
@@ -1,0 +1,48 @@
+import type { Exhibit } from './Exhibit';
+
+// Pure shell-side resolver for per-scene spawn poses (#263). Owns the
+// cluster-uniform fallback constants used when an exhibit doesn't
+// declare its own `stage` metadata (today: `hello`, and historically
+// any pre-#263-style exhibit).
+//
+// Pure module: no Three.js, no DOM, no renderer side effects. Vitest
+// imports cleanly. The shell calls `resolveStagePose(exhibit)` at boot
+// (to drive `createCameraControls`'s initial spawn and the
+// `onXrSessionStart` offset) and on every successful mount swap (to
+// drive `applyPancakeSpawnForExhibit`).
+
+/**
+ * Cluster-uniform fallback for pancake camera spawn. Matches today's
+ * pre-#263 cluster-uniform pose (`shell.ts:142` and
+ * `cameraControls.ts:87`). For cluster scenes the composed value from
+ * `composeClusterStagePose` is used instead; this constant only
+ * applies to exhibits that leave `stage` unset.
+ */
+export const CLUSTER_FALLBACK_PANCAKE_SPAWN_WORLD_XYZ = [
+  0, 1.6, 3.7,
+] as const;
+
+/**
+ * Cluster-uniform fallback for VR `local-floor` reference-space
+ * offset. Matches today's #262 stopgap (`shell.ts:68` had
+ * `VR_SPAWN_FORWARD_Z_M = 1.5`).
+ */
+export const CLUSTER_FALLBACK_VR_SPAWN_OFFSET_WORLD_XYZ = [
+  0, 0, 1.5,
+] as const;
+
+export interface ResolvedStagePose {
+  readonly pancakeSpawnWorldXYZ: readonly [number, number, number];
+  readonly vrSpawnOffsetWorldXYZ: readonly [number, number, number];
+}
+
+export function resolveStagePose(exhibit: Exhibit): ResolvedStagePose {
+  return {
+    pancakeSpawnWorldXYZ:
+      exhibit.stage?.pancakeSpawnWorldXYZ
+      ?? CLUSTER_FALLBACK_PANCAKE_SPAWN_WORLD_XYZ,
+    vrSpawnOffsetWorldXYZ:
+      exhibit.stage?.vrSpawnOffsetWorldXYZ
+      ?? CLUSTER_FALLBACK_VR_SPAWN_OFFSET_WORLD_XYZ,
+  };
+}

--- a/test/exhibits/cluster-stage-pose.test.ts
+++ b/test/exhibits/cluster-stage-pose.test.ts
@@ -37,6 +37,11 @@ describe('quadrics', () => {
       expected.vrSpawnOffsetWorldXYZ,
     );
   });
+  it('registers the rack anchor = plinth anchor', () => {
+    expect(quadrics.stage?.rackAnchorWorldXYZ).toStrictEqual(
+      expected.plinthAnchorWorldXYZ,
+    );
+  });
 });
 
 describe('tangent-planes', () => {
@@ -55,6 +60,11 @@ describe('tangent-planes', () => {
   it('registers the cutout-derived VR spawn offset', () => {
     expect(tangentPlanes.stage?.vrSpawnOffsetWorldXYZ).toStrictEqual(
       expected.vrSpawnOffsetWorldXYZ,
+    );
+  });
+  it('registers the rack anchor = plinth anchor', () => {
+    expect(tangentPlanes.stage?.rackAnchorWorldXYZ).toStrictEqual(
+      expected.plinthAnchorWorldXYZ,
     );
   });
 });
@@ -78,6 +88,11 @@ describe('gradient-levels', () => {
       expected.vrSpawnOffsetWorldXYZ,
     );
   });
+  it('registers the rack anchor = plinth anchor', () => {
+    expect(gradientLevels.stage?.rackAnchorWorldXYZ).toStrictEqual(
+      expected.plinthAnchorWorldXYZ,
+    );
+  });
 });
 
 describe('saddle-extrema', () => {
@@ -97,6 +112,11 @@ describe('saddle-extrema', () => {
   it('registers the cutout-derived VR spawn offset', () => {
     expect(saddleExtrema.stage?.vrSpawnOffsetWorldXYZ).toStrictEqual(
       expected.vrSpawnOffsetWorldXYZ,
+    );
+  });
+  it('registers the rack anchor = plinth anchor', () => {
+    expect(saddleExtrema.stage?.rackAnchorWorldXYZ).toStrictEqual(
+      expected.plinthAnchorWorldXYZ,
     );
   });
 });

--- a/test/exhibits/cluster-stage-pose.test.ts
+++ b/test/exhibits/cluster-stage-pose.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { composeClusterStagePose } from '@/scaffold/staging/clusterStagePose';
+import quadrics from '@/exhibits/quadrics';
+import tangentPlanes from '@/exhibits/tangent-planes';
+import gradientLevels from '@/exhibits/gradient-levels';
+import saddleExtrema from '@/exhibits/saddle-extrema';
+
+// Per-scene `Exhibit.stage` registration regression guard (#263 §4.2).
+// Catches a scene editor who changes the cutout half-extent (or any
+// other helper input) without re-checking the spawn-pose registration.
+//
+// Per the v2 → v3 plan revision (Sonnet v2 #2): the test compares
+// spawn-pose fields (`pancakeSpawnWorldXYZ` / `vrSpawnOffsetWorldXYZ`)
+// against the helper output, NOT `plinthAnchorWorldXYZ`. The plinth-
+// anchor field lives on `ClusterStagePose` (scaffold helper) but is
+// deliberately absent from `ExhibitStageMetadata` (`shell/Exhibit.ts`)
+// per the §3.2 shell-consumer-only invariant. Comparing spawn poses
+// gives equivalent regression coverage (both derive from the same
+// anchor arithmetic) without breaking the type invariant.
+
+describe('quadrics', () => {
+  const expected = composeClusterStagePose({
+    cutout: {
+      kind: 'rect' as const,
+      centerXZ: [0, -4] as const,
+      halfExtentX: 3.675,
+      halfExtentZ: 3.675,
+    },
+  });
+  it('registers the cutout-derived pancake spawn', () => {
+    expect(quadrics.stage?.pancakeSpawnWorldXYZ).toStrictEqual(
+      expected.pancakeSpawnWorldXYZ,
+    );
+  });
+  it('registers the cutout-derived VR spawn offset', () => {
+    expect(quadrics.stage?.vrSpawnOffsetWorldXYZ).toStrictEqual(
+      expected.vrSpawnOffsetWorldXYZ,
+    );
+  });
+});
+
+describe('tangent-planes', () => {
+  const expected = composeClusterStagePose({
+    cutout: {
+      kind: 'circle' as const,
+      centerXZ: [0, -4] as const,
+      radius: 1.5,
+    },
+  });
+  it('registers the cutout-derived pancake spawn', () => {
+    expect(tangentPlanes.stage?.pancakeSpawnWorldXYZ).toStrictEqual(
+      expected.pancakeSpawnWorldXYZ,
+    );
+  });
+  it('registers the cutout-derived VR spawn offset', () => {
+    expect(tangentPlanes.stage?.vrSpawnOffsetWorldXYZ).toStrictEqual(
+      expected.vrSpawnOffsetWorldXYZ,
+    );
+  });
+});
+
+describe('gradient-levels', () => {
+  const expected = composeClusterStagePose({
+    cutout: {
+      kind: 'rect' as const,
+      centerXZ: [0, -4] as const,
+      halfExtentX: 3.0,
+      halfExtentZ: 3.0,
+    },
+  });
+  it('registers the cutout-derived pancake spawn', () => {
+    expect(gradientLevels.stage?.pancakeSpawnWorldXYZ).toStrictEqual(
+      expected.pancakeSpawnWorldXYZ,
+    );
+  });
+  it('registers the cutout-derived VR spawn offset', () => {
+    expect(gradientLevels.stage?.vrSpawnOffsetWorldXYZ).toStrictEqual(
+      expected.vrSpawnOffsetWorldXYZ,
+    );
+  });
+});
+
+describe('saddle-extrema', () => {
+  const expected = composeClusterStagePose({
+    cutout: {
+      kind: 'rect' as const,
+      centerXZ: [0, -4] as const,
+      halfExtentX: 1.575,
+      halfExtentZ: 1.575,
+    },
+  });
+  it('registers the cutout-derived pancake spawn', () => {
+    expect(saddleExtrema.stage?.pancakeSpawnWorldXYZ).toStrictEqual(
+      expected.pancakeSpawnWorldXYZ,
+    );
+  });
+  it('registers the cutout-derived VR spawn offset', () => {
+    expect(saddleExtrema.stage?.vrSpawnOffsetWorldXYZ).toStrictEqual(
+      expected.vrSpawnOffsetWorldXYZ,
+    );
+  });
+});

--- a/test/scaffold/staging/clusterStagePose.test.ts
+++ b/test/scaffold/staging/clusterStagePose.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PANCAKE_SPAWN_PADDING_Z_M_DEFAULT,
+  PLINTH_BODY_BACK_CLEARANCE_DEFAULT,
+  VR_SPAWN_PADDING_Z_M_DEFAULT,
+  composeClusterStagePose,
+} from '@/scaffold/staging/clusterStagePose';
+
+// Pure-helper coverage for the per-scene plinth-anchor + spawn-pose
+// derivation (#263). The four scene-specific cases hit the actual
+// cluster's cutout descriptors so a regression in the helper
+// (changed defaults, busted arithmetic) flips them immediately.
+//
+// Quadrics is the calibration case: the pre-#263 cluster-uniform
+// literals `[0, 0, 0.05]` / `[0, 1.6, 3.7]` / `[0, 0, 1.5]` are
+// exact-equal expected outputs (`roundToMm` ensures strict equality,
+// not just `toBeCloseTo`).
+
+describe('composeClusterStagePose — quadrics calibration', () => {
+  // Quadrics: rect cutout, halfExtentZ = BOUND × CUTOUT_VISUAL_MARGIN
+  // = 3.5 × 1.05 = 3.675, centered at world (0, -4).
+  const QUADRICS_CUTOUT = {
+    kind: 'rect' as const,
+    centerXZ: [0, -4] as const,
+    halfExtentX: 3.675,
+    halfExtentZ: 3.675,
+  };
+
+  it('returns the calibrated plinth anchor [0, 0, 0.05] under strict equality', () => {
+    const pose = composeClusterStagePose({ cutout: QUADRICS_CUTOUT });
+    expect(pose.plinthAnchorWorldXYZ).toStrictEqual([0, 0, 0.05]);
+  });
+
+  it('returns the calibrated pancake spawn [0, 1.6, 3.7]', () => {
+    const pose = composeClusterStagePose({ cutout: QUADRICS_CUTOUT });
+    expect(pose.pancakeSpawnWorldXYZ).toStrictEqual([0, 1.6, 3.7]);
+  });
+
+  it('returns the calibrated VR offset [0, 0, 1.5]', () => {
+    const pose = composeClusterStagePose({ cutout: QUADRICS_CUTOUT });
+    expect(pose.vrSpawnOffsetWorldXYZ).toStrictEqual([0, 0, 1.5]);
+  });
+});
+
+describe('composeClusterStagePose — per-scene cases', () => {
+  it('tangent-planes (circle, radius 1.5) → anchor [0, 0, -2.125]', () => {
+    const pose = composeClusterStagePose({
+      cutout: {
+        kind: 'circle' as const,
+        centerXZ: [0, -4] as const,
+        radius: 1.5,
+      },
+    });
+    expect(pose.plinthAnchorWorldXYZ).toStrictEqual([0, 0, -2.125]);
+    expect(pose.pancakeSpawnWorldXYZ).toStrictEqual([0, 1.6, 1.525]);
+    expect(pose.vrSpawnOffsetWorldXYZ).toStrictEqual([0, 0, -0.675]);
+  });
+
+  it('gradient-levels (rect, halfExtentZ 3.0) → anchor [0, 0, -0.625]', () => {
+    const pose = composeClusterStagePose({
+      cutout: {
+        kind: 'rect' as const,
+        centerXZ: [0, -4] as const,
+        halfExtentX: 3.0,
+        halfExtentZ: 3.0,
+      },
+    });
+    expect(pose.plinthAnchorWorldXYZ).toStrictEqual([0, 0, -0.625]);
+    expect(pose.pancakeSpawnWorldXYZ).toStrictEqual([0, 1.6, 3.025]);
+    expect(pose.vrSpawnOffsetWorldXYZ).toStrictEqual([0, 0, 0.825]);
+  });
+
+  it('saddle-extrema (rect, halfExtentZ 1.575) → anchor [0, 0, -2.05]', () => {
+    const pose = composeClusterStagePose({
+      cutout: {
+        kind: 'rect' as const,
+        centerXZ: [0, -4] as const,
+        halfExtentX: 1.575,
+        halfExtentZ: 1.575,
+      },
+    });
+    expect(pose.plinthAnchorWorldXYZ).toStrictEqual([0, 0, -2.05]);
+    expect(pose.pancakeSpawnWorldXYZ).toStrictEqual([0, 1.6, 1.6]);
+    expect(pose.vrSpawnOffsetWorldXYZ).toStrictEqual([0, 0, -0.6]);
+  });
+});
+
+describe('composeClusterStagePose — derives from cutout, not surfaceCenter', () => {
+  // GPT #5 + DeepSeek #2 convergent finding from v1 roundtable: the
+  // helper must source the railing-front-Z from `cutout.centerXZ[1]`
+  // (not a hardcoded `SURFACE_CENTER.z`). Today every cluster scene's
+  // cutout coincides with SURFACE_CENTER.xz; this guard catches a
+  // future scene that shifts the cutout center.
+  it('shifts anchor when cutout center moves', () => {
+    const baseline = composeClusterStagePose({
+      cutout: {
+        kind: 'rect' as const,
+        centerXZ: [0, -4] as const,
+        halfExtentX: 3.675,
+        halfExtentZ: 3.675,
+      },
+    });
+    const shifted = composeClusterStagePose({
+      cutout: {
+        kind: 'rect' as const,
+        centerXZ: [0, -3.5] as const, // 0.5 m closer in +Z
+        halfExtentX: 3.675,
+        halfExtentZ: 3.675,
+      },
+    });
+    // Shifting centerXZ[1] by +0.5 m must shift anchor.z by +0.5 m.
+    expect(shifted.plinthAnchorWorldXYZ[2]).toBeCloseTo(
+      baseline.plinthAnchorWorldXYZ[2] + 0.5,
+    );
+  });
+
+  it('uses cutout.centerXZ[0] for anchor X', () => {
+    const offCenter = composeClusterStagePose({
+      cutout: {
+        kind: 'rect' as const,
+        centerXZ: [1.25, -4] as const,
+        halfExtentX: 3.675,
+        halfExtentZ: 3.675,
+      },
+    });
+    expect(offCenter.plinthAnchorWorldXYZ[0]).toBeCloseTo(1.25);
+    expect(offCenter.pancakeSpawnWorldXYZ[0]).toBeCloseTo(1.25);
+    expect(offCenter.vrSpawnOffsetWorldXYZ[0]).toBeCloseTo(1.25);
+  });
+});
+
+describe('composeClusterStagePose — option overrides', () => {
+  // Brackets per the helper's doc comments — smoke-tunable.
+  const BASE_CUTOUT = {
+    kind: 'rect' as const,
+    centerXZ: [0, -4] as const,
+    halfExtentX: 3.675,
+    halfExtentZ: 3.675,
+  };
+
+  it('honors plinthBodyBackClearance override', () => {
+    const tighter = composeClusterStagePose({
+      cutout: BASE_CUTOUT,
+      plinthBodyBackClearance: 0.03,
+    });
+    // Anchor.z shifts by (0.045 default − 0.03 override) = -0.015.
+    expect(tighter.plinthAnchorWorldXYZ[2]).toBeCloseTo(0.05 - 0.015);
+  });
+
+  it('honors pancakeSpawnPaddingZ override', () => {
+    const closer = composeClusterStagePose({
+      cutout: BASE_CUTOUT,
+      pancakeSpawnPaddingZ: 3.0,
+    });
+    expect(closer.pancakeSpawnWorldXYZ[2]).toBeCloseTo(0.05 + 3.0);
+  });
+
+  it('honors vrSpawnPaddingZ override', () => {
+    const farther = composeClusterStagePose({
+      cutout: BASE_CUTOUT,
+      vrSpawnPaddingZ: 1.7,
+    });
+    expect(farther.vrSpawnOffsetWorldXYZ[2]).toBeCloseTo(0.05 + 1.7);
+  });
+
+  it('exports the bracket-baked default constants', () => {
+    expect(PLINTH_BODY_BACK_CLEARANCE_DEFAULT).toBeCloseTo(0.045);
+    expect(PANCAKE_SPAWN_PADDING_Z_M_DEFAULT).toBeCloseTo(3.65);
+    expect(VR_SPAWN_PADDING_Z_M_DEFAULT).toBeCloseTo(1.45);
+  });
+});

--- a/test/shell/cameraControls.test.ts
+++ b/test/shell/cameraControls.test.ts
@@ -11,18 +11,37 @@ import {
 // envelope's bounds + damping. `domElement` is passed as null so the
 // test exercises the wrapper without a real DOM — sufficient for
 // config-validation, which is the issue's stated bar.
+//
+// Per-scene spawn pose as of #263: callers pass the boot exhibit's
+// `pancakeSpawnWorldXYZ` as the third arg. Tests below use the
+// quadrics-calibrated `[0, 1.6, 3.7]` (= today's cluster-uniform
+// fallback in `shell/stagePose.ts`) so the assertions stay bit-
+// identical to the pre-#263 fixed spawn.
+
+const QUADRICS_SPAWN_WORLD_XYZ = [0, 1.6, 3.7] as const;
 
 const makeCamera = (): THREE.PerspectiveCamera =>
   new THREE.PerspectiveCamera(75, 1, 0.1, 100);
 
 describe('createCameraControls', () => {
-  it('orients the camera at (0, 1.6, 3.7) before the controls take over', () => {
+  it('orients the camera at the passed spawn pose', () => {
     const camera = makeCamera();
-    camera.position.set(0, 1.6, 3.7); // simulate shell.ts's pre-XR default
-    createCameraControls(camera, null);
-    expect(camera.position.x).toBeCloseTo(0);
-    expect(camera.position.y).toBeCloseTo(1.6);
-    expect(camera.position.z).toBeCloseTo(3.7);
+    createCameraControls(camera, null, QUADRICS_SPAWN_WORLD_XYZ);
+    expect(camera.position.x).toBeCloseTo(QUADRICS_SPAWN_WORLD_XYZ[0]);
+    expect(camera.position.y).toBeCloseTo(QUADRICS_SPAWN_WORLD_XYZ[1]);
+    expect(camera.position.z).toBeCloseTo(QUADRICS_SPAWN_WORLD_XYZ[2]);
+  });
+
+  it('honors a per-scene spawn override (tangent-planes case)', () => {
+    // Tangent-planes' derived pancake spawn-Z under the #263
+    // helper defaults: `anchor.z (-2.125) + 3.65 = 1.525`. This
+    // case is the regression guard for the per-scene path —
+    // proves the camera lands wherever the third arg says, not
+    // at a hardcoded cluster-uniform pose.
+    const camera = makeCamera();
+    const tangentPlanesSpawn = [0, 1.6, 1.525] as const;
+    createCameraControls(camera, null, tangentPlanesSpawn);
+    expect(camera.position.z).toBeCloseTo(1.525);
   });
 
   it('applies camera.lookAt(SURFACE_CENTER) before the first controls update', () => {
@@ -33,7 +52,7 @@ describe('createCameraControls', () => {
     // confirms lookAt ran (without it, an unrotated camera looks
     // toward +Z).
     const camera = makeCamera();
-    createCameraControls(camera, null);
+    createCameraControls(camera, null, QUADRICS_SPAWN_WORLD_XYZ);
     // Read the camera's forward via its quaternion rather than
     // `getWorldDirection`, which depends on `matrixWorld` (only updated
     // at render time). The quaternion is mutated synchronously by
@@ -49,7 +68,7 @@ describe('createCameraControls', () => {
 
   it('sets controls.target to SURFACE_CENTER', () => {
     const camera = makeCamera();
-    const controls = createCameraControls(camera, null);
+    const controls = createCameraControls(camera, null, QUADRICS_SPAWN_WORLD_XYZ);
     expect(controls.target.x).toBeCloseTo(SURFACE_CENTER.x);
     expect(controls.target.y).toBeCloseTo(SURFACE_CENTER.y);
     expect(controls.target.z).toBeCloseTo(SURFACE_CENTER.z);
@@ -57,21 +76,21 @@ describe('createCameraControls', () => {
 
   it('clamps distance to [1.5, 12] m around the cluster anchor', () => {
     const camera = makeCamera();
-    const controls = createCameraControls(camera, null);
+    const controls = createCameraControls(camera, null, QUADRICS_SPAWN_WORLD_XYZ);
     expect(controls.minDistance).toBe(1.5);
     expect(controls.maxDistance).toBe(12);
   });
 
   it('clamps polar angle to [0.1π, 0.85π]', () => {
     const camera = makeCamera();
-    const controls = createCameraControls(camera, null);
+    const controls = createCameraControls(camera, null, QUADRICS_SPAWN_WORLD_XYZ);
     expect(controls.minPolarAngle).toBeCloseTo(0.1 * Math.PI);
     expect(controls.maxPolarAngle).toBeCloseTo(0.85 * Math.PI);
   });
 
   it('enables damping with factor 0.05 (requires per-frame controls.update())', () => {
     const camera = makeCamera();
-    const controls = createCameraControls(camera, null);
+    const controls = createCameraControls(camera, null, QUADRICS_SPAWN_WORLD_XYZ);
     expect(controls.enableDamping).toBe(true);
     expect(controls.dampingFactor).toBeCloseTo(0.05);
   });
@@ -86,7 +105,7 @@ describe('first render-frame stability', () => {
   // implicit `update()` against the default `target=(0,0,0)`.
   it('does not jump on the first controls.update() tick', () => {
     const camera = makeCamera();
-    const controls = createCameraControls(camera, null);
+    const controls = createCameraControls(camera, null, QUADRICS_SPAWN_WORLD_XYZ);
     const positionBefore = camera.position.clone();
     const quaternionBefore = camera.quaternion.clone();
     controls.update();

--- a/test/shell/stagePose.test.ts
+++ b/test/shell/stagePose.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { Exhibit } from '@/shell/Exhibit';
 import {
   CLUSTER_FALLBACK_PANCAKE_SPAWN_WORLD_XYZ,
+  CLUSTER_FALLBACK_RACK_ANCHOR_WORLD_XYZ,
   CLUSTER_FALLBACK_VR_SPAWN_OFFSET_WORLD_XYZ,
   resolveStagePose,
 } from '@/shell/stagePose';
@@ -36,19 +37,25 @@ describe('resolveStagePose', () => {
     expect(pose.vrSpawnOffsetWorldXYZ).toBe(
       CLUSTER_FALLBACK_VR_SPAWN_OFFSET_WORLD_XYZ,
     );
+    expect(pose.rackAnchorWorldXYZ).toBe(
+      CLUSTER_FALLBACK_RACK_ANCHOR_WORLD_XYZ,
+    );
   });
 
   it('returns the exhibit-provided poses when stage is present', () => {
     const pancake = [0, 1.6, 1.525] as const;
     const vrOffset = [0, 0, -0.675] as const;
+    const rackAnchor = [0, 0, -2.125] as const;
     const pose = resolveStagePose(
       stubExhibit({
         pancakeSpawnWorldXYZ: pancake,
         vrSpawnOffsetWorldXYZ: vrOffset,
+        rackAnchorWorldXYZ: rackAnchor,
       }),
     );
     expect(pose.pancakeSpawnWorldXYZ).toBe(pancake);
     expect(pose.vrSpawnOffsetWorldXYZ).toBe(vrOffset);
+    expect(pose.rackAnchorWorldXYZ).toBe(rackAnchor);
   });
 });
 
@@ -63,5 +70,9 @@ describe('cluster-uniform fallback constants', () => {
 
   it('VR fallback matches the #262 cluster-uniform offset', () => {
     expect(CLUSTER_FALLBACK_VR_SPAWN_OFFSET_WORLD_XYZ).toStrictEqual([0, 0, 1.5]);
+  });
+
+  it('rack-anchor fallback matches the pre-#263 SCENE_RACK_Z baseline', () => {
+    expect(CLUSTER_FALLBACK_RACK_ANCHOR_WORLD_XYZ).toStrictEqual([0, 0, 0.05]);
   });
 });

--- a/test/shell/stagePose.test.ts
+++ b/test/shell/stagePose.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { Exhibit } from '@/shell/Exhibit';
+import {
+  CLUSTER_FALLBACK_PANCAKE_SPAWN_WORLD_XYZ,
+  CLUSTER_FALLBACK_VR_SPAWN_OFFSET_WORLD_XYZ,
+  resolveStagePose,
+} from '@/shell/stagePose';
+
+// Pure-shell coverage for the #263 `Exhibit.stage` resolver. The
+// resolver substitutes cluster-uniform fallback constants when an
+// exhibit (e.g. `hello`) doesn't expose `stage` metadata. Cluster
+// scenes always do — see `test/exhibits/cluster-stage-pose.test.ts`.
+
+// Build a minimal `Exhibit`-shape stub. The resolver only reads
+// `exhibit.stage`, so the other fields are present only to satisfy
+// TypeScript's structural shape check.
+const stubExhibit = (
+  stage: Exhibit['stage'] | undefined = undefined,
+): Exhibit => ({
+  id: 'stub',
+  title: 'Stub',
+  stage,
+  mount() {},
+  update() {},
+  unmount() {},
+  onSelectStart() { return false; },
+  onSelectEnd() {},
+});
+
+describe('resolveStagePose', () => {
+  it('returns the cluster-uniform fallback when exhibit.stage is unset', () => {
+    const pose = resolveStagePose(stubExhibit(undefined));
+    expect(pose.pancakeSpawnWorldXYZ).toBe(
+      CLUSTER_FALLBACK_PANCAKE_SPAWN_WORLD_XYZ,
+    );
+    expect(pose.vrSpawnOffsetWorldXYZ).toBe(
+      CLUSTER_FALLBACK_VR_SPAWN_OFFSET_WORLD_XYZ,
+    );
+  });
+
+  it('returns the exhibit-provided poses when stage is present', () => {
+    const pancake = [0, 1.6, 1.525] as const;
+    const vrOffset = [0, 0, -0.675] as const;
+    const pose = resolveStagePose(
+      stubExhibit({
+        pancakeSpawnWorldXYZ: pancake,
+        vrSpawnOffsetWorldXYZ: vrOffset,
+      }),
+    );
+    expect(pose.pancakeSpawnWorldXYZ).toBe(pancake);
+    expect(pose.vrSpawnOffsetWorldXYZ).toBe(vrOffset);
+  });
+});
+
+describe('cluster-uniform fallback constants', () => {
+  // Pre-#263 pancake spawn (`(0, 1.6, 3.7)` — see `_private/plans/
+  // 240-pancake-default-camera.md`) and #262 VR offset (`+1.5 m`)
+  // were the cluster-uniform behavior the fallback preserves for
+  // non-cluster exhibits.
+  it('pancake fallback matches the pre-#263 cluster-uniform spawn', () => {
+    expect(CLUSTER_FALLBACK_PANCAKE_SPAWN_WORLD_XYZ).toStrictEqual([0, 1.6, 3.7]);
+  });
+
+  it('VR fallback matches the #262 cluster-uniform offset', () => {
+    expect(CLUSTER_FALLBACK_VR_SPAWN_OFFSET_WORLD_XYZ).toStrictEqual([0, 0, 1.5]);
+  });
+});


### PR DESCRIPTION
## Summary

- Drop the cluster-uniform `PLINTH_ANCHOR_WORLD_XYZ = [0, 0, 0.05]` literal + the hardcoded pancake `(0, 1.6, 3.7)` + the #262 VR offset `+1.5 m`. Each cluster scene now derives plinth anchor + pancake spawn + VR spawn offset from a single scaffold helper `composeClusterStagePose(cutoutDescriptor)`. Smaller-envelope scenes (tangent-planes, gradient-levels, saddle-extrema) slide the plinth + user toward the math object together. Quadrics is the calibration case — bit-identical to today's literals.
- New optional `Exhibit.stage` metadata exposes computed spawn poses to the shell; consumed via a pure `shell/stagePose.ts` resolver with cluster-uniform fallbacks for non-cluster exhibits (today: `hello`). Pancake mount-swap now repositions the camera + refreshes `OrbitControls.saveState()` per hop. VR `sessionstart` snapshots the unoffset `local-floor` base so offset application is stacking-safe.
- Plan: `_private/plans/263-per-scene-plinth-and-spawn.md` (v3, post-second-Sonnet sanity check). PR1 ships `sessionstart`-only VR offset; in-session VR re-offset on scene-rack hops is a tracked follow-up per §7.

Closes #263.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 45 files, all pass; +24 new tests across `clusterStagePose.test.ts` / `stagePose.test.ts` / `cluster-stage-pose.test.ts`
- [x] `vite build` clean
- [x] **Pancake (preview URL):** first-paint framing for all four scenes; tangent-planes / gradient-levels / saddle-extrema plinth-back nearly flush with railing; quadrics foreground unchanged from today
- [x] **Pancake (preview URL):** SceneRack hop → camera repositions within one frame; `reset()` snaps to the new scene's pose
- [x] **Quest 3S VR (preview URL):** arm's-length feel matches today on quadrics (calibration check); tangent-planes / gradient-levels / saddle-extrema feel ~1.45 m from new scene's plinth on `sessionstart`
- [x] **Quest 3S VR (preview URL):** quadrics → tangent-planes in-session hop — record user-to-new-plinth distance, verdict on whether the receding-plinth read is acceptable or whether the §7 follow-up needs to ship before v1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)